### PR TITLE
feat(validate): warn about relative script paths missing ${CLAUDE_SKILL_DIR}

### DIFF
--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -105,6 +105,14 @@ if [[ -n "$SKILL_FILE" ]]; then
     else
         error "SKILL.md is $WORDS words (max 500)"
     fi
+    # Check for relative script paths that should use ${CLAUDE_SKILL_DIR}
+    # Matches: uv run scripts/, python3 scripts/, python scripts/, bash scripts/, ./scripts/, sh scripts/
+    # But ignores lines already using ${CLAUDE_SKILL_DIR}
+    RELATIVE_PATHS=$(grep -nE '(uv run|python3?|bash|sh|\./)([ ]+)scripts/' "$SKILL_FILE" | grep -v 'CLAUDE_SKILL_DIR' || true)
+    if [[ -n "$RELATIVE_PATHS" ]]; then
+        COUNT=$(echo "$RELATIVE_PATHS" | wc -l)
+        warning "SKILL.md has $COUNT script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
+    fi
 else
     error "SKILL.md not found (checked root and skills/*/)"
 fi


### PR DESCRIPTION
## Summary

- Add validation check to `validate-skill.sh` that warns when SKILL.md references scripts with relative paths instead of `${CLAUDE_SKILL_DIR}/scripts/`
- Detects patterns like `uv run scripts/`, `python3 scripts/`, `bash scripts/`, `./scripts/`
- Skips lines that already use `${CLAUDE_SKILL_DIR}`
- Warning only (not error) to allow gradual migration

## Context

`${CLAUDE_SKILL_DIR}` is the [officially documented mechanism](https://code.claude.com/docs/en/skills) for skills to reference their own scripts. Relative paths break when skills are invoked from a different working directory than where the skill is installed.

## Test plan

- [ ] Run against a skill with relative paths → shows warning with count
- [ ] Run against a skill using `${CLAUDE_SKILL_DIR}` → no warning
- [ ] Run against a skill with no script references → no warning