### PR TITLE
feat: add eval validation workflow and script

### DIFF
--- a/.github/workflows/eval-validate.yml
+++ b/.github/workflows/eval-validate.yml
@@ -1,0 +1,52 @@
+name: Validate Evals
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-evals:
+    name: Eval Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Checkout validation tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: netresearch/skill-repo-skill
+          ref: main
+          path: .skill-repo-tools
+          sparse-checkout: skills/skill-repo/scripts/
+          sparse-checkout-cone-mode: false
+
+      - name: Find evals.json
+        id: find-evals
+        run: |
+          EVALS_FILE=""
+          for candidate in skills/*/evals/evals.json evals/evals.json; do
+            if [[ -f "$candidate" ]]; then
+              EVALS_FILE="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$EVALS_FILE" ]]; then
+            echo "::warning::No evals.json found, skipping validation"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Found: $EVALS_FILE"
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "path=$EVALS_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Validate evals structure
+        if: steps.find-evals.outputs.found == 'true'
+        run: bash .skill-repo-tools/skills/skill-repo/scripts/validate-evals.sh "${{ steps.find-evals.outputs.path }}"

--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -91,8 +91,8 @@ for i in $(seq 0 $((EVAL_COUNT - 1))); do
     without_file="$RESULTS_DIR/${name}_without.txt"
     with_file="$RESULTS_DIR/${name}_with.txt"
 
-    without_words=$(wc -w < "$without_file" 2>/dev/null || echo 0)
-    with_words=$(wc -w < "$with_file" 2>/dev/null || echo 0)
+    _without_words=$(wc -w < "$without_file" 2>/dev/null || echo 0)
+    _with_words=$(wc -w < "$with_file" 2>/dev/null || echo 0)
 
     # Check assertions
     pass_w=0; pass_s=0; total=0

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -88,7 +88,7 @@ Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
 uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`.
+Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`, `eval-validate.yml`.
 
 Auto-merge callers must use `pull_request_target` trigger (not `pull_request`).
 

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# validate-evals.sh - Structural validation of evals.json files
+# Supports two formats:
+#   Format A: {"skill_name": "...", "evals": [{id, eval_name, prompt, assertions: ["..."]}]}
+#   Format B: [{name, prompt, assertions: [{type, value/pattern, description?}]}]
+#
+# Usage: bash validate-evals.sh [path-to-evals.json]
+#   If no path given, searches skills/*/evals/evals.json then evals/evals.json
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+WARN=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+warn() { WARN=$((WARN + 1)); echo "  WARN: $1"; }
+
+# --- Locate evals.json ---
+EVALS_FILE="${1:-}"
+if [[ -z "$EVALS_FILE" ]]; then
+  for candidate in skills/*/evals/evals.json evals/evals.json; do
+    if [[ -f "$candidate" ]]; then
+      EVALS_FILE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$EVALS_FILE" ]] || [[ ! -f "$EVALS_FILE" ]]; then
+  echo "ERROR: No evals.json found"
+  echo "Searched: skills/*/evals/evals.json, evals/evals.json"
+  exit 1
+fi
+
+echo "Validating: $EVALS_FILE"
+echo "---"
+
+# --- Valid JSON ---
+if ! python3 -c "import json, sys; json.load(open(sys.argv[1]))" "$EVALS_FILE" 2>/dev/null; then
+  fail "Invalid JSON"
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed, $WARN warnings"
+  exit 1
+fi
+pass "Valid JSON"
+
+# --- Run all structural checks via Python ---
+RESULT=$(python3 - "$EVALS_FILE" <<'PYEOF'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    raw = json.load(f)
+
+# Detect format and normalize to list of evals
+if isinstance(raw, dict) and "evals" in raw:
+    # Format A: {skill_name, evals: [...]}
+    evals = raw["evals"]
+    fmt = "A"
+elif isinstance(raw, list):
+    # Format B: [...]
+    evals = raw
+    fmt = "B"
+else:
+    print("FAIL|Top-level structure must be an array or object with 'evals' key")
+    sys.exit(0)
+
+print(f"INFO|Detected format {'A (object with evals key)' if fmt == 'A' else 'B (top-level array)'}")
+print(f"INFO|Total evals: {len(evals)}")
+
+if not isinstance(evals, list):
+    print("FAIL|'evals' must be an array")
+    sys.exit(0)
+
+if len(evals) == 0:
+    print("FAIL|No evals found")
+    sys.exit(0)
+
+# Check eval count thresholds
+if len(evals) < 10:
+    print(f"FAIL|Eval count {len(evals)} < 10 minimum")
+elif len(evals) < 15:
+    print(f"WARN|Eval count {len(evals)} < 15 recommended")
+else:
+    print(f"PASS|Eval count {len(evals)} >= 15")
+
+# Track names for duplicate check
+names = []
+ids_found = []
+has_ids = False
+
+for i, ev in enumerate(evals):
+    label = f"eval[{i}]"
+
+    if not isinstance(ev, dict):
+        print(f"FAIL|{label}: not an object")
+        continue
+
+    # Name check (supports both 'name' and 'eval_name')
+    name = ev.get("name") or ev.get("eval_name") or ""
+    if not name or not str(name).strip():
+        print(f"FAIL|{label}: missing or empty name/eval_name")
+    else:
+        names.append(str(name).strip())
+
+    # Prompt check
+    prompt = ev.get("prompt", "")
+    if not prompt or not str(prompt).strip():
+        print(f"FAIL|{label} ({name}): missing or empty prompt")
+    else:
+        print(f"PASS|{label} ({name}): has prompt")
+
+    # ID check (optional but validated if present)
+    if "id" in ev:
+        has_ids = True
+        ids_found.append(ev["id"])
+
+    # Assertions check
+    assertions = ev.get("assertions")
+    if assertions is None:
+        print(f"FAIL|{label} ({name}): missing assertions")
+        continue
+
+    if not isinstance(assertions, list):
+        print(f"FAIL|{label} ({name}): assertions must be an array")
+        continue
+
+    if len(assertions) < 2:
+        print(f"FAIL|{label} ({name}): has {len(assertions)} assertions, need >= 2")
+        continue
+
+    # Validate assertion contents
+    empty_assertions = 0
+    for j, a in enumerate(assertions):
+        if isinstance(a, str):
+            if not a.strip():
+                empty_assertions += 1
+        elif isinstance(a, dict):
+            # Object assertions: need at least type + (value or pattern)
+            if "type" not in a:
+                print(f"FAIL|{label} ({name}): assertion[{j}] missing 'type'")
+            val = a.get("value") or a.get("pattern") or ""
+            if not str(val).strip():
+                print(f"FAIL|{label} ({name}): assertion[{j}] missing 'value' or 'pattern'")
+        else:
+            print(f"FAIL|{label} ({name}): assertion[{j}] invalid type (not string or object)")
+
+    if empty_assertions > 0:
+        print(f"FAIL|{label} ({name}): {empty_assertions} empty string assertion(s)")
+    else:
+        print(f"PASS|{label} ({name}): {len(assertions)} valid assertions")
+
+# Duplicate names
+seen = set()
+dupes = set()
+for n in names:
+    if n in seen:
+        dupes.add(n)
+    seen.add(n)
+
+if dupes:
+    print(f"FAIL|Duplicate eval names: {', '.join(sorted(dupes))}")
+else:
+    print(f"PASS|No duplicate eval names")
+
+# ID validation (if IDs are present)
+if has_ids:
+    # Check for duplicates
+    id_counts = {}
+    for eid in ids_found:
+        id_counts[eid] = id_counts.get(eid, 0) + 1
+    dupe_ids = [k for k, v in id_counts.items() if v > 1]
+    if dupe_ids:
+        print(f"FAIL|Duplicate IDs: {dupe_ids}")
+    else:
+        print(f"PASS|No duplicate IDs")
+
+    # Check sequential (1-based)
+    numeric_ids = sorted([x for x in ids_found if isinstance(x, int)])
+    if numeric_ids:
+        expected = list(range(1, len(numeric_ids) + 1))
+        if numeric_ids != expected:
+            gaps = set(expected) - set(numeric_ids)
+            extra = set(numeric_ids) - set(expected)
+            msg = ""
+            if gaps:
+                msg += f"missing: {sorted(gaps)}"
+            if extra:
+                if msg:
+                    msg += ", "
+                msg += f"unexpected: {sorted(extra)}"
+            print(f"FAIL|IDs not sequential: {msg}")
+        else:
+            print(f"PASS|IDs sequential (1-{len(numeric_ids)})")
+PYEOF
+)
+
+# --- Parse Python output ---
+while IFS='|' read -r level msg; do
+  case "$level" in
+    PASS) pass "$msg" ;;
+    FAIL) fail "$msg" ;;
+    WARN) warn "$msg" ;;
+    INFO) echo "  INFO: $msg" ;;
+  esac
+done <<< "$RESULT"
+
+# --- Summary ---
+echo ""
+echo "---"
+echo "Results: $PASS passed, $FAIL failed, $WARN warnings"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Add `skills/skill-repo/scripts/validate-evals.sh` -- portable bash script for structural validation of evals.json files. Supports both eval formats found across Netresearch skill repos (object-with-evals-key and top-level-array). Checks: valid JSON, required fields (name, prompt, assertions), assertion quality (>=2 per eval, non-empty), duplicate name/ID detection, sequential ID validation, and eval count thresholds (>=10 required, >=15 recommended).
- Add `.github/workflows/eval-validate.yml` -- reusable workflow that skill repos can call to run eval validation in CI. Auto-discovers evals.json in `skills/*/evals/` or `evals/` directories.
- Update SKILL.md to list `eval-validate.yml` as a required workflow caller.

## Test plan

- [ ] Verify `bash skills/skill-repo/scripts/validate-evals.sh` passes on this repo's own evals.json (20 evals, Format B)
- [ ] Test with Format A evals.json (object with `evals` key and numeric IDs)
- [ ] Test with malformed JSON to confirm early failure
- [ ] Verify workflow syntax is valid via CI lint job
- [ ] Confirm SKILL.md stays under 500 words