### PR TITLE
feat(release): make SLSA build provenance always-on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,14 @@ name: Release Skill
 # v-tag in the wild. Removing the bump job makes that class of bug
 # impossible.
 #
-# SLSA build provenance (opt-in): pass `with: attest: true` in the caller and
-# grant `id-token: write` + `attestations: write` on the calling job to have
-# this workflow generate a build-provenance attestation for the release
-# archives via actions/attest-build-provenance. Default off — callers that
-# don't opt in are unaffected and don't need the extra permissions.
+# SLSA build provenance: every release archive (zip + tar.gz) is attested via
+# actions/attest-build-provenance in a separate `attest` job that runs after
+# the `release` job. Callers must grant `id-token: write` and
+# `attestations: write` on the calling job (in addition to `contents: write`).
+# All netresearch skill-repo callers do; if you fork this workflow elsewhere,
+# add those two scopes to your caller before the next release tag is pushed.
+# Verify a downloaded archive with:
+#   gh attestation verify <archive>.zip --owner <org>
 
 on:
   push:
@@ -41,17 +44,16 @@ on:
         description: 'DEPRECATED — ignored. Releases happen via signed tag-push only.'
         type: string
         required: false
+      # DEPRECATED — kept declared so existing callers' `with: attest: …`
+      # doesn't error syntactically. SLSA build provenance is now always
+      # generated for release archives; every caller's job grants the required
+      # `id-token: write` and `attestations: write` since the org-wide rollout
+      # of those permissions completed. Callers should drop `with: attest: …`.
       attest:
-        description: >-
-          Generate SLSA build provenance attestations for the release archives
-          (zip + tar.gz). Default false; opt-in because callers passing true
-          MUST grant `id-token: write` and `attestations: write` on the calling
-          job, otherwise the attestation step will fail. The attestation lands
-          on GitHub's native attestation API and is verifiable via
-          `gh attestation verify <file> --owner <org>`.
+        description: 'DEPRECATED — ignored. SLSA build provenance is always generated.'
         type: boolean
         required: false
-        default: false
+        default: true
 
 permissions:
   contents: write
@@ -216,18 +218,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # SLSA build provenance — opt-in via `with: attest: true`. Runs as a separate
-  # job so callers that don't opt in are unaffected: the `if:` gate is keyed on
-  # event_name == 'workflow_call' so the `inputs` context is only consulted when
-  # this workflow is being called (not on direct tag-push triggers, where
-  # `inputs` is unavailable). The job's own permissions only matter when the
-  # job actually runs. Callers that DO opt in MUST grant id-token: write and
-  # attestations: write on the calling job, otherwise the attest step will fail
-  # at runtime with an "insufficient permissions" error.
+  # SLSA build provenance — always runs in a separate job after `release` so a
+  # transient sigstore / GitHub-attestation outage cannot roll back a published
+  # release. Callers must grant `id-token: write` and `attestations: write` on
+  # the calling job (every netresearch skill-repo caller does as of the
+  # org-wide permissions rollout); otherwise this step fails with
+  # "insufficient permissions".
   attest:
     name: Attest Build Provenance
     needs: release
