### PR TITLE
feat: add workflow quality and cross-platform compatibility checkpoints

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -115,7 +115,7 @@ Scripts in `scripts/` and workflow `run:` blocks must work on both Linux and mac
 - Use `grep -E` (extended regex), NOT `grep -P` (Perl regex — macOS BSD grep lacks `-P`)
 - Use `bash` explicitly in shebangs (macOS default shell is zsh)
 - Test regex patterns with both GNU and BSD grep behavior
-- Use `[[ ]]` conditionals (requires bash 4+, install via Homebrew on macOS)
+- Use `[[ ]]` for conditionals, which is more robust than single-bracket `[ ]` and is a bash builtin
 
 ---
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -97,6 +97,26 @@ scripts/validate-skill.sh
 3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
 4. Push: `git push origin main vX.Y.Z`
 
+## Workflow Requirements
+
+Skill repos MUST use reusable workflows from skill-repo-skill for CI standardization:
+
+| Workflow | Purpose | Required |
+|----------|---------|----------|
+| `auto-merge-deps.yml` | Auto-merge Dependabot/Renovate PRs | Yes |
+| `harness-verify.yml` | Verify AGENTS.md harness consistency | Yes |
+| `validate.yml` | Validate skill structure and lint | Yes |
+| `release.yml` | Create releases on tag push | Yes |
+
+### Cross-platform Compatibility
+
+Scripts in `scripts/` and workflow `run:` blocks must work on both Linux and macOS:
+
+- Use `grep -E` (extended regex), NOT `grep -P` (Perl regex — macOS BSD grep lacks `-P`)
+- Use `bash` explicitly in shebangs (macOS default shell is zsh)
+- Test regex patterns with both GNU and BSD grep behavior
+- Use `[[ ]]` conditionals (requires bash 4+, install via Homebrew on macOS)
+
 ---
 
 > **Contributing:** https://github.com/netresearch/skill-repo-skill

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -215,7 +215,7 @@ mechanical:
   # === CROSS-PLATFORM COMPATIBILITY ===
   - id: SR-29
     type: command
-    target: "! grep -rn 'grep.*-P ' skills/ scripts/ .github/workflows/ 2>/dev/null | grep -v node_modules | grep -v '.git/' | head -1"
+    target: "! grep -qr --exclude-dir=node_modules --exclude-dir=.git 'grep.*-P ' skills/ scripts/ .github/workflows/ 2>/dev/null"
     severity: warning
     desc: "Shell scripts must not use grep -P (Perl regex) — not available on macOS BSD grep. Use grep -E (extended regex) instead"
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -204,6 +204,21 @@ mechanical:
     severity: warning
     desc: "plugin.json should have author field"
 
+  # === WORKFLOW QUALITY CHECKS ===
+  - id: SR-28
+    type: regex
+    target: .github/workflows/auto-merge-deps.yml
+    pattern: 'pull_request_target'
+    severity: error
+    desc: "Auto-merge workflow must use pull_request_target trigger for bot PR write permissions"
+
+  # === CROSS-PLATFORM COMPATIBILITY ===
+  - id: SR-29
+    type: command
+    target: "! grep -rn 'grep.*-P ' skills/ scripts/ .github/workflows/ 2>/dev/null | grep -v node_modules | grep -v '.git/' | head -1"
+    severity: warning
+    desc: "Shell scripts must not use grep -P (Perl regex) — not available on macOS BSD grep. Use grep -E (extended regex) instead"
+
 llm_reviews:
   - id: SR-30
     domain: repo-health
@@ -226,3 +241,21 @@ llm_reviews:
       4. Does it reference extended docs in references/ where appropriate?
     severity: warning
     desc: "SKILL.md clarity and completeness"
+
+  # === REUSABLE WORKFLOW USAGE ===
+  - id: SR-32
+    domain: ci
+    prompt: |
+      Check if the skill repo uses reusable workflows from skill-repo-skill:
+      1. Verify .github/workflows/ contains callers that delegate to
+         netresearch/skill-repo-skill/.github/workflows/*.yml@main
+      2. Expected reusable workflows: auto-merge-deps.yml, harness-verify.yml,
+         validate.yml, release.yml
+      3. Flag any workflow that reimplements logic available in skill-repo-skill's
+         reusable workflows (e.g., inline validation, inline auto-merge)
+      4. Exception: repo-specific test workflows (e.g., validate-agents.yml in
+         agent-rules-skill) that test repo-specific logic may use reusable
+         workflows from skill-repo-skill but also contain inline steps
+      Report missing reusable workflow usage and inline reimplementations.
+    severity: warning
+    desc: "Skill repos should use reusable workflows from skill-repo-skill for CI standardization"

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -210,12 +210,12 @@ mechanical:
     target: .github/workflows/auto-merge-deps.yml
     pattern: 'pull_request_target'
     severity: error
-    desc: "Auto-merge workflow must use pull_request_target trigger for bot PR write permissions"
+    desc: "Auto-merge workflow must use pull_request_target trigger (not pull_request) for bot PR write permissions. LLM review SR-32 validates full correctness"
 
   # === CROSS-PLATFORM COMPATIBILITY ===
   - id: SR-29
     type: command
-    target: "! grep -qr --exclude-dir=node_modules --exclude-dir=.git 'grep.*-P ' skills/ scripts/ .github/workflows/ 2>/dev/null"
+    pattern: "! grep -qr --include='*.sh' --exclude-dir=node_modules --exclude-dir=.git 'grep.*-P ' scripts/ .github/workflows/ 2>/dev/null"
     severity: warning
     desc: "Shell scripts must not use grep -P (Perl regex) — not available on macOS BSD grep. Use grep -E (extended regex) instead"
 

--- a/skills/skill-repo/templates/auto-merge-deps.yml.template
+++ b/skills/skill-repo/templates/auto-merge-deps.yml.template
@@ -1,7 +1,7 @@
 name: Auto-merge dependency PRs
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- Add SR-28: enforce `pull_request_target` trigger in auto-merge workflow (error severity) — required for bot PR write permissions
- Add SR-29: warn on `grep -P` usage in scripts/workflows (macOS BSD grep lacks `-P`; use `grep -E` instead)
- Add SR-32 (LLM review): verify skill repos use reusable workflows from skill-repo-skill rather than reimplementing CI logic inline
- Update `auto-merge-deps.yml.template` to use `pull_request_target` (fixing the SR-28 violation in the template itself)
- Add "Workflow Requirements" and "Cross-platform Compatibility" sections to `SKILL.md`

## Test plan

- [ ] Verify `scripts/validate-skill.sh` runs SR-28/SR-29 correctly against a repo with `pull_request` trigger and `grep -P` usage
- [ ] Confirm SR-32 LLM review fires on a repo with inline CI logic
- [ ] Confirm new template generates a workflow that passes SR-28
- [ ] Check SKILL.md word count remains under 500 words (SR-21)