### PR TITLE
Expand evals to 20 and improve SKILL.md from A/B findings

### DIFF
--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# run-ab-evals.sh - A/B test evals WITHOUT vs WITH skill context
+# Usage: ./scripts/run-ab-evals.sh [concurrency]
+# Default concurrency: 4 (parallel eval pairs)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+EVALS_FILE="$REPO_DIR/skills/skill-repo/evals/evals.json"
+SKILL_FILE="$REPO_DIR/skills/skill-repo/SKILL.md"
+RESULTS_DIR="$REPO_DIR/scripts/ab-results"
+CONCURRENCY="${1:-4}"
+
+mkdir -p "$RESULTS_DIR"
+
+EVAL_COUNT=$(python3 -c "import json; print(len(json.load(open('$EVALS_FILE'))))")
+echo "Found $EVAL_COUNT evals, concurrency=$CONCURRENCY"
+
+run_single() {
+    local idx="$1"
+    local mode="$2"
+    local name prompt output_file
+
+    name=$(python3 -c "import json; print(json.load(open('$EVALS_FILE'))[$idx]['name'])")
+    prompt=$(python3 -c "import json; print(json.load(open('$EVALS_FILE'))[$idx]['prompt'])")
+    output_file="$RESULTS_DIR/${name}_${mode}.txt"
+
+    if [[ "$mode" == "without" ]]; then
+        timeout 90 claude -p \
+            --no-session-persistence \
+            --disable-slash-commands \
+            --tools "" \
+            --model sonnet \
+            "$prompt" \
+            > "$output_file" 2>/dev/null || true
+    else
+        timeout 90 claude -p \
+            --no-session-persistence \
+            --disable-slash-commands \
+            --tools "" \
+            --model sonnet \
+            --append-system-prompt "$(cat "$SKILL_FILE")" \
+            "$prompt" \
+            > "$output_file" 2>/dev/null || true
+    fi
+}
+
+run_pair() {
+    local idx="$1"
+    local name
+    name=$(python3 -c "import json; print(json.load(open('$EVALS_FILE'))[$idx]['name'])")
+    echo "  Starting eval $idx: $name"
+    run_single "$idx" "without" &
+    local pid1=$!
+    run_single "$idx" "with" &
+    local pid2=$!
+    wait "$pid1" "$pid2" 2>/dev/null || true
+    echo "  Finished eval $idx: $name"
+}
+
+# Run evals in batches
+for batch_start in $(seq 0 "$CONCURRENCY" $((EVAL_COUNT - 1))); do
+    batch_end=$((batch_start + CONCURRENCY - 1))
+    [[ $batch_end -ge $EVAL_COUNT ]] && batch_end=$((EVAL_COUNT - 1))
+
+    echo "=== Batch: evals $batch_start-$batch_end ==="
+    for i in $(seq "$batch_start" "$batch_end"); do
+        run_pair "$i" &
+    done
+    wait
+done
+
+# Analyze results
+echo ""
+echo "=== RESULTS ==="
+
+SUMMARY_FILE="$RESULTS_DIR/summary.md"
+cat > "$SUMMARY_FILE" << 'EOF'
+| # | Eval | Without | With | Delta |
+|---|------|---------|------|-------|
+EOF
+
+TOTAL_WITHOUT=0
+TOTAL_WITH=0
+TOTAL_ASSERTIONS=0
+
+for i in $(seq 0 $((EVAL_COUNT - 1))); do
+    name=$(python3 -c "import json; print(json.load(open('$EVALS_FILE'))[$i]['name'])")
+
+    without_file="$RESULTS_DIR/${name}_without.txt"
+    with_file="$RESULTS_DIR/${name}_with.txt"
+
+    without_words=$(wc -w < "$without_file" 2>/dev/null || echo 0)
+    with_words=$(wc -w < "$with_file" 2>/dev/null || echo 0)
+
+    # Check assertions
+    pass_w=0; pass_s=0; total=0
+    while IFS= read -r pattern; do
+        [[ -z "$pattern" ]] && continue
+        ((total++)) || true
+        grep -qiE "$pattern" "$without_file" 2>/dev/null && ((pass_w++)) || true
+        grep -qiE "$pattern" "$with_file" 2>/dev/null && ((pass_s++)) || true
+    done <<< "$(python3 -c "
+import json
+evals = json.load(open('$EVALS_FILE'))
+for a in evals[$i].get('assertions', []):
+    print(a.get('pattern', ''))
+")"
+
+    delta=$((pass_s - pass_w))
+    [[ $delta -gt 0 ]] && ds="+$delta" || ds="$delta"
+
+    TOTAL_WITHOUT=$((TOTAL_WITHOUT + pass_w))
+    TOTAL_WITH=$((TOTAL_WITH + pass_s))
+    TOTAL_ASSERTIONS=$((TOTAL_ASSERTIONS + total))
+
+    echo "| $((i+1)) | $name | $pass_w/$total | $pass_s/$total | $ds |" >> "$SUMMARY_FILE"
+    echo "  $name: without=$pass_w/$total with=$pass_s/$total ($ds)"
+done
+
+echo ""
+echo "TOTALS: without=$TOTAL_WITHOUT/$TOTAL_ASSERTIONS  with=$TOTAL_WITH/$TOTAL_ASSERTIONS"
+echo "| | **TOTAL** | **$TOTAL_WITHOUT/$TOTAL_ASSERTIONS** | **$TOTAL_WITH/$TOTAL_ASSERTIONS** | **+$((TOTAL_WITH - TOTAL_WITHOUT))** |" >> "$SUMMARY_FILE"
+
+cat "$SUMMARY_FILE"

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -14,41 +14,35 @@ allowed-tools: Bash(bash:*) Bash(python3:*) Bash(jq:*) Read Write Glob Grep
 
 Standards for Netresearch skill repository layout and distribution.
 
