### PR TITLE
feat: accept expectations field in eval validation

### DIFF
--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 # validate-evals.sh - Structural validation of evals.json files
-# Supports two formats:
-#   Format A: {"skill_name": "...", "evals": [{id, eval_name, prompt, assertions: ["..."]}]}
-#   Format B: [{name, prompt, assertions: [{type, value/pattern, description?}]}]
+# Supports three formats:
+#   Unified (recommended): {"skill_name": "...", "evals": [{id, eval_name, prompt,
+#       expected_output?, expectations?: ["..."], assertions?: [{type, pattern}]}]}
+#     - Evals may use expectations (string[], LLM-as-judge), assertions (object[],
+#       regex matching), or both. At least one grading mechanism is required.
+#   Legacy A: {"skill_name": "...", "evals": [{id, eval_name, prompt, assertions: [...]}]}
+#   Legacy B: [{name, prompt, assertions: [{type, value/pattern, description?}]}]
 #
 # Usage: bash validate-evals.sh [path-to-evals.json]
 #   If no path given, searches skills/*/evals/evals.json then evals/evals.json
@@ -98,17 +102,24 @@ for i, ev in enumerate(evals):
         print(f"FAIL|{label}: not an object")
         continue
 
-    # Name check (supports both 'name' and 'eval_name')
+    # Name/ID check: accept 'name', 'eval_name', or 'id' (integer) as identifier
     name = ev.get("name") or ev.get("eval_name") or ""
     if not name or not str(name).strip():
-        print(f"FAIL|{label}: missing or empty name/eval_name")
-    else:
+        # Fall back to id as identifier for Anthropic format
+        eid = ev.get("id")
+        if eid is not None and isinstance(eid, int):
+            name = f"id={eid}"
+        else:
+            print(f"FAIL|{label}: missing or empty name/eval_name/id")
+    if name and name not in ("", f"id={ev.get('id')}"):
         names.append(str(name).strip())
+    elif name.startswith("id="):
+        names.append(name)
 
-    # Prompt check
-    prompt = ev.get("prompt", "")
+    # Prompt check (accept 'prompt' or legacy 'input')
+    prompt = ev.get("prompt") or ev.get("input") or ""
     if not prompt or not str(prompt).strip():
-        print(f"FAIL|{label} ({name}): missing or empty prompt")
+        print(f"FAIL|{label} ({name}): missing or empty prompt/input")
     else:
         print(f"PASS|{label} ({name}): has prompt")
 
@@ -117,40 +128,68 @@ for i, ev in enumerate(evals):
         has_ids = True
         ids_found.append(ev["id"])
 
-    # Assertions check
+    # expected_output check (recommended, not required)
+    if "expected_output" not in ev:
+        print(f"WARN|{label} ({name}): missing expected_output (recommended)")
+
+    # Grading check: must have expectations OR assertions (or both)
+    expectations = ev.get("expectations")
     assertions = ev.get("assertions")
-    if assertions is None:
-        print(f"FAIL|{label} ({name}): missing assertions")
-        continue
+    has_expectations = False
+    has_assertions = False
 
-    if not isinstance(assertions, list):
-        print(f"FAIL|{label} ({name}): assertions must be an array")
-        continue
-
-    if len(assertions) < 2:
-        print(f"FAIL|{label} ({name}): has {len(assertions)} assertions, need >= 2")
-        continue
-
-    # Validate assertion contents
-    empty_assertions = 0
-    for j, a in enumerate(assertions):
-        if isinstance(a, str):
-            if not a.strip():
-                empty_assertions += 1
-        elif isinstance(a, dict):
-            # Object assertions: need at least type + (value or pattern)
-            if "type" not in a:
-                print(f"FAIL|{label} ({name}): assertion[{j}] missing 'type'")
-            val = a.get("value") or a.get("pattern") or ""
-            if not str(val).strip():
-                print(f"FAIL|{label} ({name}): assertion[{j}] missing 'value' or 'pattern'")
+    # Validate expectations (string[], 2+ items)
+    if expectations is not None:
+        if not isinstance(expectations, list):
+            print(f"FAIL|{label} ({name}): expectations must be an array")
+        elif len(expectations) < 2:
+            print(f"FAIL|{label} ({name}): has {len(expectations)} expectations, need >= 2")
         else:
