### PR TITLE
feat: add release-discipline reference with version-parity check

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -94,19 +94,7 @@ Auto-merge and pr-quality callers must use `pull_request_target` trigger (not `p
 
 ## Releasing
 
-1. Bump version in `.claude-plugin/plugin.json` — open as PR, do not commit to main
-2. Merge the bump PR after CI green and approval
-3. Pull main locally; verify the merged version is present
-4. Run version-parity check — all identifiers must match the target tag
-5. Create signed tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
-6. Push tag: `git push origin vX.Y.Z`
-7. Monitor the Release workflow to green before declaring done
-
-**Tag only after the bump PR is merged.** Tag-before-bump causes Release workflows to run against the wrong version. See `references/release-discipline.md`.
-
-**Never edit installed skill paths** (`~/.claude/skills/**`, `~/.claude/plugins/**`). Always edit the repo worktree — cache edits are silently clobbered on next update.
-
-For multi-skill-repo releases (>3 repos at once), produce a dry-run manifest and wait for explicit approval. See `references/release-discipline.md`.
+Open bump PR → merge → pull main → verify version parity → signed tag → push tag → monitor Release workflow. **Tag only after the bump PR is merged** (tag-before-bump runs Release against the wrong version). Never edit installed skill paths (`~/.claude/skills/**`, `~/.claude/plugins/**`); always the worktree. Multi-repo releases (>3) require a dry-run manifest + approval. See `references/release-discipline.md`.
 
 ## Installation
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -94,10 +94,19 @@ Auto-merge and pr-quality callers must use `pull_request_target` trigger (not `p
 
 ## Releasing
 
-1. Bump version in `.claude-plugin/plugin.json`
-2. Commit: `chore: release vX.Y.Z`
-3. Tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
-4. Push: `git push origin main vX.Y.Z`
+1. Bump version in `.claude-plugin/plugin.json` — open as PR, do not commit to main
+2. Merge the bump PR after CI green and approval
+3. Pull main locally; verify the merged version is present
+4. Run version-parity check — all identifiers must match the target tag
+5. Create signed tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
+6. Push tag: `git push origin vX.Y.Z`
+7. Monitor the Release workflow to green before declaring done
+
+**Tag only after the bump PR is merged.** Tag-before-bump causes Release workflows to run against the wrong version. See `references/release-discipline.md`.
+
+**Never edit installed skill paths** (`~/.claude/skills/**`, `~/.claude/plugins/**`). Always edit the repo worktree — cache edits are silently clobbered on next update.
+
+For multi-skill-repo releases (>3 repos at once), produce a dry-run manifest and wait for explicit approval. See `references/release-discipline.md`.
 
 ## Installation
 
@@ -121,6 +130,7 @@ scripts/validate-skill.sh
 
 - `references/installation-methods.md`
 - `references/composer-setup.md`
+- `references/release-discipline.md` — version-parity check, cache safety, multi-repo dry-run
 
 ---
 

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -1,0 +1,139 @@
+# Release Discipline
+
+Every step that caused the "30 failed plugin releases" incident, codified as rules.
+
+## Canonical Order: Bump PR Merged → Tag Pushed
+
+**Tag a version only after the version-bump PR is merged to the default branch.** Tagging first causes the Release workflow to run against the old code, fail CI, and produce an immutable GitHub release locked to a bad tag.
+
+```
+WRONG: git tag -s v1.2.4 → git push → open bump PR
+RIGHT: open bump PR → merge → pull main → git tag -s v1.2.4 → git push
+```
+
+## Pre-Release Version-Parity Check
+
+Before pushing any tag, all version identifiers must match. This is the single check that would have prevented the 30-repo release failure.
+
+```bash
+#!/bin/bash
+# scripts/check-version-parity.sh
+set -euo pipefail
+
+PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+TAG_VERSION="${1:-}"  # e.g. v1.2.4 → strip the v → 1.2.4
+TAG_VERSION="${TAG_VERSION#v}"
+
+# composer.json MUST NOT have a version field (derived from git tag)
+if jq -e '.version' composer.json >/dev/null 2>&1; then
+  echo "ERROR: composer.json has a version field — remove it (git tag is source of truth)"
+  exit 1
+fi
+
+# plugin.json version MUST match the tag
+if [[ -n "$TAG_VERSION" && "$PLUGIN_VERSION" != "$TAG_VERSION" ]]; then
+  echo "ERROR: plugin.json=$PLUGIN_VERSION tag=$TAG_VERSION — mismatch"
+  exit 1
+fi
+
+# If SKILL.md frontmatter has metadata.version, it must match too
+for skill_md in skills/*/SKILL.md; do
+  SKILL_VERSION=$(awk '/^  version:/ {gsub(/"/,"",$2); print $2; exit}' "$skill_md")
+  if [[ -n "$SKILL_VERSION" && "$SKILL_VERSION" != "$PLUGIN_VERSION" ]]; then
+    echo "ERROR: $skill_md version=$SKILL_VERSION plugin.json=$PLUGIN_VERSION — mismatch"
+    exit 1
+  fi
+done
+
+echo "OK: version parity confirmed at $PLUGIN_VERSION"
+```
+
+Run before every `git push origin vX.Y.Z`.
+
+## Cache Safety: Never Edit the Installed Copy
+
+Installed skills and plugins live under `~/.claude/` (or wherever the marketplace resolves them). Editing these paths directly is always wrong — the next `/plugin update` or marketplace sync will silently overwrite your changes, taking any local fixes with it.
+
+### Paths that are off-limits for edits
+
+- `~/.claude/skills/**`
+- `~/.claude/plugins/cache/**`
+- `~/.claude/plugins/marketplaces/**`
+- Anything inside a `.bare/` directory (git bare clone; worktree source)
+
+### Pre-edit check
+
+Before every Write or Edit in skill-repo workflows:
+
+```bash
+pwd_real=$(realpath .)
+case "$pwd_real" in
+  */.claude/skills/*|*/.claude/plugins/*|*/.bare/*)
+    echo "REFUSING to edit installed/cache path: $pwd_real"
+    echo "Navigate to the source worktree first."
+    exit 1
+    ;;
+esac
+```
+
+### Recovery when edits landed in the wrong place
+
+1. Stop. Do not run `/plugin update` or `composer update` — they may wipe your edits.
+2. `diff -r ~/.claude/skills/<name>/ ~/projects/<name>-skill/main/skills/<name>/` to see what drifted.
+3. Copy the legitimate changes into the source worktree.
+4. Commit from the worktree; never from the cache.
+
+## Multi-Skill-Repo Release Dry-Run
+
+When releasing >3 skill repos in one sweep, produce this manifest and wait for user approval before executing:
+
+```
+Skill-Repo Release Plan (2026-04-18)
+
+| Repo                        | Current | Target  | Change type | Notes                  |
+|-----------------------------|---------|---------|-------------|------------------------|
+| netresearch/git-workflow    | 1.9.0   | 1.10.0  | minor       | adds critical-rules    |
+| netresearch/github-project  | 2.10.0  | 2.11.0  | minor       | multi-repo-operations  |
+| netresearch/skill-repo      | 1.18.0  | 1.19.0  | minor       | release-discipline ref |
+
+Preconditions (verified per repo):
+  [✓] default branch CI green
+  [✓] no pending version-bump PR
+  [✓] version-parity check passes
+  [✓] working tree clean
+
+Execution order per repo:
+  1. Create version-bump PR on feat/release-vX.Y.Z branch
+  2. Wait for CI green and approval
+  3. Merge via merge-commit (respects atomic-commit policy)
+  4. Pull main; run check-version-parity.sh vX.Y.Z
+  5. Create signed tag vX.Y.Z
+  6. Push tag
+  7. Monitor Release workflow to green
+  8. Halt all further releases if this one fails — produce rollback
+
+Reply "go" to proceed, or name repos to skip.
+```
+
+## Immutable-Release Caveat
+
+Deleted GitHub releases do NOT free the tag for reuse. Once a release is published and deleted, that tag string is permanently locked as a deleted release — a new release with the same tag will fail. See `git-workflow-skill` → `references/github-releases.md`. Therefore: get it right the first time. The version-parity check above is what "right the first time" means in practice.
+
+## Tag Signing (Mandatory)
+
+```bash
+git tag -s vX.Y.Z -m "vX.Y.Z"         # -s: sign with GPG/SSH
+git push origin vX.Y.Z                # signed tag reaches the remote
+```
+
+Never `git tag vX.Y.Z` (unsigned). Repos with protected tag rulesets will reject unsigned tags.
+
+## No `--latest` Drift for Non-Default Branches
+
+When releasing from a non-default branch (e.g. a v1.x maintenance line while v2.x is default), pass `--latest=false` to avoid stealing the "Latest" badge by timestamp:
+
+```bash
+gh release create v1.5.12 --latest=false --title "v1.5.12" --notes-file CHANGELOG-v1.5.12.md
+```
+
+GitHub marks releases "Latest" by creation timestamp, not semver. A v1.5.12 created after v2.0.0 will become "Latest" without this flag — wrong, misleading, and often noticed only by downstream consumers.

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -15,40 +15,24 @@ RIGHT: open bump PR → merge → pull main → git tag -s v1.2.4 → git push
 
 Before pushing any tag, all version identifiers must match. This is the single check that would have prevented the 30-repo release failure.
 
+Use the shipped script `scripts/check-version-parity.sh` (in this repo under `skills/skill-repo/scripts/check-version-parity.sh`):
+
 ```bash
-#!/bin/bash
-# scripts/check-version-parity.sh
-set -euo pipefail
+# No arguments — compare plugin.json against SKILL.md metadata.version
+skills/skill-repo/scripts/check-version-parity.sh
 
-PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-TAG_VERSION="${1:-}"  # e.g. v1.2.4 → strip the v → 1.2.4
-TAG_VERSION="${TAG_VERSION#v}"
-
-# composer.json MUST NOT have a version field (derived from git tag)
-if jq -e '.version' composer.json >/dev/null 2>&1; then
-  echo "ERROR: composer.json has a version field — remove it (git tag is source of truth)"
-  exit 1
-fi
-
-# plugin.json version MUST match the tag
-if [[ -n "$TAG_VERSION" && "$PLUGIN_VERSION" != "$TAG_VERSION" ]]; then
-  echo "ERROR: plugin.json=$PLUGIN_VERSION tag=$TAG_VERSION — mismatch"
-  exit 1
-fi
-
-# If SKILL.md frontmatter has metadata.version, it must match too
-for skill_md in skills/*/SKILL.md; do
-  SKILL_VERSION=$(awk '/^  version:/ {gsub(/"/,"",$2); print $2; exit}' "$skill_md")
-  if [[ -n "$SKILL_VERSION" && "$SKILL_VERSION" != "$PLUGIN_VERSION" ]]; then
-    echo "ERROR: $skill_md version=$SKILL_VERSION plugin.json=$PLUGIN_VERSION — mismatch"
-    exit 1
-  fi
-done
-
-echo "OK: version parity confirmed at $PLUGIN_VERSION"
+# With tag argument — also require plugin.json.version == tag (v prefix optional)
+skills/skill-repo/scripts/check-version-parity.sh v1.2.4
 ```
 
-Run before every `git push origin vX.Y.Z`.
+What it checks:
+
+- `.claude-plugin/plugin.json` has a `.version` field — exits with an error if missing.
+- `composer.json` does **not** have a `.version` field — composer versions come from the git tag via the Release workflow, so a hard-coded version drifts silently.
+- If a tag argument is provided, `plugin.json.version` equals that tag with the `v` prefix stripped.
+- Every `skills/*/SKILL.md` that declares `metadata.version` in frontmatter matches `plugin.json.version`.
+
+If called without an argument and all parity passes, the script prints an advisory suggesting the next tag call. Run before every `git push origin vX.Y.Z`.
 
 ## Cache Safety: Never Edit the Installed Copy
 

--- a/skills/skill-repo/scripts/check-version-parity.sh
+++ b/skills/skill-repo/scripts/check-version-parity.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# check-version-parity.sh — verify plugin.json, composer.json, and SKILL.md
+# versions are consistent before a release.
+#
+# Usage:
+#   check-version-parity.sh               # compare plugin.json vs SKILL.md
+#   check-version-parity.sh v1.2.3        # also require plugin.json == 1.2.3
+#   check-version-parity.sh 1.2.3         # same, leading v optional
+#
+# Exit codes: 0 = parity OK, 1 = mismatch or missing version.
+#
+# Behavior:
+#   * Reads .claude-plugin/plugin.json version (required)
+#   * If SKILL.md frontmatter has metadata.version, requires it matches
+#   * composer.json MUST NOT have a version field (version is derived from
+#     git tags by the release workflow). Composer-shipped version would
+#     drift from the tag.
+#   * If a tag argument is provided, requires plugin.json version == tag
+#     with 'v' prefix stripped.
+
+set -euo pipefail
+
+TAG_ARG="${1:-}"
+TAG_VERSION="${TAG_ARG#v}"  # strip leading v if present (empty stays empty)
+
+PLUGIN_JSON=".claude-plugin/plugin.json"
+COMPOSER_JSON="composer.json"
+
+if [[ ! -f "$PLUGIN_JSON" ]]; then
+  echo "ERROR: $PLUGIN_JSON not found — run from skill repo root" >&2
+  exit 1
+fi
+
+PLUGIN_VERSION=$(jq -r '.version // empty' "$PLUGIN_JSON")
+if [[ -z "$PLUGIN_VERSION" ]]; then
+  echo "ERROR: $PLUGIN_JSON has no .version field" >&2
+  exit 1
+fi
+
+# composer.json MUST NOT have a version field
+if [[ -f "$COMPOSER_JSON" ]] && jq -e 'has("version")' "$COMPOSER_JSON" > /dev/null 2>&1; then
+  CJ_VERSION=$(jq -r '.version // empty' "$COMPOSER_JSON")
+  echo "ERROR: $COMPOSER_JSON has a version field ($CJ_VERSION) — remove it" >&2
+  echo "       Git tag is the source of truth for composer packages." >&2
+  exit 1
+fi
+
+# Tag argument must match plugin.json
+if [[ -n "$TAG_VERSION" && "$PLUGIN_VERSION" != "$TAG_VERSION" ]]; then
+  echo "ERROR: plugin.json=$PLUGIN_VERSION does not match tag $TAG_ARG" >&2
+  exit 1
+fi
+
+# SKILL.md metadata.version (if present) must match plugin.json
+MISMATCH=0
+shopt -s nullglob
+SKILL_FILES=(skills/*/SKILL.md)
+shopt -u nullglob
+
+if [[ ${#SKILL_FILES[@]} -eq 0 ]]; then
+  echo "WARN: no skills/*/SKILL.md files found" >&2
+fi
+
+for skill_md in "${SKILL_FILES[@]}"; do
+  # Extract metadata.version from YAML frontmatter (indented key).
+  # Tolerate quoted or unquoted values; return empty if absent.
+  SKILL_VERSION=$(awk '
+    /^---$/ { fm = !fm; next }
+    fm && /^[[:space:]]+version:[[:space:]]*/ {
+      gsub(/^[[:space:]]+version:[[:space:]]*/, "")
+      gsub(/["\047]/, "")
+      gsub(/[[:space:]]+$/, "")
+      print
+      exit
+    }
+  ' "$skill_md")
+
+  if [[ -n "$SKILL_VERSION" && "$SKILL_VERSION" != "$PLUGIN_VERSION" ]]; then
+    echo "ERROR: $skill_md metadata.version=$SKILL_VERSION does not match plugin.json=$PLUGIN_VERSION" >&2
+    MISMATCH=1
+  fi
+done
+
+if (( MISMATCH )); then
+  exit 1
+fi
+
+if [[ -n "$TAG_VERSION" ]]; then
+  echo "OK: plugin.json and tag match at $PLUGIN_VERSION"
+else
+  echo "OK: plugin.json and SKILL.md versions match at $PLUGIN_VERSION"
+  echo "    (pass a tag argument like v$PLUGIN_VERSION to verify tag parity)"
+fi


### PR DESCRIPTION
## Summary

Codifies the release-ordering and version-parity rules that would have prevented the 30-failed-plugin-releases incident.

## Changes

### `skills/skill-repo/references/release-discipline.md` (new)

- **Canonical order**: bump PR merged → tag pushed (never reverse)
- **Pre-release version-parity check script** — validates `plugin.json.version` == tag == SKILL.md metadata version; rejects if `composer.json` has a `version` field
- **Cache-safety rules and recovery** — paths off-limits (`~/.claude/skills/**`, `~/.claude/plugins/**`, `.bare/`); recovery steps when edits land in the wrong place
- **Multi-skill-repo release dry-run manifest template** with approval prompt
- **Immutable-release caveat** — deleted tags stay locked; get it right first time
- **Signed tags** (mandatory) and `--latest=false` for non-default-branch releases

### `skills/skill-repo/SKILL.md`

- Rewrites the Releasing section to use a bump-PR flow (no more direct main commits)
- Adds cache-safety one-liner + multi-repo dry-run pointer
- Registers the new reference

## Why

The 30-failed-plugin-releases class of bug (tag pushed before the version-bump PR was merged, so Release workflow ran against the old version) is structurally preventable. Encoding the check in a script the skill owns means every release gets the guardrail for free.

## Test plan

- [ ] \`scripts/validate-skill.sh\` passes
- [ ] Version-parity check script logic is sound (dry-run against this repo)
- [ ] No breaking changes to existing sections