### PR TITLE
ci: fix auto-merge-deps reusable workflow reference

### DIFF
--- a/.github/workflows/auto-merge-deps-caller.yml
+++ b/.github/workflows/auto-merge-deps-caller.yml
@@ -11,4 +11,3 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,9 +81,7 @@ The `release.yml` workflow triggers on `v*` tags, validates that the tag matches
 
 ### Reusable Workflows (consumed by other repos)
 
-Other skill repos call these workflows with `uses: netresearch/skill-repo-skill/.github/workflows/<name>.yml@main`.
-
-**`validate.yml`** -- the main validation pipeline:
+**`validate.yml`** -- the main validation pipeline, hosted in this repo. Other skill repos call it with `uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main`:
 
 - Checks out the calling repo and sparse-checks out validation tools from this repo
 - Runs `validate-skill.sh` (structure, frontmatter, licensing, metadata consistency)
@@ -94,7 +92,7 @@ Other skill repos call these workflows with `uses: netresearch/skill-repo-skill/
 - Python lint via `ruff` on all `*.py` files
 - Validates checkpoint YAML schemas
 
-**`auto-merge-deps.yml`** -- auto-merge for repos without branch protection:
+**auto-merge for dependency PRs** -- lives in the org-level `netresearch/.github` repo, not here. Skill repos call it with `uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main`:
 
 - Triggers on PRs from `dependabot[bot]` or `renovate[bot]`
 - Auto-approves, waits for all CI checks to pass, then merges
@@ -102,7 +100,7 @@ Other skill repos call these workflows with `uses: netresearch/skill-repo-skill/
 ### This Repo's Own CI
 
 - `lint.yml` runs markdown lint, ShellCheck, and skill validation on push to main and PRs
-- `auto-merge-deps-caller.yml` calls the local `auto-merge-deps.yml` workflow
+- `auto-merge-deps-caller.yml` is this repo's own caller for the org-level auto-merge workflow
 
 ### Caller Workflow Pattern
 
@@ -127,6 +125,7 @@ Example for auto-merge:
 name: Auto-merge dependency PRs
 on:
   pull_request_target:
+permissions: {}
 jobs:
   auto-merge:
     uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,10 @@ Example for auto-merge:
 # .github/workflows/auto-merge-deps.yml
 name: Auto-merge dependency PRs
 on:
-  pull_request:
+  pull_request_target:
 jobs:
   auto-merge:
-    uses: netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/skills/skill-repo/templates/auto-merge-deps.yml.template
+++ b/skills/skill-repo/templates/auto-merge-deps.yml.template
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    uses: netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

The template at `skills/skill-repo/templates/auto-merge-deps.yml.template` and the AGENTS.md example pointed at `netresearch/skill-repo-skill/.github/workflows/auto-merge-deps.yml`, which **does not exist** (this repo has `auto-merge-deps-caller.yml`). The real reusable workflow lives at `netresearch/.github/.github/workflows/auto-merge-deps.yml`.

Every `pull_request` event in the ~30 skill repos bootstrapped from this template fails with "reusable workflow not found", polluting the workflow run history.

## Changes

- Template → points at the correct org-level reusable workflow
- AGENTS.md example → same fix; also switches the example `on:` trigger to `pull_request_target` (matches this repo's own caller)
- This repo's own caller (`.github/workflows/auto-merge-deps-caller.yml`) → drops \`secrets: inherit\` (upstream workflow only uses auto-provided \`GITHUB_TOKEN\`; explicit-over-inherit per org policy)

## Follow-up

A separate batch will push the same `uses:` fix to the ~30 repos that already copied the broken template.

## Test plan

- [ ] Ruleset/lint checks pass
- [ ] Eyeball-verify template diff is minimal (one-line \`uses:\` change)