-            print(f"FAIL|{label} ({name}): assertion[{j}] invalid type (not string or object)")
+            empty_exp = 0
+            for j, e in enumerate(expectations):
+                if not isinstance(e, str):
+                    print(f"FAIL|{label} ({name}): expectations[{j}] must be a string")
+                elif not e.strip():
+                    empty_exp += 1
+            if empty_exp > 0:
+                print(f"FAIL|{label} ({name}): {empty_exp} empty expectation string(s)")
+            else:
+                has_expectations = True
+                print(f"PASS|{label} ({name}): {len(expectations)} valid expectations")
 
-    if empty_assertions > 0:
-        print(f"FAIL|{label} ({name}): {empty_assertions} empty string assertion(s)")
-    else:
-        print(f"PASS|{label} ({name}): {len(assertions)} valid assertions")
+    # Validate assertions (object[] or string[], 2+ items)
+    if assertions is not None:
+        if not isinstance(assertions, list):
+            print(f"FAIL|{label} ({name}): assertions must be an array")
+        elif len(assertions) < 2:
+            print(f"FAIL|{label} ({name}): has {len(assertions)} assertions, need >= 2")
+        else:
+            empty_assertions = 0
+            for j, a in enumerate(assertions):
+                if isinstance(a, str):
+                    if not a.strip():
+                        empty_assertions += 1
+                elif isinstance(a, dict):
+                    # Object assertions: need at least type + (value or pattern)
+                    if "type" not in a:
+                        print(f"FAIL|{label} ({name}): assertion[{j}] missing 'type'")
+                    val = a.get("value") or a.get("pattern") or ""
+                    if not str(val).strip():
+                        print(f"FAIL|{label} ({name}): assertion[{j}] missing 'value' or 'pattern'")
+                else:
+                    print(f"FAIL|{label} ({name}): assertion[{j}] invalid type (not string or object)")
+
+            if empty_assertions > 0:
+                print(f"FAIL|{label} ({name}): {empty_assertions} empty string assertion(s)")
+            else:
+                has_assertions = True
+                print(f"PASS|{label} ({name}): {len(assertions)} valid assertions")
+
+    # Must have at least one grading mechanism
+    if not has_expectations and not has_assertions:
+        if expectations is None and assertions is None:
+            print(f"FAIL|{label} ({name}): missing grading (need expectations or assertions)")
+        # else: already reported specific validation errors above
 
 # Duplicate names
 seen = set()

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -103,17 +103,15 @@ for i, ev in enumerate(evals):
         continue
 
     # Name/ID check: accept 'name', 'eval_name', or 'id' (integer) as identifier
-    name = ev.get("name") or ev.get("eval_name") or ""
-    if not name or not str(name).strip():
+    name = str(ev.get("name") or ev.get("eval_name") or "").strip()
+    if not name:
         # Fall back to id as identifier for Anthropic format
         eid = ev.get("id")
-        if eid is not None and isinstance(eid, int):
+        if isinstance(eid, int):
             name = f"id={eid}"
         else:
             print(f"FAIL|{label}: missing or empty name/eval_name/id")
-    if name and name not in ("", f"id={ev.get('id')}"):
-        names.append(str(name).strip())
-    elif name.startswith("id="):
+    if name:
         names.append(name)
 
     # Prompt check (accept 'prompt' or legacy 'input')
@@ -123,13 +121,17 @@ for i, ev in enumerate(evals):
     else:
         print(f"PASS|{label} ({name}): has prompt")
 
-    # ID check (optional but validated if present)
+    # ID check (optional but validated if present; must be integer)
     if "id" in ev:
