### PR TITLE
fix(release): produce actually-signed annotated tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,19 +135,22 @@ jobs:
           set -euo pipefail
           COMMIT_SHA=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha')
 
-          # Create annotated tag object (GitHub signs it)
-          gh api "repos/${{ github.repository }}/git/tags" \
+          # Create annotated tag object (GitHub signs it with its web-flow key)
+          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/tags" \
             -f tag="v$NEW" \
             -f message="Release v$NEW" \
             -f object="$COMMIT_SHA" \
-            -f type="commit"
+            -f type="commit" \
+            --jq '.sha')
 
-          # Create tag ref
+          # Point the tag ref at the annotated tag object, not at the commit.
+          # Pointing at the commit would create a lightweight (unsigned) tag
+          # and orphan the tag object we just created.
           gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/tags/v$NEW" \
-            -f sha="$COMMIT_SHA"
+            -f sha="$TAG_SHA"
 
-          echo "Created tag v$NEW at $COMMIT_SHA"
+          echo "Created signed tag v$NEW ($TAG_SHA) at commit $COMMIT_SHA"
 
   # --- Job 2: Build and release (runs on tag push OR after bump) ---
   release:


### PR DESCRIPTION
## Problem

The reusable release workflow creates an annotated tag object via `POST /git/tags`, then creates the tag ref via `POST /git/refs` pointing at the **commit** SHA rather than the tag object's SHA. That produces a lightweight (unsigned) tag and orphans the tag object we just created.

Verified on today's 33 fresh releases — all show `object.type=commit` on `GET /git/refs/tags/v*`:

```
[matrix-skill] v1.20.1: object.type=commit
[skill-repo-skill] v1.19.0: object.type=commit
[agent-rules-skill] v3.9.0: object.type=commit
```

## Fix

Capture the tag object SHA from the `git/tags` response and use it for the ref. GitHub signs annotated tag objects created via the REST API with its web-flow key, so the resulting tag becomes a proper signed annotated tag — matching the "Verified" guarantee on API-created commits.

## Impact

Every consumer repo is already wired to `@main`, so the fix propagates on their next release with no per-repo change.

## Test plan

- [ ] After merge, trigger any release via `gh workflow run release.yml --repo netresearch/<repo> --field bump=patch`
- [ ] Confirm `GET /git/refs/tags/vX.Y.Z` shows `object.type=tag`
- [ ] Confirm tag page on GitHub UI shows "Verified" badge