-    if: ${{ github.event_name == 'workflow_call' && inputs.attest }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -122,21 +122,19 @@ gh release create v1.5.12 --latest=false --title "v1.5.12" --notes-file CHANGELO
 
 GitHub marks releases "Latest" by creation timestamp, not semver. A v1.5.12 created after v2.0.0 will become "Latest" without this flag — wrong, misleading, and often noticed only by downstream consumers.
 
-## SLSA Build Provenance (Opt-In)
+## SLSA Build Provenance
 
-The reusable release workflow can attach SLSA build-provenance attestations to each release archive via `actions/attest-build-provenance`. Pass `with: attest: true` in the caller's `release.yml` and grant `id-token: write` + `attestations: write` on the calling job:
+The reusable release workflow attaches SLSA build-provenance attestations to every release archive via `actions/attest-build-provenance`. Callers must grant `id-token: write` + `attestations: write` on the calling job (in addition to `contents: write` for the release upload):
 
 ```yaml
 # .github/workflows/release.yml in the consuming repo
 jobs:
   release:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
-    with:
-      attest: true
     permissions:
       contents: write          # release upload
-      id-token: write          # required for attest=true (OIDC token for sigstore)
-      attestations: write      # required for attest=true (GitHub native attestation API)
+      id-token: write          # OIDC for sigstore (required by the attest job)
+      attestations: write      # GitHub native attestation API (required by the attest job)
 ```
 
 Verify on a downloaded release archive with:
@@ -145,6 +143,6 @@ Verify on a downloaded release archive with:
 gh attestation verify <skill-name>-skill-vX.Y.Z.zip --owner netresearch
 ```
 
-Why opt-in: granting `id-token: write` and `attestations: write` to repos that don't need provenance widens the attack surface for no benefit. Default off keeps the principle of least privilege; repos can flip the input on individually as they're reviewed.
+The attestation runs as a separate job (`needs: release`) so a failure in attestation does not roll back the GitHub release — the release succeeds, the attestation step is the one that surfaces an "insufficient permissions" error if a caller hasn't granted the two write scopes.
 
-The attestation runs as a separate job (`needs: release`) so a failure in attestation does not roll back the GitHub release — the release succeeds, the attestation step is the one that surfaces an "insufficient permissions" error if a caller passed `attest: true` without granting the new scopes.
+The previously-documented `with: attest: true` opt-in is gone: the input is still declared (so existing `with: attest: true` doesn't error syntactically) but it's deprecated and ignored — every release gets provenance unconditionally. Drop the line on your next release-touching PR.

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -143,6 +143,6 @@ Verify on a downloaded release archive with:
 gh attestation verify <skill-name>-skill-vX.Y.Z.zip --owner netresearch
 ```
 
-The attestation runs as a separate job (`needs: release`) so a failure in attestation does not roll back the GitHub release — the release succeeds, the attestation step is the one that surfaces an "insufficient permissions" error if a caller hasn't granted the two write scopes.
+The attestation runs as a separate job (`needs: release`) so a failure in attestation does not roll back the GitHub release — the release succeeds, and the attestation job is the one that surfaces a `Resource not accessible by integration` error if a caller hasn't granted both `id-token: write` and `attestations: write` (the `contents: write` scope alone is not enough).
 
-The previously-documented `with: attest: true` opt-in is gone: the input is still declared (so existing `with: attest: true` doesn't error syntactically) but it's deprecated and ignored — every release gets provenance unconditionally. Drop the line on your next release-touching PR.
+The previously-documented `with: attest: true` opt-in is gone: the input is still declared (so existing `with: attest: true` doesn't error syntactically) but it's deprecated and ignored — every release gets provenance unconditionally. On your next release-touching PR, drop the `with: attest: true` line — and the entire `with:` block if `attest` was its only entry, since `bump` is also deprecated.


### PR DESCRIPTION
## Summary

Drops the opt-in design from PR #78. Every release archive now gets a SLSA build-provenance attestation unconditionally — the `if: workflow_call && inputs.attest` gate is gone, the `attest` input is marked DEPRECATED and ignored, and the docs no longer present opt-in as a choice.

## Why

The lock-step rollout completed: every consumer of this reusable workflow has merged the permission grant.

| Tracked | Caller PRs |
|---|---|
| 36 | grant `id-token: write` + `attestations: write`, drop `pull-requests: write` |
| 1 (matrix-skill) | done earlier in [#35](https://github.com/netresearch/matrix-skill/pull/35) |

With every caller already granting the permissions, opt-in adds nothing. **Always-on is what the user actually wanted** when this work started ("why opt-in!?") and what makes provenance a baseline rather than a checkbox.

## Compatibility

- **Backward compatible.** The `attest` input stays declared (default `true`, ignored on use) so callers still passing `with: attest: true` don't error syntactically. Same pattern as the deprecated `bump` input on this workflow. Callers can drop the line on their next release-touching PR.
- **No new permissions required.** Every caller already grants the two scopes from the previous rollout.

## What changes

```diff
       attest:
-        description: >-
-          Generate SLSA build provenance attestations for the release archives
-          (zip + tar.gz). Default false; opt-in because callers passing true
-          MUST grant `id-token: write` and `attestations: write` on the calling
-          job, otherwise the attestation step will fail. The attestation lands
-          on GitHub's native attestation API and is verifiable via
-          `gh attestation verify <file> --owner <org>`.
-        type: boolean
-        required: false
-        default: false
+        description: 'DEPRECATED — ignored. SLSA build provenance is always generated.'
+        type: boolean
+        required: false
+        default: true

   attest:
     name: Attest Build Provenance
     needs: release
-    if: ${{ github.event_name == 'workflow_call' && inputs.attest }}
     runs-on: ubuntu-latest
```

Plus the file-level comment and `release-discipline.md` reference docs both updated to reflect "always on, not opt-in".

## Test plan

- [ ] CI green on this PR
- [ ] After merge: the next release in any consumer (e.g. `matrix-skill v1.22.1`) produces a release archive verifiable with `gh attestation verify <archive>.zip --owner netresearch`
- [ ] No release-day surprise for the consumer that hadn't passed `attest: true` (every consumer in the org already grants the permissions; the `if:` gate is the only thing that was hiding the attest job for them)