-        has_ids = True
-        ids_found.append(ev["id"])
+        if not isinstance(ev["id"], int):
+            print(f"FAIL|{label} ({name}): id must be an integer")
+        else:
+            has_ids = True
+            ids_found.append(ev["id"])
 
-    # expected_output check (recommended, not required)
-    if "expected_output" not in ev:
+    # expected_output check (recommended for unified format, skip for legacy)
+    is_unified = any(key in ev for key in ("eval_name", "id", "expectations", "expected_output"))
+    if is_unified and "expected_output" not in ev:
         print(f"WARN|{label} ({name}): missing expected_output (recommended)")
 
     # Grading check: must have expectations OR assertions (or both)
@@ -145,15 +147,15 @@ for i, ev in enumerate(evals):
         elif len(expectations) < 2:
             print(f"FAIL|{label} ({name}): has {len(expectations)} expectations, need >= 2")
         else:
-            empty_exp = 0
+            invalid_exp = 0
             for j, e in enumerate(expectations):
                 if not isinstance(e, str):
+                    invalid_exp += 1
                     print(f"FAIL|{label} ({name}): expectations[{j}] must be a string")
                 elif not e.strip():
-                    empty_exp += 1
-            if empty_exp > 0:
-                print(f"FAIL|{label} ({name}): {empty_exp} empty expectation string(s)")
-            else:
+                    invalid_exp += 1
+                    print(f"FAIL|{label} ({name}): expectations[{j}] is empty")
+            if invalid_exp == 0:
                 has_expectations = True
                 print(f"PASS|{label} ({name}): {len(expectations)} valid expectations")
 
@@ -164,24 +166,25 @@ for i, ev in enumerate(evals):
         elif len(assertions) < 2:
             print(f"FAIL|{label} ({name}): has {len(assertions)} assertions, need >= 2")
         else:
-            empty_assertions = 0
+            invalid_assertions = 0
             for j, a in enumerate(assertions):
                 if isinstance(a, str):
                     if not a.strip():
-                        empty_assertions += 1
+                        invalid_assertions += 1
+                        print(f"FAIL|{label} ({name}): assertion[{j}] is empty")
                 elif isinstance(a, dict):
-                    # Object assertions: need at least type + (value or pattern)
                     if "type" not in a:
+                        invalid_assertions += 1
                         print(f"FAIL|{label} ({name}): assertion[{j}] missing 'type'")
                     val = a.get("value") or a.get("pattern") or ""
                     if not str(val).strip():
+                        invalid_assertions += 1
                         print(f"FAIL|{label} ({name}): assertion[{j}] missing 'value' or 'pattern'")
                 else:
+                    invalid_assertions += 1
                     print(f"FAIL|{label} ({name}): assertion[{j}] invalid type (not string or object)")
 
-            if empty_assertions > 0:
-                print(f"FAIL|{label} ({name}): {empty_assertions} empty string assertion(s)")
-            else:
+            if invalid_assertions == 0:
                 has_assertions = True
                 print(f"PASS|{label} ({name}): {len(assertions)} valid assertions")
 

