### PR TITLE
feat(workflows): add reusable pr-quality workflow

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,61 @@
+# Reusable workflow: PR Quality Gates
+#
+# Solo-maintainer auto-approve: approves PRs from repo collaborators so that
+# required_approving_review_count >= 1 is satisfied without manual review for
+# trusted authors.
+#
+# SECURITY: This workflow is designed to be called from a `pull_request_target`
+# trigger, which runs with base branch permissions. NEVER add an actions/checkout
+# step here -- that would allow code from the PR to execute with write access to
+# the repository.
+#
+# Caller example (.github/workflows/pr-quality.yml in the consumer repo):
+#
+#   name: PR Quality Gates
+#   on:
+#     pull_request_target:
+#       types: [opened, synchronize, reopened]
+#   jobs:
+#     pr-quality:
+#       uses: netresearch/skill-repo-skill/.github/workflows/pr-quality.yml@main
+#       permissions:
+#         pull-requests: write
+#
+# Bootstrap: The PR that introduces the caller workflow in a consumer repo must
+# be approved manually (the workflow isn't on the base branch yet). All
+# subsequent PRs auto-approve.
+
+name: PR Quality Gates (reusable)
+
+on:
+    workflow_call:
+
+jobs:
+    auto-approve:
+        name: Auto-approve (collaborators)
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+
+        steps:
+            - name: Harden Runner
+              uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+              with:
+                  egress-policy: audit
+
+            - name: Check author permission
+              id: check-permission
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || echo "none")
+                  echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
+
+            - name: Auto-approve PR
+              if: steps.check-permission.outputs.permission == 'admin' || steps.check-permission.outputs.permission == 'write'
+              env:
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh pr review --approve "$PR_URL"

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -88,9 +88,9 @@ Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
 uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`, `eval-validate.yml`.
+Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml`.
 
-Auto-merge callers must use `pull_request_target` trigger (not `pull_request`).
+Auto-merge and pr-quality callers must use `pull_request_target` trigger (not `pull_request`). Never define actions directly in skill repos — always call reusable workflows so action version bumps happen in one place.
 
 ## Releasing
 

--- a/skills/skill-repo/templates/pr-quality.yml.template
+++ b/skills/skill-repo/templates/pr-quality.yml.template
@@ -1,0 +1,13 @@
+name: PR Quality Gates
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  pr-quality:
+    uses: netresearch/skill-repo-skill/.github/workflows/pr-quality.yml@main
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-quality.yml` as a reusable workflow (`workflow_call`) so consumer skill repos no longer need to pin `step-security/harden-runner` directly.
- Adds `skills/skill-repo/templates/pr-quality.yml.template` as the thin caller skill repos should use.
- Updates `skills/skill-repo/SKILL.md` to list `pr-quality.yml` among the required reusable callers and makes the "no direct actions" rule explicit.

## Why

Six skill repos (security-audit, typo3-conformance, typo3-testing, php-modernization, typo3-docs, enterprise-readiness) each maintained their own `pr-quality.yml` with a direct pin of `step-security/harden-runner`. Every action bump produced a separate Dependabot PR per repo. Moving the action into a single reusable workflow collapses those to one PR in this repo.

## Follow-up

- Consumer repos will be updated in separate PRs to replace their local pr-quality.yml with a caller that references netresearch/skill-repo-skill/.github/workflows/pr-quality.yml@main.
- The 5 open Dependabot PRs in the consumer repos will be closed as superseded after migration.

## Test plan

- [ ] Reusable workflow parses (will be validated when first caller runs)
- [ ] Consumer caller PRs trigger this workflow successfully on pull_request_target
- [ ] Auto-approve behavior for collaborators still works end-to-end