### PR TITLE
fix(pr-quality): include maintain role and restore caller SECURITY note

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -54,7 +54,10 @@ jobs:
                   echo "permission=$PERMISSION" >> "$GITHUB_OUTPUT"
 
             - name: Auto-approve PR
-              if: steps.check-permission.outputs.permission == 'admin' || steps.check-permission.outputs.permission == 'write'
+              # Matches the permission levels GitHub returns for repository
+              # collaborators with write-or-higher access: admin, maintain, write.
+              # (read/triage are explicitly excluded; none means not a collaborator.)
+              if: contains(fromJSON('["admin","maintain","write"]'), steps.check-permission.outputs.permission)
               env:
                   PR_URL: ${{ github.event.pull_request.html_url }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/skills/skill-repo/templates/pr-quality.yml.template
+++ b/skills/skill-repo/templates/pr-quality.yml.template
@@ -1,3 +1,13 @@
+# SECURITY: This caller runs on `pull_request_target`, so the job receives
+# base-branch permissions (including `pull-requests: write`). Do NOT add an
+# `actions/checkout` of the PR head or otherwise execute PR-controlled code
+# here — that would escalate untrusted code to write scope. All logic lives
+# in the reusable workflow; this file must stay a thin caller.
+#
+# Bootstrap: when first adding this file to a repo, the PR that introduces
+# it must be merged manually (the workflow isn't on the base branch yet).
+# All subsequent PRs auto-approve via the reusable workflow.
+
 name: PR Quality Gates
 
 on:


### PR DESCRIPTION
## Summary

Addresses review feedback on #56:

- **Auto-approve includes `maintain`** — GitHub returns `maintain` for collaborators with elevated access; previously only `admin` and `write` were auto-approved, silently excluding maintainers. Matches Copilot's suggestion on #56.
- **Template regains SECURITY note** — `pr-quality.yml.template` now includes the `pull_request_target` warning block that was dropped when thinning the consumer callers. Caller files are where future editors are most likely to add steps, so the warning belongs there in addition to the reusable workflow.

## Not changed (declined)

- **Pinning to `@v1` instead of `@main`**: declined. All other reusable callers in this ecosystem (`release.yml`, `ci.yml`, `lint.yml`, `auto-merge-deps.yml`, `harness-verify.yml`) use `@main`. Changing only `pr-quality.yml` would be inconsistent. Pinning policy is a project-wide decision that should be addressed separately across all callers, not just this one.

## Test plan

- [ ] Reusable workflow still parses and runs
- [ ] Collaborator with `maintain` permission should now be auto-approved