-## When to Use
-
-- Creating a new skill repository
-- Standardizing an existing skill repo
-- Setting up release workflows
-
 ## Repository Structure
 
 ```
-{skill-name}/
-├── .claude-plugin/plugin.json  # Plugin metadata (required)
-├── SKILL.md              # AI instructions (required)
-├── README.md             # Human documentation (required)
-├── LICENSE-MIT           # Code license (required)
-├── LICENSE-CC-BY-SA-4.0  # Content license (required)
-├── composer.json         # PHP distribution
-├── references/           # Extended docs
-├── scripts/              # Automation
-└── .github/workflows/release.yml
+{repo-name}/
+├── .claude-plugin/plugin.json   # Plugin metadata (required)
+├── skills/{name}/SKILL.md       # AI instructions (required)
+├── README.md                    # Human docs (required)
+├── LICENSE-MIT                  # Code license (required)
+├── LICENSE-CC-BY-SA-4.0         # Content license (required)
+├── composer.json                # PHP distribution (required)
+├── references/                  # Extended docs for >500w content
+├── scripts/                     # Automation
+└── .github/workflows/
+    ├── release.yml              # Tag-triggered release
+    ├── validate.yml             # Caller for reusable validation
+    └── auto-merge-deps.yml      # Caller for dep auto-merge
 ```
 
-## Licensing
-
-Skill repos use split licensing:
+## Licensing (Split Model)
 
 | Path pattern | License |
 |---|---|
-| `skills/**/*.md`, `references/**`, `assets/**/*.md`, `README.md`, `docs/**` | CC-BY-SA-4.0 |
-| `scripts/**`, `Build/**`, `.github/workflows/**`, `*.sh`, `*.py`, `*.php` | MIT |
+| `skills/**/*.md`, `references/**`, `README.md`, `docs/**` | CC-BY-SA-4.0 |
+| `scripts/**`, `.github/workflows/**`, `*.sh`, `*.py`, `*.php` | MIT |
 | `composer.json`, `plugin.json`, config files | MIT |
-| Code snippets embedded in `.md` files | Dual (both apply) |
 