--- a/tests/evals-expectations-only.json
+++ b/tests/evals-expectations-only.json
@@ -1,0 +1,110 @@
+{
+  "skill_name": "test-expectations-only",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "setup_project_structure",
+      "prompt": "Create a new project with standard directory layout including src, tests, and docs directories",
+      "expected_output": "Project structure created with src/, tests/, and docs/ directories",
+      "expectations": [
+        "Response describes creating src/, tests/, and docs/ directories",
+        "Response mentions initializing the project with a standard layout"
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "configure_linting",
+      "prompt": "Set up ESLint with the recommended configuration for a TypeScript project",
+      "expected_output": "ESLint configured with TypeScript support",
+      "expectations": [
+        "Response includes ESLint configuration for TypeScript",
+        "Response mentions installing @typescript-eslint/parser and plugin",
+        "Response shows a valid .eslintrc configuration file"
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "write_unit_tests",
+      "prompt": "Write unit tests for a UserService class that has getById and create methods",
+      "expected_output": "Unit tests covering getById and create methods",
+      "expectations": [
+        "Response includes test cases for getById method",
+        "Response includes test cases for create method",
+        "Response covers both success and error scenarios"
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "implement_auth_middleware",
+      "prompt": "Create an Express middleware that validates JWT tokens from the Authorization header",
+      "expected_output": "JWT validation middleware for Express",
+      "expectations": [
+        "Response extracts the token from the Authorization header",
+        "Response validates the JWT token and handles invalid tokens"
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "database_migration",
+      "prompt": "Create a database migration that adds a users table with email, name, and created_at columns",
+      "expected_output": "Migration file for users table creation",
+      "expectations": [
+        "Response creates a migration with a users table",
+        "Response includes email, name, and created_at columns",
+        "Response includes both up and down migration functions"
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "api_error_handling",
+      "prompt": "Implement a global error handler for a REST API that returns consistent error responses",
+      "expected_output": "Global error handling middleware with consistent error format",
+      "expectations": [
+        "Response implements a centralized error handler",
+        "Response returns a consistent JSON error response structure"
+      ]
+    },
+    {
+      "id": 7,
+      "eval_name": "docker_compose_setup",
+      "prompt": "Create a docker-compose.yml for a Node.js app with PostgreSQL and Redis services",
+      "expected_output": "Docker Compose configuration with three services",
+      "expectations": [
+        "Response includes a Node.js application service",
+        "Response includes a PostgreSQL database service",
+        "Response includes a Redis cache service"
+      ]
+    },
+    {
+      "id": 8,
+      "eval_name": "ci_pipeline_config",
+      "prompt": "Set up a GitHub Actions CI pipeline that runs linting, tests, and builds on every pull request",
+      "expected_output": "GitHub Actions workflow for CI on pull requests",
+      "expectations": [
+        "Response creates a workflow triggered on pull requests",
+        "Response includes steps for linting, testing, and building"
+      ]
+    },
+    {
+      "id": 9,
+      "eval_name": "env_config_management",
+      "prompt": "Implement a configuration module that loads settings from environment variables with defaults and validation",
+      "expected_output": "Configuration module with env var loading and validation",
+      "expectations": [
+        "Response reads configuration from environment variables",
+        "Response provides sensible default values",
+        "Response validates required configuration values"
+      ]
+    },
+    {
+      "id": 10,
+      "eval_name": "logging_setup",
+      "prompt": "Set up structured logging with different log levels and a JSON output format for production",
+      "expected_output": "Structured logging configuration with JSON format",
+      "expectations": [
+        "Response configures multiple log levels (debug, info, warn, error)",
+        "Response outputs logs in JSON format for production use"
+      ]
+    }
+  ]
+}

--- a/tests/evals-legacy-regex.json
+++ b/tests/evals-legacy-regex.json
@@ -1,0 +1,86 @@
+[
+  {
+    "name": "create_dockerfile",
+    "prompt": "Create a multi-stage Dockerfile for a Node.js application with a build and production stage",
+    "assertions": [
+      { "type": "content", "pattern": "FROM.*node.*AS" },
+      { "type": "content", "pattern": "(COPY|ADD)" },
+      { "type": "content", "pattern": "(CMD|ENTRYPOINT)" }
+    ]
+  },
+  {
+    "name": "setup_nginx_reverse_proxy",
+    "prompt": "Configure Nginx as a reverse proxy for a Node.js app running on port 3000",
+    "assertions": [
+      { "type": "content", "pattern": "proxy_pass" },
+      { "type": "content", "pattern": "3000" }
+    ]
+  },
+  {
+    "name": "git_hooks_setup",
+    "prompt": "Set up pre-commit and pre-push git hooks using Husky for linting and testing",
+    "assertions": [
+      { "type": "content", "pattern": "[Hh]usky" },
+      { "type": "content", "pattern": "pre-commit" },
+      { "type": "content", "pattern": "(lint|eslint)" }
+    ]
+  },
+  {
+    "name": "env_file_template",
+    "prompt": "Create a .env.example file for a web application with database, cache, and API key settings",
+    "assertions": [
+      { "type": "content", "pattern": "DB_(HOST|URL|CONNECTION)" },
+      { "type": "content", "pattern": "REDIS" }
+    ]
+  },
+  {
+    "name": "terraform_basic_setup",
+    "prompt": "Write a basic Terraform configuration for an AWS EC2 instance with a security group",
+    "assertions": [
+      { "type": "content", "pattern": "aws_instance" },
+      { "type": "content", "pattern": "aws_security_group" }
+    ]
+  },
+  {
+    "name": "makefile_targets",
+    "prompt": "Create a Makefile with build, test, lint, and clean targets for a Go project",
+    "assertions": [
+      { "type": "content", "pattern": "build:" },
+      { "type": "content", "pattern": "test:" },
+      { "type": "content", "pattern": "(lint|vet):" }
+    ]
+  },
+  {
+    "name": "kubernetes_deployment",
+    "prompt": "Write a Kubernetes Deployment manifest for a web app with 3 replicas and resource limits",
+    "assertions": [
+      { "type": "content", "pattern": "replicas:\\s*3" },
+      { "type": "content", "pattern": "(limits|resources)" }
+    ]
+  },
+  {
+    "name": "graphql_schema",
+    "prompt": "Define a GraphQL schema for a blog with Post and Author types including queries and mutations",
+    "assertions": [
+      { "type": "content", "pattern": "type Post" },
+      { "type": "content", "pattern": "type Author" },
+      { "type": "content", "pattern": "(Query|Mutation)" }
+    ]
+  },
+  {
+    "name": "openapi_spec",
+    "prompt": "Write an OpenAPI 3.0 specification for a pet store API with list and create endpoints",
+    "assertions": [
+      { "type": "content", "pattern": "openapi.*3" },
+      { "type": "content", "pattern": "/pets" }
+    ]
+  },
+  {
+    "name": "monitoring_setup",
+    "prompt": "Configure Prometheus metrics collection for a Node.js Express application",
+    "assertions": [
+      { "type": "content", "pattern": "[Pp]rometheus" },
+      { "type": "content", "pattern": "(metrics|counter|histogram)" }
+    ]
+  }
+]

--- a/tests/evals-unified.json
+++ b/tests/evals-unified.json
@@ -1,0 +1,128 @@
+{
+  "skill_name": "test-unified-format",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "create_rest_endpoint",
+      "prompt": "Create a REST endpoint for managing users with CRUD operations",
+      "expected_output": "REST API endpoints for user CRUD",
+      "expectations": [
+        "Response implements GET, POST, PUT, and DELETE endpoints",
+        "Response follows RESTful naming conventions"
+      ],
+      "assertions": [
+        { "type": "content", "pattern": "(GET|POST|PUT|DELETE)" },
+        { "type": "content", "pattern": "/users" }
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "input_validation",
+      "prompt": "Add input validation to a user registration endpoint that checks email format and password strength",
+      "expected_output": "Input validation for registration",
+      "expectations": [
+        "Response validates email format using a regex or library",
+        "Response checks password meets minimum strength requirements"
+      ],
+      "assertions": [
+        { "type": "content", "pattern": "(email|@)" },
+        { "type": "content", "pattern": "(password|strength)" }
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "rate_limiting",
+      "prompt": "Implement rate limiting middleware that allows 100 requests per minute per IP",
+      "expected_output": "Rate limiting middleware implementation",
+      "expectations": [
+        "Response implements per-IP rate limiting",
+        "Response uses a sliding window or token bucket algorithm",
+        "Response returns 429 status when limit is exceeded"
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "caching_layer",
+      "prompt": "Add Redis caching to a product listing endpoint with a 5-minute TTL",
+      "expected_output": "Redis caching implementation for product listing",
+      "expectations": [
+        "Response connects to Redis for caching",
+        "Response sets a TTL of 5 minutes on cached data"
+      ],
+      "assertions": [
+        { "type": "content", "pattern": "[Rr]edis" },
+        { "type": "content", "pattern": "(TTL|ttl|300|expire)" }
+      ]
+    },
+    {
+      "id": 5,
+      "eval_name": "pagination_support",
+      "prompt": "Implement cursor-based pagination for a list endpoint that returns 20 items per page",
+      "expected_output": "Cursor-based pagination implementation",
+      "assertions": [
+        { "type": "content", "pattern": "(cursor|page)" },
+        { "type": "content", "pattern": "(20|limit|per_page)" }
+      ]
+    },
+    {
+      "id": 6,
+      "eval_name": "websocket_handler",
+      "prompt": "Create a WebSocket handler for real-time chat messages with room support",
+      "expected_output": "WebSocket chat handler with rooms",
+      "expectations": [
+        "Response implements WebSocket connection handling",
+        "Response supports chat rooms or channels",
+        "Response broadcasts messages to room members"
+      ]
+    },
+    {
+      "id": 7,
+      "eval_name": "file_upload",
+      "prompt": "Implement a file upload endpoint that accepts images up to 5MB and stores them in S3",
+      "expected_output": "File upload endpoint with S3 storage",
+      "expectations": [
+        "Response handles multipart file uploads",
+        "Response validates file size limit of 5MB"
+      ],
+      "assertions": [
+        { "type": "content", "pattern": "(upload|multer|multipart)" },
+        { "type": "content", "pattern": "(S3|s3|aws)" }
+      ]
+    },
+    {
+      "id": 8,
+      "eval_name": "health_check",
+      "prompt": "Create a health check endpoint that verifies database and cache connectivity",
+      "expected_output": "Health check endpoint with dependency verification",
+      "expectations": [
+        "Response checks database connectivity",
+        "Response checks cache service availability",
+        "Response returns appropriate health status"
+      ]
+    },
+    {
+      "id": 9,
+      "eval_name": "request_logging",
+      "prompt": "Add request logging middleware that logs method, path, status code, and response time",
+      "expected_output": "Request logging middleware",
+      "assertions": [
+        { "type": "content", "pattern": "(method|GET|POST)" },
+        { "type": "content", "pattern": "(status|statusCode)" }
+      ]
+    },
+    {
+      "id": 10,
+      "eval_name": "graceful_shutdown",
+      "prompt": "Implement graceful shutdown handling that closes database connections and finishes pending requests",
+      "expected_output": "Graceful shutdown implementation",
+      "expectations": [
+        "Response handles SIGTERM and SIGINT signals",
+        "Response closes database connections before exiting"
+      ],
+      "assertions": [
+        { "type": "content", "pattern": "(SIGTERM|SIGINT|signal)" },
+        { "type": "content", "pattern": "(close|shutdown|disconnect)" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `validate-evals.sh` now accepts `expectations` (string list) as an alternative to `assertions` (regex objects)
- Both can coexist in the same eval — the unified schema aligning with Anthropic's skill-creator format
- Legacy formats (skill-repo regex, Anthropic-like) continue to pass
- Adds test fixtures for expectations-only, unified, and legacy formats

## Context

Design spec: netresearch/github-release-skill docs/superpowers/specs/2026-04-16-unified-eval-schema-design.md

Anthropic's skill-creator plugin uses `expectations` (natural language for LLM-as-judge grading). Our skill-repo uses `assertions` (regex patterns for fast automated checks). The unified schema accepts both, letting evals use either or both grading approaches.

## Test plan

- [x] Expectations-only evals pass validation (test fixture)
- [x] Unified evals (both expectations + assertions) pass validation (test fixture)
- [x] Legacy regex evals still pass — no regression (test fixture)
- [x] Existing skill-repo evals still pass (regression test)