### PR TITLE
fix: add checkpoint preventing version field in composer.json

### DIFF
--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -11,7 +11,7 @@ jobs:
     name: Verify Harness Consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -73,6 +73,13 @@ mechanical:
     severity: error
     desc: "plugin.json must have version field"
 
+  - id: SR-09b
+    type: not_contains
+    target: composer.json
+    pattern: '"version"'
+    severity: error
+    desc: "composer.json must NOT have a version field — Composer derives version from git tags. Adding it creates maintenance drift."
+
   - id: SR-10
     type: contains
     target: composer.json


### PR DESCRIPTION
## Summary

- Adds checkpoint SR-09b that verifies `composer.json` does NOT contain a `"version"` field
- Composer derives version from git tags — a hardcoded version field is an anti-pattern that creates maintenance drift
- Discovered when an assessment agent incorrectly added `"version": "1.16.0"` to a skill repo's composer.json for "version consistency" with plugin.json

## Test plan

- [ ] Run assessment against a skill repo with no version in composer.json — should PASS SR-09b
- [ ] Run assessment against a skill repo with version in composer.json — should FAIL SR-09b