### PR TITLE
feat(ci): auto-bump versions on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,96 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Auto-bump version in plugin.json and SKILL.md
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_BARE="${TAG_VERSION#v}"
+          PLUGIN_FILE=".claude-plugin/plugin.json"
+
+          # Read current plugin.json version
+          PLUGIN_VERSION=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE'))['version'])")
+
+          if [[ "$TAG_BARE" == "$PLUGIN_VERSION" ]]; then
+            echo "Versions already match ($TAG_BARE), no bump needed."
+            exit 0
+          fi
+
+          echo "::notice::Tag version ($TAG_BARE) differs from plugin.json ($PLUGIN_VERSION). Auto-bumping on main..."
+
+          # Update plugin.json in working tree (for packaging step)
+          python3 -c "
+          import json, pathlib
+          p = pathlib.Path('$PLUGIN_FILE')
+          data = json.loads(p.read_text())
+          data['version'] = '$TAG_BARE'
+          p.write_text(json.dumps(data, indent=2) + '\n')
+          "
+          echo "Updated $PLUGIN_FILE to $TAG_BARE"
+
+          # Update SKILL.md frontmatter version(s) in working tree
+          SKILL_PATHS=$(python3 -c "
+          import json
+          data = json.load(open('$PLUGIN_FILE'))
+          skills = data.get('skills', [])
+          if isinstance(skills, str):
+              skills = [skills]
+          for s in skills:
+              print(s.strip('/').rstrip('/'))
+          ")
+
+          while IFS= read -r skill_path; do
+            [[ -z "$skill_path" ]] && continue
+            skill_path="${skill_path#./}"
+            SKILL_MD="$skill_path/SKILL.md"
+            if [[ -f "$SKILL_MD" ]]; then
+              sed -i "s/^  version: \".*\"/  version: \"$TAG_BARE\"/" "$SKILL_MD"
+              echo "Updated $SKILL_MD to $TAG_BARE"
+            fi
+          done <<< "$SKILL_PATHS"
+
+          # Push the version bump to main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Collect changed files
+          CHANGED_FILES=("$PLUGIN_FILE")
+          while IFS= read -r skill_path; do
+            [[ -z "$skill_path" ]] && continue
+            skill_path="${skill_path#./}"
+            SKILL_MD="$skill_path/SKILL.md"
+            [[ -f "$SKILL_MD" ]] && CHANGED_FILES+=("$SKILL_MD")
+          done <<< "$SKILL_PATHS"
+
+          # Stash the version changes, apply them on main, then restore working tree
+          git stash push -- "${CHANGED_FILES[@]}"
+          git checkout main
+          git stash pop
+          git add "${CHANGED_FILES[@]}"
+          git commit -m "chore: bump version to $TAG_BARE [skip ci]"
+          git push origin main
+
+          # Return to the tag ref and re-apply version updates for packaging
+          git checkout "$TAG_VERSION"
+          python3 -c "
+          import json, pathlib
+          p = pathlib.Path('$PLUGIN_FILE')
+          data = json.loads(p.read_text())
+          data['version'] = '$TAG_BARE'
+          p.write_text(json.dumps(data, indent=2) + '\n')
+          "
+          while IFS= read -r skill_path; do
+            [[ -z "$skill_path" ]] && continue
+            skill_path="${skill_path#./}"
+            SKILL_MD="$skill_path/SKILL.md"
+            if [[ -f "$SKILL_MD" ]]; then
+              sed -i "s/^  version: \".*\"/  version: \"$TAG_BARE\"/" "$SKILL_MD"
+            fi
+          done <<< "$SKILL_PATHS"
 
       - name: Validate version and build packages
         env:


### PR DESCRIPTION
## Summary

- Adds an auto-bump step to the release workflow that updates `plugin.json` and `SKILL.md` versions to match the tag before packaging
- Prevents version mismatch failures when tags are created via `gh release create`, the GitHub web UI, or any path that bypasses local git hooks
- The version bump is committed to `main` with `[skip ci]` to avoid recursive workflow triggers
- When versions already match (hooks were used), the step is a no-op

## How it works

1. Tag `v1.12.0` is pushed (plugin.json still says `1.11.2`)
2. New "Auto-bump" step detects the mismatch
3. Updates `plugin.json` and `SKILL.md` frontmatter in the working tree
4. Stashes changes, checks out `main`, applies and pushes the bump commit
5. Returns to the tag ref, re-applies updates for the packaging step
6. Existing "Validate version" step now passes, release proceeds normally

## Test plan

- [ ] Create a tag where plugin.json version already matches -- verify "no bump needed" message and normal release
- [ ] Create a tag via `gh release create v1.12.0` without bumping plugin.json -- verify auto-bump commit appears on main and release succeeds
- [ ] Verify `[skip ci]` in the bump commit message prevents recursive workflow triggers