-Composer/plugin metadata uses SPDX compound expression: `(MIT AND CC-BY-SA-4.0)`
+SPDX expression: `(MIT AND CC-BY-SA-4.0)`. Copyright: `Netresearch DTT GmbH`. No bare `LICENSE` file — use split files only.
 
-## SKILL.md Requirements
+## SKILL.md Frontmatter
 
 ```yaml
 ---
@@ -57,38 +51,46 @@ description: "Use when <trigger conditions>"
 ---
 ```
 
-- Under 500 words, use references/ for extended content
+Body: max 500 words. Use `references/` for extended content.
 
-## Installation Methods
+## plugin.json (`.claude-plugin/plugin.json`)
 
-1. **Marketplace**: `/plugin marketplace add netresearch/claude-code-marketplace`
-2. **Release**: Download and extract to `~/.claude/skills/{name}/`
-3. **Composer**: `composer require netresearch/{repo-name}`
+```json
+{
+  "name": "skill-name",
+  "version": "1.0.0",
+  "skills": ["./skills/skill-name"],
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": {"name": "Netresearch DTT GmbH", "url": "https://www.netresearch.de"}
+}
+```
 
-## Composer Package
+## composer.json
 
-Composer name **must match GitHub repo name** exactly.
+Name **must match GitHub repo name**. Type must be `ai-agent-skill`. No `version` field (derived from git tags). No `composer.lock`.
 
 ```json
 {
   "name": "netresearch/{repo-name}",
   "type": "ai-agent-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "require": {"netresearch/composer-agent-skill-plugin": "*"},
-  "extra": {"ai-agent-skill": "SKILL.md"}
+  "extra": {"ai-agent-skill": "skills/{name}/SKILL.md"}
 }
 ```
 
-## Validation
+## Reusable Workflow Callers
 
