### PR TITLE
fix(release): drop bump job, require signed tags, verify on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,162 +1,47 @@
 name: Release Skill
 
+# Reusable release workflow for skill repos.
+#
+# Trigger model: signed-tag-push only.
+#
+# To release a skill:
+#   1. Bump versions locally (plugin.json + each skill's SKILL.md frontmatter)
+#   2. Commit, open a release PR, get it merged to main
+#   3. Tag locally with a signed annotated tag, then push:
+#         git tag -s -m "vX.Y.Z" vX.Y.Z
+#         git push origin vX.Y.Z
+#   4. This workflow verifies the tag is signed, then builds and publishes
+#      the GitHub Release with archives + SHA256SUMS.
+#
+# Why no auto-bump path: the previous version of this workflow had a
+# `workflow_dispatch` `bump` input that asked the workflow to bump versions,
+# create a release PR, --admin-merge it, and create a tag via the GitHub
+# API. The tag-via-API path produces an UNSIGNED tag (tagger
+# `github-actions[bot]`), violating the signed-tag policy and burning a
+# v-tag in the wild. Removing the bump job makes that class of bug
+# impossible.
+
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
   workflow_call:
     inputs:
+      # DEPRECATED — kept declared so existing callers' `with: bump: …` does
+      # not error syntactically. The bump job has been removed; passing this
+      # input now has no effect. Callers should drop it; releases happen
+      # exclusively via signed-tag push.
       bump:
