### PR TITLE
feat: split licensing (MIT + CC-BY-SA-4.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "1.6.6",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
-  "license": "MIT",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {
     "name": "Netresearch DTT GmbH",
     "url": "https://www.netresearch.de"

--- a/LICENSE-CC-BY-SA-4.0
+++ b/LICENSE-CC-BY-SA-4.0
@@ -1,0 +1,19 @@
+Creative Commons Attribution-ShareAlike 4.0 International
+
+Copyright (c) 2025-2026 Netresearch DTT GmbH
+
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+International License. To view a copy of this license, visit
+https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+- Share: copy and redistribute the material in any medium or format
+- Adapt: remix, transform, and build upon the material for any purpose,
+  even commercially
+
+Under the following terms:
+- Attribution: You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made.
+- ShareAlike: If you remix, transform, or build upon the material, you
+  must distribute your contributions under the same license as the original.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Netresearch DTT GmbH
+Copyright (c) 2025-2026 Netresearch DTT GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The skill triggers on keywords like:
 {skill-name}/
 ├── SKILL.md              # AI instructions
 ├── README.md             # Human documentation
-├── LICENSE               # MIT license
+├── LICENSE-MIT           # Code license (MIT)
+├── LICENSE-CC-BY-SA-4.0  # Content license (CC-BY-SA-4.0)
 ├── composer.json         # PHP distribution
 ├── references/           # Extended docs
 ├── scripts/              # Automation
@@ -100,7 +101,8 @@ The skill triggers on keywords like:
 skill-repo-skill/
 ├── SKILL.md                      # AI instructions
 ├── README.md                     # This file
-├── LICENSE                       # MIT
+├── LICENSE-MIT                   # Code license (MIT)
+├── LICENSE-CC-BY-SA-4.0          # Content license (CC-BY-SA-4.0)
 ├── composer.json                 # PHP distribution
 ├── templates/
 │   ├── README.md.template        # README template for skills
@@ -134,7 +136,12 @@ Contributions welcome! Please submit PRs for:
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details.
+This project uses split licensing:
+
+- **Code** (scripts, workflows, configs): [MIT](LICENSE-MIT)
+- **Content** (skill definitions, documentation, references): [CC-BY-SA-4.0](LICENSE-CC-BY-SA-4.0)
+
+See the individual license files for full terms.
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "netresearch/skill-repo-skill",
   "description": "Guide for structuring Netresearch skill repositories with multi-channel distribution",
   "type": "ai-agent-skill",
-  "license": "MIT",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "authors": [
     {
       "name": "Netresearch DTT GmbH",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -19,12 +19,26 @@ Standards for Netresearch skill repository layout and distribution.
 {skill-name}/
 ├── SKILL.md              # AI instructions (required)
 ├── README.md             # Human documentation (required)
-├── LICENSE               # MIT (required)
+├── LICENSE-MIT           # Code license (required)
+├── LICENSE-CC-BY-SA-4.0  # Content license (required)
 ├── composer.json         # PHP distribution
 ├── references/           # Extended docs
 ├── scripts/              # Automation
 └── .github/workflows/release.yml
 ```
+
+## Licensing
+
+Skill repos use split licensing:
+
+| Path pattern | License |
+|---|---|
+| `skills/**/*.md`, `references/**`, `assets/**/*.md`, `README.md`, `docs/**` | CC-BY-SA-4.0 |
+| `scripts/**`, `Build/**`, `.github/workflows/**`, `*.sh`, `*.py`, `*.php` | MIT |
+| `composer.json`, `plugin.json`, config files | MIT |
+| Code snippets embedded in `.md` files | Dual (both apply) |
+
+Composer/plugin metadata uses SPDX compound expression: `(MIT AND CC-BY-SA-4.0)`
 
 ## SKILL.md Requirements
 

--- a/skills/skill-repo/scripts/migrate-licensing.sh
+++ b/skills/skill-repo/scripts/migrate-licensing.sh
@@ -94,33 +94,23 @@ Under the following terms:
   must distribute your contributions under the same license as the original.
 CCEOF
 
-# 3. Update composer.json
-if [[ -f "$REPO_DIR/composer.json" ]]; then
-    python3 -c "
-import json
-with open('$REPO_DIR/composer.json', 'r') as f:
-    data = json.load(f)
-data['license'] = '(MIT AND CC-BY-SA-4.0)'
-with open('$REPO_DIR/composer.json', 'w') as f:
-    json.dump(data, f, indent=4)
-    f.write('\n')
-"
-    echo "Updated composer.json license"
-fi
+# 3. Update composer.json and plugin.json
+python3 - "$REPO_DIR" << 'PYEOF'
+import json, sys, os
+repo_dir = sys.argv[1]
 
-# 4. Update plugin.json
-if [[ -f "$REPO_DIR/.claude-plugin/plugin.json" ]]; then
-    python3 -c "
-import json
-with open('$REPO_DIR/.claude-plugin/plugin.json', 'r') as f:
-    data = json.load(f)
-data['license'] = '(MIT AND CC-BY-SA-4.0)'
-with open('$REPO_DIR/.claude-plugin/plugin.json', 'w') as f:
-    json.dump(data, f, indent=4)
-    f.write('\n')
-"
-    echo "Updated plugin.json license"
-fi
+for rel_path, label in [("composer.json", "composer.json"), (".claude-plugin/plugin.json", "plugin.json")]:
+    full_path = os.path.join(repo_dir, rel_path)
+    if not os.path.isfile(full_path):
+        continue
+    with open(full_path, 'r') as f:
+        data = json.load(f)
+    data['license'] = '(MIT AND CC-BY-SA-4.0)'
+    with open(full_path, 'w') as f:
+        json.dump(data, f, indent=4)
+        f.write('\n')
+    print(f"Updated {label} license")
+PYEOF
 
 # 5. Update README.md license section
 if [[ -f "$REPO_DIR/README.md" ]]; then

--- a/skills/skill-repo/scripts/migrate-licensing.sh
+++ b/skills/skill-repo/scripts/migrate-licensing.sh
@@ -124,7 +124,7 @@ fi
 
 # 5. Update README.md license section
 if [[ -f "$REPO_DIR/README.md" ]]; then
-    python3 << 'PYEOF'
+    python3 - "$REPO_DIR" << 'PYEOF'
 import re, sys
 
 repo_dir = sys.argv[1] if len(sys.argv) > 1 else "."

--- a/skills/skill-repo/scripts/migrate-licensing.sh
+++ b/skills/skill-repo/scripts/migrate-licensing.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# migrate-licensing.sh - Migrate a skill repo from single LICENSE to split licensing
+# Usage: ./migrate-licensing.sh <repo-root-path>
+set -euo pipefail
+
+REPO_DIR="${1:-.}"
+YEAR="2025-2026"
+
+echo "Migrating licensing in: $REPO_DIR"
+
+# 1. Create LICENSE-MIT
+if [[ -f "$REPO_DIR/LICENSE" ]]; then
+    if grep -q "GNU GENERAL PUBLIC LICENSE" "$REPO_DIR/LICENSE"; then
+        echo "INFO: Repo has GPL license — creating MIT from scratch"
+        cat > "$REPO_DIR/LICENSE-MIT" << 'MITEOF'
+MIT License
+
+Copyright (c) 2025-2026 Netresearch DTT GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+MITEOF
+    else
+        # Existing MIT — copy and update year
+        cp "$REPO_DIR/LICENSE" "$REPO_DIR/LICENSE-MIT"
+        if ! grep -q "2026" "$REPO_DIR/LICENSE-MIT"; then
+            sed -i -E "s/Copyright \(c\) ([0-9]{4})/Copyright (c) \1-2026/" "$REPO_DIR/LICENSE-MIT"
+        fi
+    fi
+    # Stage removal of old LICENSE
+    git -C "$REPO_DIR" rm -f LICENSE 2>/dev/null || rm -f "$REPO_DIR/LICENSE"
+else
+    echo "INFO: No LICENSE found — creating LICENSE-MIT from scratch"
+    cat > "$REPO_DIR/LICENSE-MIT" << MITEOF
+MIT License
+
+Copyright (c) $YEAR Netresearch DTT GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+MITEOF
+fi
+
+# 2. Create LICENSE-CC-BY-SA-4.0
+cat > "$REPO_DIR/LICENSE-CC-BY-SA-4.0" << CCEOF
+Creative Commons Attribution-ShareAlike 4.0 International
+
+Copyright (c) $YEAR Netresearch DTT GmbH
+
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+International License. To view a copy of this license, visit
+https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+- Share: copy and redistribute the material in any medium or format
+- Adapt: remix, transform, and build upon the material for any purpose,
+  even commercially
+
+Under the following terms:
+- Attribution: You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made.
+- ShareAlike: If you remix, transform, or build upon the material, you
+  must distribute your contributions under the same license as the original.
+CCEOF
+
+# 3. Update composer.json
+if [[ -f "$REPO_DIR/composer.json" ]]; then
+    python3 -c "
+import json
+with open('$REPO_DIR/composer.json', 'r') as f:
+    data = json.load(f)
+data['license'] = '(MIT AND CC-BY-SA-4.0)'
+with open('$REPO_DIR/composer.json', 'w') as f:
+    json.dump(data, f, indent=4)
+    f.write('\n')
+"
+    echo "Updated composer.json license"
+fi
+
+# 4. Update plugin.json
+if [[ -f "$REPO_DIR/.claude-plugin/plugin.json" ]]; then
+    python3 -c "
+import json
+with open('$REPO_DIR/.claude-plugin/plugin.json', 'r') as f:
+    data = json.load(f)
+data['license'] = '(MIT AND CC-BY-SA-4.0)'
+with open('$REPO_DIR/.claude-plugin/plugin.json', 'w') as f:
+    json.dump(data, f, indent=4)
+    f.write('\n')
+"
+    echo "Updated plugin.json license"
+fi
+
+# 5. Update README.md license section
+if [[ -f "$REPO_DIR/README.md" ]]; then
+    python3 << 'PYEOF'
+import re, sys
+
+repo_dir = sys.argv[1] if len(sys.argv) > 1 else "."
+readme_path = f"{repo_dir}/README.md"
+
+with open(readme_path, 'r') as f:
+    content = f.read()
+
+# Replace license section
+new_license = """## License
+
+This project uses split licensing:
+
+- **Code** (scripts, workflows, configs): [MIT](LICENSE-MIT)
+- **Content** (skill definitions, documentation, references): [CC-BY-SA-4.0](LICENSE-CC-BY-SA-4.0)
+
+See the individual license files for full terms."""
+
+# Match ## License section until next ## heading or --- or end of file
+pattern = r'## License\n.*?(?=\n## |\n---|\Z)'
+content = re.sub(pattern, new_license, content, flags=re.DOTALL)
+
+# Fix structure diagrams
+content = re.sub(
+    r'├── LICENSE\s+# (?:MIT|GPL[^\n]*)',
+    '├── LICENSE-MIT           # Code license (MIT)\n├── LICENSE-CC-BY-SA-4.0  # Content license (CC-BY-SA-4.0)',
+    content
+)
+
+with open(readme_path, 'w') as f:
+    f.write(content)
+PYEOF
+    echo "Updated README.md license section"
+fi
+
+echo "Done! Review changes with: git -C $REPO_DIR diff"

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -138,7 +138,12 @@ if [[ -f "$REPO_DIR/composer.json" ]]; then
     fi
 
     # License SPDX expression
-    COMP_LICENSE=$(python3 -c "import json; print(json.load(open('$REPO_DIR/composer.json')).get('license',''))" 2>/dev/null || echo "")
+    COMP_LICENSE=$(python3 - "$REPO_DIR" <<'PYEOF' 2>/dev/null || echo ""
+import json, sys
+with open(f'{sys.argv[1]}/composer.json', 'r') as f:
+    print(json.load(f).get('license', ''))
+PYEOF
+)
     if [[ "$COMP_LICENSE" == "(MIT AND CC-BY-SA-4.0)" ]]; then
         success "composer.json license is correct SPDX expression"
     else
@@ -146,7 +151,12 @@ if [[ -f "$REPO_DIR/composer.json" ]]; then
     fi
 
     # Name must match GitHub repo name (netresearch/{repo-name})
-    COMP_NAME=$(python3 -c "import json; print(json.load(open('$REPO_DIR/composer.json')).get('name',''))" 2>/dev/null || echo "")
+    COMP_NAME=$(python3 - "$REPO_DIR" <<'PYEOF' 2>/dev/null || echo ""
+import json, sys
+with open(f'{sys.argv[1]}/composer.json', 'r') as f:
+    print(json.load(f).get('name', ''))
+PYEOF
+)
     REPO_NAME=""
     if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
         REPO_NAME="${GITHUB_REPOSITORY#*/}"
@@ -175,20 +185,22 @@ if [[ -f "$REPO_DIR/composer.json" ]]; then
     fi
 
     # ai-agent-skill extra path(s) exist (supports both string and array values)
-    SKILL_PATH_ERRORS=$(python3 -c "
-import json, os
-data = json.load(open('$REPO_DIR/composer.json'))
+    SKILL_PATH_ERRORS=$(python3 - "$REPO_DIR" <<'PYEOF' 2>/dev/null || echo "ERROR"
+import json, os, sys
+repo_dir = sys.argv[1]
+data = json.load(open(os.path.join(repo_dir, 'composer.json')))
 val = data.get('extra', {}).get('ai-agent-skill', '')
 paths = val if isinstance(val, list) else [val] if val else []
 if not paths:
     print('MISSING')
 else:
     for p in paths:
-        if not os.path.isfile(os.path.join('$REPO_DIR', p)):
+        if not os.path.isfile(os.path.join(repo_dir, p)):
             print('NOTFOUND:' + p)
         else:
             print('OK:' + p)
-" 2>/dev/null || echo "ERROR")
+PYEOF
+)
     if [[ "$SKILL_PATH_ERRORS" == "MISSING" ]]; then
         error "composer.json missing extra.ai-agent-skill"
     elif [[ "$SKILL_PATH_ERRORS" == "ERROR" ]]; then
@@ -211,8 +223,18 @@ if [[ -f "$PLUGIN_FILE" ]]; then
     success "plugin.json exists"
 
     # Name matches SKILL.md name (only for single-skill repos)
-    PLUGIN_NAME=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE')).get('name',''))" 2>/dev/null || echo "")
-    SKILL_COUNT=$(python3 -c "import json; print(len(json.load(open('$PLUGIN_FILE')).get('skills',[])))" 2>/dev/null || echo "1")
+    PLUGIN_NAME=$(python3 - "$PLUGIN_FILE" <<'PYEOF' 2>/dev/null || echo ""
+import json, sys
+with open(sys.argv[1], 'r') as f:
+    print(json.load(f).get('name', ''))
+PYEOF
+)
+    SKILL_COUNT=$(python3 - "$PLUGIN_FILE" <<'PYEOF' 2>/dev/null || echo "1"
+import json, sys
+with open(sys.argv[1], 'r') as f:
+    print(len(json.load(f).get('skills', [])))
+PYEOF
+)
     if [[ "$SKILL_COUNT" -le 1 ]]; then
         if [[ -n "$NAME" ]] && [[ "$PLUGIN_NAME" == "$NAME" ]]; then
             success "plugin.json name matches SKILL.md: $PLUGIN_NAME"
@@ -224,19 +246,27 @@ if [[ -f "$PLUGIN_FILE" ]]; then
     fi
 
     # Skills is array
-    SKILLS_TYPE=$(python3 -c "import json; s=json.load(open('$PLUGIN_FILE')).get('skills'); print('array' if isinstance(s, list) else type(s).__name__)" 2>/dev/null || echo "unknown")
+    SKILLS_TYPE=$(python3 - "$PLUGIN_FILE" <<'PYEOF' 2>/dev/null || echo "unknown"
+import json, sys
+with open(sys.argv[1], 'r') as f:
+    s = json.load(f).get('skills')
+print('array' if isinstance(s, list) else type(s).__name__)
+PYEOF
+)
     if [[ "$SKILLS_TYPE" == "array" ]]; then
         success "plugin.json skills is array"
 
         # Check each skill path exists as directory
-        MISSING_PATHS=$(python3 -c "
-import json, os
-data = json.load(open('$PLUGIN_FILE'))
+        MISSING_PATHS=$(python3 - "$PLUGIN_FILE" "$REPO_DIR" <<'PYEOF' 2>/dev/null || true
+import json, os, sys
+with open(sys.argv[1], 'r') as f:
+    data = json.load(f)
 for path in data.get('skills', []):
-    full = os.path.join('$REPO_DIR', path)
+    full = os.path.join(sys.argv[2], path)
     if not os.path.isdir(full):
         print(path)
-" 2>/dev/null || true)
+PYEOF
+)
         if [[ -z "$MISSING_PATHS" ]]; then
             success "All plugin.json skill paths exist"
         else
@@ -249,7 +279,12 @@ for path in data.get('skills', []):
     fi
 
     # Author URL
-    AUTHOR_URL=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE')).get('author',{}).get('url',''))" 2>/dev/null || echo "")
+    AUTHOR_URL=$(python3 - "$PLUGIN_FILE" <<'PYEOF' 2>/dev/null || echo ""
+import json, sys
+with open(sys.argv[1], 'r') as f:
+    print(json.load(f).get('author', {}).get('url', ''))
+PYEOF
+)
     if [[ -n "$AUTHOR_URL" ]]; then
         AUTHOR_URL_CLEAN="${AUTHOR_URL%/}"
         if [[ "$AUTHOR_URL_CLEAN" == "https://www.netresearch.de" ]]; then

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -97,13 +97,20 @@ else
 fi
 
 # --- Required files ---
-for file in README.md LICENSE .gitignore; do
+for file in README.md LICENSE-MIT LICENSE-CC-BY-SA-4.0 .gitignore; do
     if [[ -f "$REPO_DIR/$file" ]]; then
         success "$file exists"
     else
         error "$file not found"
     fi
 done
+
+# Warn about old single LICENSE file
+if [[ -f "$REPO_DIR/LICENSE" ]] && [[ -f "$REPO_DIR/LICENSE-MIT" ]]; then
+    warning "Old LICENSE file still exists alongside LICENSE-MIT — remove it"
+elif [[ -f "$REPO_DIR/LICENSE" ]] && [[ ! -f "$REPO_DIR/LICENSE-MIT" ]]; then
+    warning "Single LICENSE file found — migrate to LICENSE-MIT + LICENSE-CC-BY-SA-4.0"
+fi
 
 # Release workflow
 if [[ -f "$REPO_DIR/.github/workflows/release.yml" ]]; then
@@ -128,6 +135,14 @@ if [[ -f "$REPO_DIR/composer.json" ]]; then
         success "composer.json type is ai-agent-skill"
     else
         error "composer.json type must be 'ai-agent-skill'"
+    fi
+
+    # License SPDX expression
+    COMP_LICENSE=$(python3 -c "import json; print(json.load(open('$REPO_DIR/composer.json')).get('license',''))" 2>/dev/null || echo "")
+    if [[ "$COMP_LICENSE" == "(MIT AND CC-BY-SA-4.0)" ]]; then
+        success "composer.json license is correct SPDX expression"
+    else
+        warning "composer.json license should be '(MIT AND CC-BY-SA-4.0)', got: $COMP_LICENSE"
     fi
 
     # Name must match GitHub repo name (netresearch/{repo-name})

--- a/skills/skill-repo/templates/LICENSE-CC-BY-SA-4.0.template
+++ b/skills/skill-repo/templates/LICENSE-CC-BY-SA-4.0.template
@@ -1,0 +1,19 @@
+Creative Commons Attribution-ShareAlike 4.0 International
+
+Copyright (c) {YEAR} Netresearch DTT GmbH
+
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0
+International License. To view a copy of this license, visit
+https://creativecommons.org/licenses/by-sa/4.0/ or send a letter to
+Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+You are free to:
+- Share: copy and redistribute the material in any medium or format
+- Adapt: remix, transform, and build upon the material for any purpose,
+  even commercially
+
+Under the following terms:
+- Attribution: You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made.
+- ShareAlike: If you remix, transform, or build upon the material, you
+  must distribute your contributions under the same license as the original.

--- a/skills/skill-repo/templates/LICENSE-MIT.template
+++ b/skills/skill-repo/templates/LICENSE-MIT.template
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {YEAR} Netresearch DTT GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -51,7 +51,8 @@ The skill triggers on keywords like:
 {skill-name}/
 ├── SKILL.md              # AI instructions
 ├── README.md             # This file
-├── LICENSE               # MIT license
+├── LICENSE-MIT           # Code license (MIT)
+├── LICENSE-CC-BY-SA-4.0  # Content license (CC-BY-SA-4.0)
 ├── composer.json         # PHP distribution
 ├── references/           # Extended documentation
 │   └── ...
@@ -74,7 +75,12 @@ Contributions welcome! Please submit PRs for:
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details.
+This project uses split licensing:
+
+- **Code** (scripts, workflows, configs): [MIT](LICENSE-MIT)
+- **Content** (skill definitions, documentation, references): [CC-BY-SA-4.0](LICENSE-CC-BY-SA-4.0)
+
+See the individual license files for full terms.
 
 ## Credits
 

--- a/skills/skill-repo/templates/composer.json.template
+++ b/skills/skill-repo/templates/composer.json.template
@@ -2,7 +2,7 @@
   "name": "netresearch/{repo-name}",
   "description": "{Skill description}",
   "type": "ai-agent-skill",
-  "license": "MIT",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "authors": [
     {
       "name": "Netresearch DTT GmbH",

--- a/skills/skill-repo/templates/release.yml.template
+++ b/skills/skill-repo/templates/release.yml.template
@@ -36,7 +36,8 @@ jobs:
 
           # Copy skill-relevant files only
           cp SKILL.md dist/
-          cp LICENSE dist/
+          cp LICENSE-MIT dist/
+          cp LICENSE-CC-BY-SA-4.0 dist/
 
           # Copy directories if they exist
           [ -d "references" ] && cp -r references dist/


### PR DESCRIPTION
## Summary

- Introduces split licensing for all Netresearch skill repos: **MIT** for code (scripts, workflows, configs), **CC-BY-SA-4.0** for content (skill definitions, docs, references)
- Updates templates, SKILL.md, and validation script to enforce the new standard
- Adds a `migrate-licensing.sh` script for batch migration
- Self-applies to skill-repo-skill

## Changes

- **License templates**: `LICENSE-MIT.template` + `LICENSE-CC-BY-SA-4.0.template`
- **SKILL.md**: New licensing section with path-to-license mapping
- **Templates**: Updated `composer.json.template`, `README.md.template`, `release.yml.template`
- **Validation**: `validate-skill.sh` checks for both license files + SPDX expression in composer.json
- **Migration script**: `migrate-licensing.sh` for converting existing repos
- **Self-application**: skill-repo-skill itself migrated

## Context

All 28 other Netresearch skill repos have already been migrated and pushed to their respective `main` branches.

## Test plan

- [x] `validate-skill.sh` passes on skill-repo-skill itself (0 errors, 0 warnings)
- [x] Migration script tested on cli-tools-skill before batch run
- [x] All 29 skill repos verified: LICENSE-MIT + LICENSE-CC-BY-SA-4.0 present, old LICENSE removed, composer.json updated