### PR TITLE
fix(ci): improve auto-merge strategy detection and add validate-agents reusable workflow

### DIFF
--- a/.github/workflows/auto-merge-deps-caller.yml
+++ b/.github/workflows/auto-merge-deps-caller.yml
@@ -1,7 +1,7 @@
 name: Auto-merge dependency PRs
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions: {}
 

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,5 +1,3 @@
-# Auto-merge dependency updates for repositories WITHOUT branch protection
-# Uses direct merge since --auto flag requires branch protection
 name: Auto-merge dependency PRs
 
 on:
@@ -13,9 +11,9 @@ jobs:
   auto-merge:
     name: Auto-merge dependency PRs
     runs-on: ubuntu-latest
-    # Use PR author login instead of github.actor to handle synchronize events
-    # when someone else pushes to the dependabot/renovate branch
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
       - name: Harden Runner
@@ -30,43 +28,21 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-approve PR
+      - name: Approve PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Wait for CI checks
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "Waiting for CI checks to complete..."
-          for i in {1..60}; do
-            CHECKS=$(gh pr checks "$PR_URL" --json name,state \
-              --jq '[.[] | select(.name | test("Auto-merge dependency PRs"; "i") | not)]')
-
-            FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
-
-            if [ "$FAILED" != "0" ]; then
-              echo "Some checks failed, skipping merge"
-              exit 1
-            fi
-
-            if [ "$PENDING" = "0" ]; then
-              echo "All checks passed!"
-              exit 0
-            fi
-
-            echo "Waiting for $PENDING check(s)... (attempt $i/60)"
-            sleep 10
-          done
-          echo "Timeout waiting for checks"
-          exit 1
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge PR
-        run: gh pr merge --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STRATEGY=$(gh api "repos/$REPO" --jq '
+            if .allow_squash_merge then "--squash"
+            elif .allow_merge_commit then "--merge"
+            elif .allow_rebase_merge then "--rebase"
+            else "--merge" end')
+          gh pr merge --auto "$STRATEGY" "$PR_URL"

--- a/.github/workflows/validate-agents.yml
+++ b/.github/workflows/validate-agents.yml
@@ -1,0 +1,142 @@
+name: Validate AGENTS.md
+
+on:
+  workflow_call:
+    inputs:
+      scripts-repo:
+        description: 'Repository containing validation scripts'
+        required: false
+        type: string
+        default: ''
+      scripts-path:
+        description: 'Path to validation scripts within the repo'
+        required: false
+        type: string
+        default: 'skills/agent-rules/scripts'
+      os-matrix:
+        description: 'JSON array of OS runners'
+        required: false
+        type: string
+        default: '["ubuntu-latest", "macos-latest"]'
+
+permissions:
+  contents: read
+
+jobs:
+  test-generator:
+    name: Test Generator (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.os-matrix) }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install bash jq
+
+      - name: Test generator on fixture repos
+        shell: bash
+        run: |
+          SCRIPT_DIR="${{ inputs.scripts-path }}"
+          if [ ! -d "$SCRIPT_DIR" ]; then
+            echo "Scripts directory not found: $SCRIPT_DIR"
+            exit 1
+          fi
+
+          GENERATOR="$SCRIPT_DIR/generate-agents.sh"
+          if [ ! -f "$GENERATOR" ]; then
+            echo "Generator script not found: $GENERATOR"
+            exit 1
+          fi
+
+          FIXTURES_DIR="$(dirname "$SCRIPT_DIR")/references/examples"
+          if [ ! -d "$FIXTURES_DIR" ]; then
+            echo "No fixture repos found in $FIXTURES_DIR, skipping generator test"
+            exit 0
+          fi
+
+          FAILED=0
+          for fixture in "$FIXTURES_DIR"/*/; do
+            name=$(basename "$fixture")
+            echo "::group::Testing fixture: $name"
+
+            # Dry run
+            if ! bash "$GENERATOR" --dry-run "$fixture"; then
+              echo "::error::Dry run failed for $name"
+              FAILED=1
+            fi
+
+            # Force run
+            if ! bash "$GENERATOR" --force "$fixture"; then
+              echo "::error::Force run failed for $name"
+              FAILED=1
+            fi
+
+            # Regression checks
+            if [ -f "$fixture/AGENTS.md" ]; then
+              if grep -qP '^\|(\s*\|)+\s*$' "$fixture/AGENTS.md"; then
+                echo "::error::Blank table rows in $name/AGENTS.md"
+                FAILED=1
+              fi
+              if grep -q '``' "$fixture/AGENTS.md"; then
+                echo "::error::Empty backticks in $name/AGENTS.md"
+                FAILED=1
+              fi
+              if grep -qE '\{\{[A-Z][A-Z0-9_]*\}\}' "$fixture/AGENTS.md"; then
+                echo "::error::Unresolved placeholders in $name/AGENTS.md"
+                FAILED=1
+              fi
+            fi
+
+            echo "::endgroup::"
+          done
+
+          exit $FAILED
+
+  validate:
+    name: Validate Structure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate AGENTS.md structure
+        run: |
+          VALIDATE_SCRIPT="${{ inputs.scripts-path }}/validate-structure.sh"
+          if [ -f "$VALIDATE_SCRIPT" ]; then
+            bash "$VALIDATE_SCRIPT" . --check-freshness
+          else
+            echo "No validate-structure.sh found, skipping"
+          fi
+
+      - name: Check for unresolved placeholders
+        run: |
+          FOUND=$(find . -name "AGENTS.md" -exec grep -lE '\{\{[A-Z][A-Z0-9_]*\}\}' {} \; 2>/dev/null || true)
+          if [ -n "$FOUND" ]; then
+            echo "::error::Unresolved placeholders found in: $FOUND"
+            exit 1
+          fi
+
+      - name: Verify commands exist
+        run: |
+          VERIFY_SCRIPT="${{ inputs.scripts-path }}/verify-commands.sh"
+          if [ -f "$VERIFY_SCRIPT" ]; then
+            bash "$VERIFY_SCRIPT" .
+          else
+            echo "No verify-commands.sh found, skipping"
+          fi

--- a/.github/workflows/validate-agents.yml
+++ b/.github/workflows/validate-agents.yml
@@ -47,8 +47,10 @@ jobs:
 
       - name: Test generator on fixture repos
         shell: bash
+        env:
+          SCRIPTS_PATH: ${{ inputs.scripts-path }}
         run: |
-          SCRIPT_DIR="${{ inputs.scripts-path }}"
+          SCRIPT_DIR="$SCRIPTS_PATH"
           if [ ! -d "$SCRIPT_DIR" ]; then
             echo "Scripts directory not found: $SCRIPT_DIR"
             exit 1
@@ -116,8 +118,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate AGENTS.md structure
+        env:
+          SCRIPTS_PATH: ${{ inputs.scripts-path }}
         run: |
-          VALIDATE_SCRIPT="${{ inputs.scripts-path }}/validate-structure.sh"
+          VALIDATE_SCRIPT="$SCRIPTS_PATH/validate-structure.sh"
           if [ -f "$VALIDATE_SCRIPT" ]; then
             bash "$VALIDATE_SCRIPT" . --check-freshness
           else
@@ -133,8 +137,10 @@ jobs:
           fi
 
       - name: Verify commands exist
+        env:
+          SCRIPTS_PATH: ${{ inputs.scripts-path }}
         run: |
-          VERIFY_SCRIPT="${{ inputs.scripts-path }}/verify-commands.sh"
+          VERIFY_SCRIPT="$SCRIPTS_PATH/verify-commands.sh"
           if [ -f "$VERIFY_SCRIPT" ]; then
             bash "$VERIFY_SCRIPT" .
           else


### PR DESCRIPTION
## Summary

- Replace the manual CI polling loop in `auto-merge-deps.yml` with `gh pr merge --auto` plus dynamic merge strategy detection (squash/merge/rebase based on repo settings via GitHub API)
- Switch `auto-merge-deps-caller.yml` trigger from `pull_request` to `pull_request_target` so it fires on dependabot/renovate PRs from forks
- Add new `validate-agents.yml` reusable workflow for AGENTS.md validation, supporting OS matrix, fixture-based generator testing, placeholder checks, and optional script-based structure/command validation

## Test plan

- [ ] Verify a dependabot PR triggers the auto-merge workflow and uses the correct merge strategy for the repo
- [ ] Confirm no manual polling timeout occurs — auto-merge waits for branch protection checks natively
- [ ] Call `validate-agents.yml` from agent-rules-skill or another skill repo and confirm the test-generator and validate jobs run on both ubuntu and macos
- [ ] Confirm unresolved placeholder detection (`{{PLACEHOLDER}}`) fails the validate job when present