### PR TITLE
feat(release): opt-in SLSA build provenance via attest input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,15 +217,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # SLSA build provenance — opt-in via `with: attest: true`. Runs as a separate
-  # job so callers that don't opt in are unaffected: the `if: ${{ inputs.attest }}`
-  # gate skips this job entirely, and its job-level permissions are only
-  # required when the job actually runs. Callers that DO opt in MUST grant
-  # id-token: write and attestations: write on the calling job, otherwise the
-  # attest step will fail at runtime with an "insufficient permissions" error.
+  # job so callers that don't opt in are unaffected: the `if:` gate is keyed on
+  # event_name == 'workflow_call' so the `inputs` context is only consulted when
+  # this workflow is being called (not on direct tag-push triggers, where
+  # `inputs` is unavailable). The job's own permissions only matter when the
+  # job actually runs. Callers that DO opt in MUST grant id-token: write and
+  # attestations: write on the calling job, otherwise the attest step will fail
+  # at runtime with an "insufficient permissions" error.
   attest:
     name: Attest Build Provenance
     needs: release
-    if: ${{ inputs.attest }}
+    if: ${{ github.event_name == 'workflow_call' && inputs.attest }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ name: Release Skill
 # `github-actions[bot]`), violating the signed-tag policy and burning a
 # v-tag in the wild. Removing the bump job makes that class of bug
 # impossible.
+#
+# SLSA build provenance (opt-in): pass `with: attest: true` in the caller and
+# grant `id-token: write` + `attestations: write` on the calling job to have
+# this workflow generate a build-provenance attestation for the release
+# archives via actions/attest-build-provenance. Default off — callers that
+# don't opt in are unaffected and don't need the extra permissions.
 
 on:
   push:
@@ -35,6 +41,17 @@ on:
         description: 'DEPRECATED — ignored. Releases happen via signed tag-push only.'
         type: string
         required: false
+      attest:
+        description: >-
+          Generate SLSA build provenance attestations for the release archives
+          (zip + tar.gz). Default false; opt-in because callers passing true
+          MUST grant `id-token: write` and `attestations: write` on the calling
+          job, otherwise the attestation step will fail. The attestation lands
+          on GitHub's native attestation API and is verifiable via
+          `gh attestation verify <file> --owner <org>`.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -198,3 +215,43 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # SLSA build provenance — opt-in via `with: attest: true`. Runs as a separate
+  # job so callers that don't opt in are unaffected: the `if: ${{ inputs.attest }}`
+  # gate skips this job entirely, and its job-level permissions are only
+  # required when the job actually runs. Callers that DO opt in MUST grant
+  # id-token: write and attestations: write on the calling job, otherwise the
+  # attest step will fail at runtime with an "insufficient permissions" error.
+  attest:
+    name: Attest Build Provenance
+    needs: release
+    if: ${{ inputs.attest }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "$TAG" --repo "$REPO" \
+            --pattern '*.zip' --pattern '*.tar.gz' --dir dist
+          ls -lh dist/
+
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/*.zip
+            dist/*.tar.gz

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -121,3 +121,31 @@ gh release create v1.5.12 --latest=false --title "v1.5.12" --notes-file CHANGELO
 ```
 
 GitHub marks releases "Latest" by creation timestamp, not semver. A v1.5.12 created after v2.0.0 will become "Latest" without this flag — wrong, misleading, and often noticed only by downstream consumers.
+
+## SLSA Build Provenance (Opt-In)
+
+The reusable release workflow can attach SLSA build-provenance attestations to each release archive via `actions/attest-build-provenance`. Pass `with: attest: true` in the caller's `release.yml` and grant `id-token: write` + `attestations: write` on the calling job:
+
+```yaml
+# .github/workflows/release.yml in the consuming repo
+jobs:
+  release:
+    uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
+    with:
+      attest: true
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write          # required for attest=true (OIDC token for sigstore)
+      attestations: write      # required for attest=true (GitHub native attestation API)
+```
+
+Verify on a downloaded release archive with:
+
+```bash
+gh attestation verify <skill-name>-skill-vX.Y.Z.zip --owner netresearch
+```
+
+Why opt-in: granting `id-token: write` and `attestations: write` to repos that don't need provenance widens the attack surface for no benefit. Default off keeps the principle of least privilege; repos can flip the input on individually as they're reviewed.
+
+The attestation runs as a separate job (`needs: release`) so a failure in attestation does not roll back the GitHub release — the release succeeds, the attestation step is the one that surfaces an "insufficient permissions" error if a caller passed `attest: true` without granting the new scopes.

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -134,8 +134,7 @@ jobs:
     with:
       attest: true
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write          # release upload
       id-token: write          # required for attest=true (OIDC token for sigstore)
       attestations: write      # required for attest=true (GitHub native attestation API)
 ```


### PR DESCRIPTION
## Summary

Adds an opt-in path for callers of this reusable release workflow to get **SLSA build-provenance attestations** on their release archives. Closes the `validate-pre-release.sh` finding *"Release workflow permissions (missing: id-token:write, attestations:write)"* in any caller that opts in, without breaking existing callers.

## Design — non-breaking opt-in

- New boolean input \`attest\` (default \`false\`). Existing callers (\`github-release-skill\`, \`jira-skill\`, \`matrix-skill\`, \`typo3-testing-skill\`, \`go-development-skill\`, …) see no change.
- Attestation runs as a **separate job** (\`attest\`) with \`needs: release\` and \`if: \${{ inputs.attest }}\`. The new job declares \`id-token: write\` and \`attestations: write\` at job level; these are only required when the job runs.
- Existing \`release\` job's permissions are untouched.
- Callers that opt in MUST grant \`id-token: write\` and \`attestations: write\` on the calling job. Documented in the input description, the file-level comment, and \`references/release-discipline.md\`.

\`\`\`yaml
# Caller side — for repos that want attestation:
jobs:
  release:
    uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
    with:
      attest: true
    permissions:
      contents: write
      pull-requests: write
      id-token: write          # required when attest=true
      attestations: write      # required when attest=true
\`\`\`

## How attestation works in this design

1. The \`release\` job builds the zip + tar.gz archives and creates the GitHub Release via \`softprops/action-gh-release\` (existing).
2. The new \`attest\` job (\`needs: release\`) downloads the just-published archives via \`gh release download\` and runs \`actions/attest-build-provenance@v4.1.0\` against them.
3. The attestation lands on GitHub's native attestation API, queryable via \`gh attestation verify\`.

A failure in step 2 does NOT roll back step 1 — the GitHub Release is already published; only the attestation step surfaces the error. This is a deliberate trade-off (fail-soft on the new path so a misconfigured caller doesn't lose its release).

## Verification

After a release shipped with \`attest: true\`:

\`\`\`bash
# Download an archive
gh release download v1.22.0 -p '*-plugin-v1.22.0.zip' --repo netresearch/matrix-skill

# Verify the attestation
gh attestation verify matrix-communication-plugin-v1.22.0.zip --owner netresearch
\`\`\`

Expected output: SLSA v1.0 in-toto statement linking the archive's SHA256 to this workflow run, the commit, and the trigger event.

## Implementation notes

- \`actions/attest-build-provenance\` SHA-pinned to v4.1.0 (\`a2bbfa2\`) per the repo's supply-chain-hardening convention.
- \`step-security/harden-runner\` preserved on the new job.
- Attestation covers both \`*.zip\` and \`*.tar.gz\` from \`dist/\`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: bump caller \`netresearch/matrix-skill\` to pass \`attest: true\` + grant the two new permissions, then ship a test release (or a documentation-only release) and run \`gh attestation verify\` on the resulting archive
- [ ] Existing callers that don't opt in continue to release without errors (verify on the next routine release of any non-matrix-skill caller)