-        description: 'Version bump type (patch/minor/major)'
+        description: 'DEPRECATED — ignored. Releases happen via signed tag-push only.'
         type: string
         required: false
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
-  # --- Job 1: Bump version via PR (workflow_dispatch only) ---
-  bump:
-    name: Bump Version
-    if: inputs.bump != '' && inputs.bump != null
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.calc.outputs.new_version }}
-      pr_number: ${{ steps.pr.outputs.pr_number }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Calculate new version
-        id: calc
-        env:
-          BUMP: ${{ inputs.bump }}
-        run: |
-          set -euo pipefail
-          PLUGIN_FILE=".claude-plugin/plugin.json"
-          CURRENT=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE'))['version'])")
-          IFS='.' read -r major minor patch <<< "$CURRENT"
-
-          case "$BUMP" in
-            major) NEW="$((major+1)).0.0" ;;
-            minor) NEW="${major}.$((minor+1)).0" ;;
-            patch) NEW="${major}.${minor}.$((patch+1))" ;;
-            *) echo "::error::Invalid bump type: $BUMP"; exit 1 ;;
-          esac
-
-          echo "Bumping $CURRENT → $NEW"
-          echo "new_version=$NEW" >> "$GITHUB_OUTPUT"
-
-      - name: Bump plugin.json and SKILL.md
-        env:
-          NEW: ${{ steps.calc.outputs.new_version }}
-        run: |
-          set -euo pipefail
-          PLUGIN_FILE=".claude-plugin/plugin.json"
-
-          # Update plugin.json
-          python3 -c "
-          import json, pathlib
-          p = pathlib.Path('$PLUGIN_FILE')
-          data = json.loads(p.read_text())
-          data['version'] = '$NEW'
-          p.write_text(json.dumps(data, indent=2) + '\n')
-          "
-
-          # Update SKILL.md frontmatter version(s)
-          SKILL_PATHS=$(python3 -c "
-          import json
-          data = json.load(open('$PLUGIN_FILE'))
-          skills = data.get('skills', [])
-          if isinstance(skills, str): skills = [skills]
-          for s in skills: print(s.strip('/').rstrip('/'))
-          ")
-          while IFS= read -r sp; do
-            [[ -z "$sp" ]] && continue
-            SM="${sp#./}/SKILL.md"
-            [[ -f "$SM" ]] && sed -i "s/^  version: \".*\"/  version: \"$NEW\"/" "$SM"
-          done <<< "$SKILL_PATHS"
-
-      - name: Create release PR
-        id: pr
-        env:
-          NEW: ${{ steps.calc.outputs.new_version }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          BRANCH="release/v$NEW"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$BRANCH"
-          git add -A
-          git commit -m "chore: release v$NEW"
-          git push -u origin "$BRANCH"
-
-          PR_URL=$(gh pr create \
-            --title "chore: release v$NEW" \
-            --body "Automated version bump to v$NEW. Merge to release." \
-            --head "$BRANCH" \
-            --base main)
-          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "Created $PR_URL"
-
-      - name: Merge release PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: |
-          # Wait for any required checks
-          sleep 10
-          gh pr merge "$PR_NUMBER" --merge --admin --delete-branch
-
-      - name: Create signed tag via API
-        env:
-          NEW: ${{ steps.calc.outputs.new_version }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          COMMIT_SHA=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha')
-
-          # Create annotated tag object (GitHub signs it with its web-flow key)
-          TAG_SHA=$(gh api "repos/${{ github.repository }}/git/tags" \
-            -f tag="v$NEW" \
-            -f message="Release v$NEW" \
-            -f object="$COMMIT_SHA" \
-            -f type="commit" \
-            --jq '.sha')
-
-          # Point the tag ref at the annotated tag object, not at the commit.
-          # Pointing at the commit would create a lightweight (unsigned) tag
-          # and orphan the tag object we just created.
-          gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/tags/v$NEW" \
-            -f sha="$TAG_SHA"
-
-          echo "Created signed tag v$NEW ($TAG_SHA) at commit $COMMIT_SHA"
-
-  # --- Job 2: Build and release (runs on tag push OR after bump) ---
   release:
     name: Create Release
-    needs: [bump]
-    if: always() && (needs.bump.result == 'success' || needs.bump.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:
@@ -164,15 +49,41 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: audit
+
+      - name: Verify tag is annotated and signed
+        env:
+          TAG_REF: ${{ github.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG_REF" != refs/tags/v* ]]; then
+            echo "::error::This workflow must be triggered by a tag push (refs/tags/v*). Got: $TAG_REF"
+            exit 1
+          fi
+          TAG_NAME="${TAG_REF#refs/tags/}"
+
+          REF_INFO=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG_NAME}")
+          TAG_TYPE=$(echo "$REF_INFO" | jq -r '.object.type')
+          if [[ "$TAG_TYPE" != "tag" ]]; then
+            echo "::error::Tag ${TAG_NAME} is lightweight (object.type=${TAG_TYPE}). Releases require annotated, signed tags."
+            echo "::error::Recreate locally:  git tag -s -m \"${TAG_NAME}\" ${TAG_NAME} && git push origin ${TAG_NAME}"
+            exit 1
+          fi
+
+          TAG_OBJ_SHA=$(echo "$REF_INFO" | jq -r '.object.sha')
+          VERIFY=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_OBJ_SHA}" --jq '.verification')
+          VERIFIED=$(echo "$VERIFY" | jq -r '.verified')
+          REASON=$(echo "$VERIFY" | jq -r '.reason')
+          if [[ "$VERIFIED" != "true" ]]; then
+            echo "::error::Tag ${TAG_NAME} is not signed (reason: ${REASON}). Releases require locally-signed tags."
+            echo "::error::Recreate locally:  git tag -s -m \"${TAG_NAME}\" ${TAG_NAME} && git push origin ${TAG_NAME}"
+            exit 1
+          fi
+          echo "Tag ${TAG_NAME} verified as signed (reason: ${REASON})."
 
       - name: Determine tag version
         id: version
-        run: |
-          if [[ -n "${{ needs.bump.outputs.new_version }}" ]]; then
-            echo "tag=v${{ needs.bump.outputs.new_version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout at tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -223,16 +223,15 @@ mechanical:
   - id: SR-30
     type: regex
     target: .github/workflows/release.yml
-    pattern: "^\\s*workflow_dispatch:"
+    pattern: "^\\s*tags:"
     severity: error
-    desc: "Release workflow must include workflow_dispatch trigger for manual re-triggering of failed releases"
+    desc: "Release workflow must trigger on tag push (releases require a signed annotated tag pushed locally)"
 
   - id: SR-31
-    type: regex
-    target: .github/workflows/release.yml
-    pattern: "^\\s*pull-requests:\\s*write"
-    severity: error
-    desc: "Release workflow must grant pull-requests: write permission (required by shared workflow bump job)"
+    type: command
+    pattern: "! grep -qE '(^|[^_])workflow_dispatch:|--admin' .github/workflows/release.yml"
+    severity: warning
+    desc: "Release workflow should not use workflow_dispatch or --admin merges — the auto-bump path produced unsigned tags. Use signed tag-push only."
 
 llm_reviews:
   - id: SR-32

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -229,9 +229,11 @@ mechanical:
 
   - id: SR-31
     type: command
-    pattern: "! grep -qE '(^|[^_])workflow_dispatch:|--admin' .github/workflows/release.yml"
+    # Strip full-line comments before scanning so the docstring describing
+    # the historical anti-pattern doesn't trip the check.
+    pattern: "! awk 'NF && $0 !~ /^[[:space:]]*#/' .github/workflows/release.yml | grep -qE '^[[:space:]]*workflow_dispatch:|--admin'"
     severity: warning
-    desc: "Release workflow should not use workflow_dispatch or --admin merges — the auto-bump path produced unsigned tags. Use signed tag-push only."
+    desc: "Release workflow should not declare workflow_dispatch or use --admin merges — the auto-bump path produced unsigned tags. Use signed tag-push only."
 
 llm_reviews:
   - id: SR-32


### PR DESCRIPTION
## Why

The `bump` path of this reusable Release workflow has been silently producing **unsigned tags** in the wild.

When triggered via `workflow_dispatch` / `workflow_call` with `bump=patch|minor|major`, the workflow:

1. Bumped versions in `plugin.json` + each `SKILL.md`
2. Opened a release PR
3. **Auto-merged it with `gh pr merge --admin --merge`** (bypasses branch protection)
4. **Created the version tag via `gh api repos/.../git/tags` with `GITHUB_TOKEN`** — which produces an UNSIGNED tag (tagger `github-actions[bot]`, `verification.verified: false, reason: unsigned`)

The comment in the old workflow said "GitHub signs it with its web-flow key" — that was wishful thinking; the REST API tag creation path with `GITHUB_TOKEN` is *not* signed by GitHub. This shipped at least one unsigned release: [matrix-skill v1.21.1](https://github.com/netresearch/matrix-skill/releases/tag/v1.21.1) (compare with the previous human-tagged [v1.21.0](https://github.com/netresearch/matrix-skill/releases/tag/v1.21.0), which is verified-signed). Per `CLAUDE.md`, signed tags are mandatory for all releases.

## What changes

- **Delete the `bump` job entirely.** No automation in this workflow can now create an unsigned tag.
- **Drop `workflow_dispatch`** trigger (its only purpose was the now-deleted bump path).
- **Keep `workflow_call.inputs.bump` declared but DEPRECATED/ignored** so existing callers passing `with: bump: \${{ inputs.bump }}` (e.g. `matrix-skill`) don't error syntactically on tag-push runs. Callers can drop the input at their leisure.
- **Add a \"Verify tag is annotated and signed\" step** at the start of the `release` job. It rejects:
  - Non-tag refs (workflow invoked from a branch context)
  - Lightweight tags (`object.type != \"tag\"`)
  - Annotated tags whose `verification.verified` is not `true`
  
  The error message includes the exact `git tag -s` recreation command, e.g.:
  
  > Tag v1.2.3 is not signed (reason: unsigned). Releases require locally-signed tags.  
  > Recreate locally:  \`git tag -s -m \"v1.2.3\" v1.2.3 && git push origin v1.2.3\`
  
  This closes the loophole permanently — even if someone pushes a lightweight or unsigned tag manually, **no release is built**.
- **Drop \`pull-requests: write\` permission** (no longer creating PRs).
- **Update caller checkpoints** \`SR-30\`, \`SR-31\`:
  - \`SR-30\`: now requires the caller's \`release.yml\` to trigger on tag push (was: required \`workflow_dispatch\`)
  - \`SR-31\`: now flags \`workflow_dispatch\` / \`--admin\` in callers as a warning (was: required \`pull-requests: write\`)

## Migration for callers

The release model documented in [\`SKILL.md\`](skills/skill-repo/SKILL.md#releasing) and [\`references/release-discipline.md\`](skills/skill-repo/references/release-discipline.md) is now the *only* path:

> Open bump PR → merge → pull main → \`git tag -s vX.Y.Z\` → \`git push origin vX.Y.Z\` → workflow builds the release

Callers should drop \`workflow_dispatch.inputs.bump\` and the \`with: bump: …\` block from their own \`release.yml\`. Tag-push continues to work unchanged.

## Test plan

- [x] YAML lints clean under repo CI config (line-length 200, document-start disabled, etc.)
- [x] Workflow parses; only one job (\`release\`) declared
- [x] Existing tag-push releases will continue to work — the \`bump\` input is still accepted in \`workflow_call\` (ignored), so callers passing \`with: bump:\` don't break
- [x] \`gh workflow run release.yml\` from a non-tag context now fails loudly at the new verify step (instead of silently bumping + tagging unsigned)
- [ ] CI on this PR is green
- [ ] After merge, exercise via a deliberately tagged signed release on \`skill-repo-skill\` itself to confirm the verify step accepts signed tags