-```bash
-scripts/validate-skill.sh
+Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
+
+```yaml
+# .github/workflows/validate.yml
+uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-## References
+Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`.
 
-- `references/installation-methods.md`
-- `references/composer-setup.md`
-- `templates/README.md.template`
+Auto-merge callers must use `pull_request_target` trigger (not `pull_request`).
 
 ## Releasing
 
@@ -97,25 +99,28 @@ scripts/validate-skill.sh
 3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
 4. Push: `git push origin main vX.Y.Z`
 
-## Workflow Requirements
+## Installation
 
-Skill repos MUST use reusable workflows from skill-repo-skill for CI standardization:
+1. **Marketplace**: `/plugin marketplace add netresearch/claude-code-marketplace`
+2. **Release**: Download to `~/.claude/skills/{name}/`
+3. **Composer**: `composer require netresearch/{repo-name}`
 
-| Workflow | Purpose | Required |
-|----------|---------|----------|
-| `auto-merge-deps.yml` | Auto-merge Dependabot/Renovate PRs | Yes |
-| `harness-verify.yml` | Verify AGENTS.md harness consistency | Yes |
-| `validate.yml` | Validate skill structure and lint | Yes |
-| `release.yml` | Create releases on tag push | Yes |
+## Validation
 
-### Cross-platform Compatibility
+```bash
+scripts/validate-skill.sh
+```
 
-Scripts in `scripts/` and workflow `run:` blocks must work on both Linux and macOS:
+## Cross-platform Compatibility
 
-- Use `grep -E` (extended regex), NOT `grep -P` (Perl regex — macOS BSD grep lacks `-P`)
-- Use `bash` explicitly in shebangs (macOS default shell is zsh)
-- Test regex patterns with both GNU and BSD grep behavior
-- Use `[[ ]]` for conditionals, which is more robust than single-bracket `[ ]` and is a bash builtin
+- Use `grep -E` not `grep -P` (macOS BSD grep lacks `-P`)
+- Use `bash` in shebangs (macOS default is zsh)
+- Use `[[ ]]` for conditionals
+
+## References
+
+- `references/installation-methods.md`
+- `references/composer-setup.md`
 
 ---
 

--- a/skills/skill-repo/evals/evals.json
+++ b/skills/skill-repo/evals/evals.json
@@ -1,35 +1,183 @@
 [
   {
     "name": "create_new_skill_repo",
-    "prompt": "Create a new skill repo from scratch called 'my-awesome-skill' with proper structure",
+    "prompt": "Create a new skill repo from scratch called 'my-awesome-skill' with proper Netresearch structure",
     "assertions": [
-      {
-        "type": "content",
-        "pattern": "plugin\\.json"
-      },
-      {
-        "type": "content",
-        "pattern": "SKILL\\.md"
-      },
-      {
-        "type": "content",
-        "pattern": "LICENSE-(MIT|CC-BY-SA)"
-      }
+      { "type": "content", "pattern": "\\.claude-plugin/plugin\\.json" },
+      { "type": "content", "pattern": "SKILL\\.md" },
+      { "type": "content", "pattern": "LICENSE-MIT" },
+      { "type": "content", "pattern": "LICENSE-CC-BY-SA-4\\.0" },
+      { "type": "content", "pattern": "composer\\.json" },
+      { "type": "content", "pattern": "release\\.yml" }
     ]
   },
   {
     "name": "validate_skill_repo_structure",
     "prompt": "Validate this skill repo structure and tell me what's missing or wrong",
     "assertions": [
-      {
-        "type": "tool_use",
-        "tool": "Bash",
-        "pattern": "validate-skill"
-      },
-      {
-        "type": "content",
-        "pattern": "(plugin\\.json|SKILL\\.md|LICENSE)"
-      }
+      { "type": "tool_use", "tool": "Bash", "pattern": "validate-skill" },
+      { "type": "content", "pattern": "(plugin\\.json|SKILL\\.md|LICENSE)" }
+    ]
+  },
+  {
+    "name": "split_licensing_setup",
+    "prompt": "What license files does a Netresearch skill repo need and what SPDX expression goes in composer.json?",
+    "assertions": [
+      { "type": "content", "pattern": "LICENSE-MIT" },
+      { "type": "content", "pattern": "LICENSE-CC-BY-SA-4\\.0" },
+      { "type": "content", "pattern": "\\(MIT AND CC-BY-SA-4\\.0\\)" },
+      { "type": "content", "pattern": "Netresearch DTT GmbH" }
+    ]
+  },
+  {
+    "name": "migrate_single_license",
+    "prompt": "This repo has a single LICENSE file. Migrate it to the split licensing model required by Netresearch skill repos.",
+    "assertions": [
+      { "type": "content", "pattern": "LICENSE-MIT" },
+      { "type": "content", "pattern": "LICENSE-CC-BY-SA-4\\.0" },
+      { "type": "content", "pattern": "(remove|delete|old).*LICENSE" }
+    ]
+  },
+  {
+    "name": "composer_json_setup",
+    "prompt": "Set up composer.json for a skill repo called 'netresearch/typo3-testing-skill'. What fields are required?",
+    "assertions": [
+      { "type": "content", "pattern": "ai-agent-skill" },
+      { "type": "content", "pattern": "composer-agent-skill-plugin" },
+      { "type": "content", "pattern": "netresearch/typo3-testing-skill" },
+      { "type": "content", "pattern": "SKILL\\.md" }
+    ]
+  },
+  {
+    "name": "composer_no_version_field",
+    "prompt": "Should composer.json in a skill repo have a version field? Why or why not?",
+    "assertions": [
+      { "type": "content", "pattern": "(no|not|never|omit|should not|must not)" },
+      { "type": "content", "pattern": "(git tag|derive|tag)" }
+    ]
+  },
+  {
+    "name": "composer_no_lock_file",
+    "prompt": "Should a skill repo commit composer.lock?",
+    "assertions": [
+      { "type": "content", "pattern": "(no|never|must not|should not)" },
+      { "type": "content", "pattern": "(librar|skill|package)" }
+    ]
+  },
+  {
+    "name": "plugin_json_structure",
+    "prompt": "Create a valid plugin.json for a skill called 'security-audit' in .claude-plugin/",
+    "assertions": [
+      { "type": "content", "pattern": "\"name\"" },
+      { "type": "content", "pattern": "\"version\"" },
+      { "type": "content", "pattern": "\"skills\"" },
+      { "type": "content", "pattern": "\\./skills/" },
+      { "type": "content", "pattern": "netresearch\\.de" }
+    ]
+  },
+  {
+    "name": "skillmd_frontmatter_format",
+    "prompt": "Write valid SKILL.md frontmatter for a skill named 'docker-development'",
+    "assertions": [
+      { "type": "content", "pattern": "^---" },
+      { "type": "content", "pattern": "name: docker-development" },
+      { "type": "content", "pattern": "description: \"Use when" }
+    ]
+  },
+  {
+    "name": "skillmd_word_limit",
+    "prompt": "What is the word limit for SKILL.md and where should extended content go?",
+    "assertions": [
+      { "type": "content", "pattern": "500" },
+      { "type": "content", "pattern": "references/" }
+    ]
+  },
+  {
+    "name": "reusable_workflow_caller",
+    "prompt": "Create a caller workflow for validate.yml that uses the reusable workflow from skill-repo-skill",
+    "assertions": [
+      { "type": "content", "pattern": "netresearch/skill-repo-skill/\\.github/workflows/validate\\.yml@main" },
+      { "type": "content", "pattern": "uses:" }
+    ]
+  },
+  {
+    "name": "release_workflow_setup",
+    "prompt": "What release workflow does a skill repo need and how is it triggered?",
+    "assertions": [
+      { "type": "content", "pattern": "release\\.yml" },
+      { "type": "content", "pattern": "(tag|v\\*|push)" },
+      { "type": "content", "pattern": "plugin\\.json" }
+    ]
+  },
+  {
+    "name": "release_process_steps",
+    "prompt": "Walk me through the release process for a Netresearch skill repo at version 2.1.0",
+    "assertions": [
+      { "type": "content", "pattern": "plugin\\.json" },
+      { "type": "content", "pattern": "git tag" },
+      { "type": "content", "pattern": "v2\\.1\\.0" },
+      { "type": "content", "pattern": "git push" }
+    ]
+  },
+  {
+    "name": "installation_methods",
+    "prompt": "What are the three ways to install a Netresearch skill?",
+    "assertions": [
+      { "type": "content", "pattern": "(marketplace|Marketplace)" },
+      { "type": "content", "pattern": "(composer|Composer)" },
+      { "type": "content", "pattern": "(release|download|Release)" }
+    ]
+  },
+  {
+    "name": "multi_skill_package",
+    "prompt": "How do I set up composer.json and plugin.json for a repo containing two skills: jira-communication and jira-syntax?",
+    "assertions": [
+      { "type": "content", "pattern": "jira-communication" },
+      { "type": "content", "pattern": "jira-syntax" },
+      { "type": "content", "pattern": "(array|\\[)" }
+    ]
+  },
+  {
+    "name": "cross_platform_scripts",
+    "prompt": "What cross-platform rules must scripts in a skill repo follow?",
+    "assertions": [
+      { "type": "content", "pattern": "grep -E" },
+      { "type": "content", "pattern": "(macOS|BSD|darwin)" },
+      { "type": "content", "pattern": "(-P|Perl)" }
+    ]
+  },
+  {
+    "name": "license_path_mapping",
+    "prompt": "Which license applies to scripts/*.sh files and which applies to references/*.md files in a skill repo?",
+    "assertions": [
+      { "type": "content", "pattern": "MIT" },
+      { "type": "content", "pattern": "CC-BY-SA" }
+    ]
+  },
+  {
+    "name": "fix_validation_errors",
+    "prompt": "validate-skill.sh reports: ERROR: composer.json type must be 'ai-agent-skill' and ERROR: plugin.json author.url must be https://www.netresearch.de. Fix these issues.",
+    "assertions": [
+      { "type": "content", "pattern": "ai-agent-skill" },
+      { "type": "content", "pattern": "netresearch\\.de" }
+    ]
+  },
+  {
+    "name": "readme_requirements",
+    "prompt": "What sections and content must a Netresearch skill repo README.md include?",
+    "assertions": [
+      { "type": "content", "pattern": "(Installation|installation)" },
+      { "type": "content", "pattern": "(License|license)" },
+      { "type": "content", "pattern": "Netresearch" }
+    ]
+  },
+  {
+    "name": "auto_merge_workflow",
+    "prompt": "Set up the auto-merge workflow for dependency PRs in a skill repo",
+    "assertions": [
+      { "type": "content", "pattern": "auto-merge-deps" },
+      { "type": "content", "pattern": "netresearch/skill-repo-skill" },
+      { "type": "content", "pattern": "(dependabot|renovate|pull_request)" }
     ]
   }
 ]


### PR DESCRIPTION
## Summary

- Expanded evals from 2 to 20, covering all skill areas (repo structure, licensing, workflows, composer, plugin.json, validation, cross-platform)
- Ran A/B testing on all 20 evals: WITHOUT skill vs WITH skill
- Used A/B findings to improve SKILL.md (added missing plugin.json example, composer constraints, workflow caller pattern, fixed structure diagram)
- Added `scripts/run-ab-evals.sh` for repeatable skill quality measurement
- SKILL.md word count reduced from 475 to 427 while adding critical missing content

## A/B Results (20 evals, 61 assertions)

| # | Eval | Without | With | Delta |
|---|------|---------|------|-------|
| 1 | create_new_skill_repo | 0/6 | 6/6 | +6 |
| 2 | validate_skill_repo_structure | 0/2 | 2/2 | +2 |
| 3 | split_licensing_setup | 0/4 | 3/4 | +3 |
| 4 | migrate_single_license | 0/3 | 3/3 | +3 |
| 5 | composer_json_setup | 1/4 | 4/4 | +3 |
| 6 | composer_no_version_field | 2/2 | 2/2 | 0 |
| 7 | composer_no_lock_file | 2/2 | 2/2 | 0 |
| 8 | plugin_json_structure | 3/5 | 5/5 | +2 |
| 9 | skillmd_frontmatter_format | 2/3 | 3/3 | +1 |
| 10 | skillmd_word_limit | 0/2 | 2/2 | +2 |
| 11 | reusable_workflow_caller | 0/2 | 2/2 | +2 |
| 12 | release_workflow_setup | 2/3 | 3/3 | +1 |
| 13 | release_process_steps | 1/4 | 4/4 | +3 |
| 14 | installation_methods | 0/3 | 3/3 | +3 |
| 15 | multi_skill_package | 3/3 | 3/3 | 0 |
| 16 | cross_platform_scripts | 3/3 | 3/3 | 0 |
| 17 | license_path_mapping | 0/2 | 2/2 | +2 |
| 18 | fix_validation_errors | 2/2 | 2/2 | 0 |
| 19 | readme_requirements | 0/3 | 3/3 | +3 |
| 20 | auto_merge_workflow | 2/3 | 3/3 | +1 |
| | **TOTAL** | **23/61 (38%)** | **60/61 (98%)** | **+37** |

**Key findings:** The skill lifts assertion pass rate from 38% to 98%. Largest gains on Netresearch-specific content (repo structure, licensing, workflows, installation methods) where baseline knowledge is zero. General knowledge evals (composer.lock, cross-platform, fix validation) show 0 delta -- model already knows these patterns.

## SKILL.md Improvements (from A/B gaps)

- Added `plugin.json` example with `author.url`, `version`, `skills` array
- Added `composer.json` constraints: no `version` field, no `composer.lock`
- Added reusable workflow caller pattern with `uses:` syntax
- Fixed structure diagram: `SKILL.md` is at `skills/{name}/SKILL.md` not root
- Added `pull_request_target` requirement for auto-merge callers
- Added copyright entity (`Netresearch DTT GmbH`) to licensing section
- Word count: 475 -> 427 (saved 48 words while adding content)

## Test plan

- [x] `validate-skill.sh` passes (0 errors, 0 warnings)
- [x] SKILL.md word count is 427 (under 500 limit)
- [x] All 20 evals have valid JSON structure
- [x] A/B test script runs successfully with parallel execution