### PR TITLE
fix(release): one atomic job — fold attest into the release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,14 @@ name: Release Skill
 # Callers must grant `id-token: write` and `attestations: write` on the calling
 # job (in addition to `contents: write`). All netresearch skill-repo callers do;
 # fork this workflow only after granting those scopes.
-# Verify a downloaded archive with:
-#   gh attestation verify <archive>.zip --owner <org>
+# Verify a downloaded archive with (pin to the SPECIFIC repo, not just the org —
+# `--owner` and an org-wide identity regex would accept attestations from any
+# other repo in the org):
+#   gh attestation verify <archive>.zip --repo <org>/<repo-name>
 # Verify the checksums signature with:
 #   cosign verify-blob \
 #     --certificate SHA256SUMS.txt.pem --signature SHA256SUMS.txt.sig \
-#     --certificate-identity-regexp "https://github.com/<org>/.*" \
+#     --certificate-identity-regexp "^https://github\.com/<org>/<repo-name>/" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
 #     SHA256SUMS.txt
 
@@ -245,10 +247,12 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # Anchor the regex to the start so a trailing-substring match against
+          # an arbitrary URL can't pass verification.
           cosign verify-blob \
             --certificate SHA256SUMS.txt.pem \
             --signature SHA256SUMS.txt.sig \
-            --certificate-identity-regexp "https://github.com/${REPO}/.*" \
+            --certificate-identity-regexp "^https://github\.com/${REPO}/" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             SHA256SUMS.txt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,28 @@ name: Release Skill
 # v-tag in the wild. Removing the bump job makes that class of bug
 # impossible.
 #
-# SLSA build provenance: every release archive (zip + tar.gz) is attested via
-# actions/attest-build-provenance in a separate `attest` job that runs after
-# the `release` job. Callers must grant `id-token: write` and
-# `attestations: write` on the calling job (in addition to `contents: write`).
-# All netresearch skill-repo callers do; if you fork this workflow elsewhere,
-# add those two scopes to your caller before the next release tag is pushed.
+# Supply-chain attestation: every release archive (zip + tar.gz) is signed
+# and provenance-attested in the SAME job that publishes the GitHub Release,
+# BEFORE the assets are made public — no race window where unsigned artifacts
+# are downloadable. The flow is, in order:
+#   1. Build the archives (zip + tar.gz).
+#   2. Generate SHA256SUMS.txt over them.
+#   3. Cosign sign-blob (keyless / Sigstore) the SHA256SUMS.txt
+#      → SHA256SUMS.txt.sig + SHA256SUMS.txt.pem.
+#   4. SLSA build-provenance attest the archives + SHA256SUMS.txt via
+#      actions/attest-build-provenance → published to GitHub's attestation API.
+#   5. softprops/action-gh-release creates the Release with all assets at once.
+# Callers must grant `id-token: write` and `attestations: write` on the calling
+# job (in addition to `contents: write`). All netresearch skill-repo callers do;
+# fork this workflow only after granting those scopes.
 # Verify a downloaded archive with:
 #   gh attestation verify <archive>.zip --owner <org>
+# Verify the checksums signature with:
+#   cosign verify-blob \
+#     --certificate SHA256SUMS.txt.pem --signature SHA256SUMS.txt.sig \
+#     --certificate-identity-regexp "https://github.com/<org>/.*" \
+#     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+#     SHA256SUMS.txt
 
 on:
   push:
@@ -62,6 +76,10 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write          # OIDC for sigstore (cosign + attest)
+      attestations: write      # GitHub native attestation API
 
     steps:
       - name: Harden Runner
@@ -209,6 +227,39 @@ jobs:
           echo "=== Release packages ==="
           ls -lh dist/releases/
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign SHA256SUMS with Cosign (keyless)
+        working-directory: dist/releases
+        run: |
+          set -euo pipefail
+          cosign sign-blob --yes \
+            --output-certificate SHA256SUMS.txt.pem \
+            --output-signature SHA256SUMS.txt.sig \
+            SHA256SUMS.txt
+
+      - name: Verify Cosign signature
+        working-directory: dist/releases
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cosign verify-blob \
+            --certificate SHA256SUMS.txt.pem \
+            --signature SHA256SUMS.txt.sig \
+            --certificate-identity-regexp "https://github.com/${REPO}/.*" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            SHA256SUMS.txt
+
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/releases/*.zip
+            dist/releases/*.tar.gz
+            dist/releases/SHA256SUMS.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
@@ -217,42 +268,3 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # SLSA build provenance — always runs in a separate job after `release` so a
-  # transient sigstore / GitHub-attestation outage cannot roll back a published
-  # release. Callers must grant `id-token: write` and `attestations: write` on
-  # the calling job (every netresearch skill-repo caller does as of the
-  # org-wide permissions rollout); otherwise this step fails with
-  # "insufficient permissions".
-  attest:
-    name: Attest Build Provenance
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-        with:
-          egress-policy: audit
-
-      - name: Download release archives
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          gh release download "$TAG" --repo "$REPO" \
-            --pattern '*.zip' --pattern '*.tar.gz' --dir dist
-          ls -lh dist/
-
-      - name: Generate SLSA build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: |
-            dist/*.zip
-            dist/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,15 @@ name: Release Skill
 # v-tag in the wild. Removing the bump job makes that class of bug
 # impossible.
 #
-# Supply-chain attestation: every release archive (zip + tar.gz) is signed
-# and provenance-attested in the SAME job that publishes the GitHub Release,
-# BEFORE the assets are made public — no race window where unsigned artifacts
-# are downloadable. The flow is, in order:
+# Supply-chain attestation: every release ships with provenance-attested
+# archives and a Cosign-signed checksum file that binds the archives by their
+# SHA-256 digest. Only `SHA256SUMS.txt` is Cosign-signed; the `.zip`/`.tar.gz`
+# files themselves are integrity-protected via that signed checksum (verifying
+# the signature on `SHA256SUMS.txt` and then `sha256sum --check` against it
+# proves any individual archive was produced by this workflow). All of this
+# happens in the SAME job that publishes the GitHub Release, BEFORE the assets
+# are made public — no race window where unattested artefacts are downloadable.
+# The flow is, in order:
 #   1. Build the archives (zip + tar.gz).
 #   2. Generate SHA256SUMS.txt over them.
 #   3. Cosign sign-blob (keyless / Sigstore) the SHA256SUMS.txt
@@ -35,14 +40,15 @@ name: Release Skill
 # Callers must grant `id-token: write` and `attestations: write` on the calling
 # job (in addition to `contents: write`). All netresearch skill-repo callers do;
 # fork this workflow only after granting those scopes.
-# Verify a downloaded archive with (pin to the SPECIFIC repo, not just the org —
-# `--owner` and an org-wide identity regex would accept attestations from any
-# other repo in the org):
+# Verify a downloaded archive with (pin to the SPECIFIC repo + workflow file +
+# tag ref — `--owner` and an org-wide identity regex would accept attestations
+# from any other repo or branch in the org):
 #   gh attestation verify <archive>.zip --repo <org>/<repo-name>
+#   sha256sum --check SHA256SUMS.txt   # after verifying the signature below
 # Verify the checksums signature with:
 #   cosign verify-blob \
 #     --certificate SHA256SUMS.txt.pem --signature SHA256SUMS.txt.sig \
-#     --certificate-identity-regexp "^https://github\.com/<org>/<repo-name>/" \
+#     --certificate-identity-regexp "^https://github\.com/<org>/<repo-name>/\.github/workflows/release\.yml@refs/tags/" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
 #     SHA256SUMS.txt
 
@@ -247,12 +253,16 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # Anchor the regex to the start so a trailing-substring match against
-          # an arbitrary URL can't pass verification.
+          # Pin the cert identity to: this exact repo, the release.yml workflow
+          # file, on a tag ref (refs/tags/). `^` anchors the start so a
+          # substring match can't sneak through. `\.` escapes the dot so it
+          # matches a literal period instead of any character. Caller's
+          # release.yml triggers on `push: tags: 'v*'`, so refs/tags/ is the
+          # only legitimate ref a release-time signature could carry.
           cosign verify-blob \
             --certificate SHA256SUMS.txt.pem \
             --signature SHA256SUMS.txt.sig \
-            --certificate-identity-regexp "^https://github\.com/${REPO}/" \
+            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/release\.yml@refs/tags/" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             SHA256SUMS.txt
 

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -122,9 +122,17 @@ gh release create v1.5.12 --latest=false --title "v1.5.12" --notes-file CHANGELO
 
 GitHub marks releases "Latest" by creation timestamp, not semver. A v1.5.12 created after v2.0.0 will become "Latest" without this flag — wrong, misleading, and often noticed only by downstream consumers.
 
-## SLSA Build Provenance
+## Supply-Chain Attestation
 
-The reusable release workflow attaches SLSA build-provenance attestations to every release archive via `actions/attest-build-provenance`. Callers must grant `id-token: write` + `attestations: write` on the calling job (in addition to `contents: write` for the release upload):
+Every release archive is signed and provenance-attested in the SAME job that publishes the GitHub Release, BEFORE the assets are made public — there is no window where unsigned or unattested artifacts are downloadable. The flow, in order:
+
+1. Build `*.zip` and `*.tar.gz` archives.
+2. Generate `SHA256SUMS.txt` over them.
+3. **Cosign** keyless `sign-blob` the `SHA256SUMS.txt` → produces `SHA256SUMS.txt.sig` + `SHA256SUMS.txt.pem`.
+4. **`actions/attest-build-provenance`** generates a SLSA build-provenance attestation for the archives + checksums file → published to GitHub's attestation API.
+5. **`softprops/action-gh-release`** publishes the GitHub Release with all assets attached at once.
+
+Callers must grant three permissions on the calling job:
 
 ```yaml
 # .github/workflows/release.yml in the consuming repo
@@ -133,16 +141,34 @@ jobs:
     uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
     permissions:
       contents: write          # release upload
-      id-token: write          # OIDC for sigstore (required by the attest job)
-      attestations: write      # GitHub native attestation API (required by the attest job)
+      id-token: write          # OIDC for sigstore (Cosign + attest-build-provenance)
+      attestations: write      # GitHub native attestation API
 ```
 
-Verify on a downloaded release archive with:
+If any of those scopes is missing the job fails fast with `Resource not accessible by integration`; `contents: write` alone is not enough.
+
+### Verify a downloaded release archive
 
 ```bash
+# SLSA build provenance (GitHub-native attestation API)
 gh attestation verify <skill-name>-skill-vX.Y.Z.zip --owner netresearch
+
+# Cosign sign-blob signature on the checksums (no GitHub API needed)
+cosign verify-blob \
+  --certificate SHA256SUMS.txt.pem \
+  --signature   SHA256SUMS.txt.sig \
+  --certificate-identity-regexp "https://github.com/netresearch/.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  SHA256SUMS.txt
+
+# Then verify the archive matches the (now-signed) checksum
+sha256sum --check SHA256SUMS.txt
 ```
 
-The attestation runs as a separate job (`needs: release`) so a failure in attestation does not roll back the GitHub release — the release succeeds, and the attestation job is the one that surfaces a `Resource not accessible by integration` error if a caller hasn't granted both `id-token: write` and `attestations: write` (the `contents: write` scope alone is not enough).
+### Why one atomic job
 
-The previously-documented `with: attest: true` opt-in is gone: the input is still declared (so existing `with: attest: true` doesn't error syntactically) but it's deprecated and ignored — every release gets provenance unconditionally. On your next release-touching PR, drop the `with: attest: true` line — and the entire `with:` block if `attest` was its only entry, since `bump` is also deprecated.
+Splitting attestation into a separate `needs: release` job (the original design here) creates a race: the GitHub Release publishes BEFORE the attestation exists, so anyone downloading in that window gets unsigned, un-attested artifacts. Folding everything into the same job before the upload eliminates the window — either the whole bundle (archives + signature + provenance) ships, or nothing does.
+
+Same pattern as `netresearch/.github/.github/workflows/golib-create-release.yml` and `netresearch/typo3-ci-workflows/.github/workflows/release.yml`. No reason for skill repos to diverge.
+
+The previously-documented `with: attest: true` opt-in is gone; the input is still declared as `DEPRECATED — ignored` so any caller that still passes it doesn't error syntactically, but every release now gets provenance unconditionally. Drop the `with:` block if `attest` was its only entry (also true for `bump`).

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -124,7 +124,9 @@ GitHub marks releases "Latest" by creation timestamp, not semver. A v1.5.12 crea
 
 ## Supply-Chain Attestation
 
-Every release archive is signed and provenance-attested in the SAME job that publishes the GitHub Release, BEFORE the assets are made public — there is no window where unsigned or unattested artifacts are downloadable. The flow, in order:
+Every release ships with provenance-attested archives and a Cosign-signed `SHA256SUMS.txt` that binds those archives by digest. Only the checksum file is Cosign-signed; the `.zip`/`.tar.gz` archives are integrity-protected through it — verifying the signature on `SHA256SUMS.txt` and then running `sha256sum --check` against the downloaded archive proves the archive was produced by this workflow.
+
+All of this happens in the SAME job that publishes the GitHub Release, BEFORE the assets are made public — there is no window where unsigned or unattested artifacts are downloadable. The flow, in order:
 
 1. Build `*.zip` and `*.tar.gz` archives.
 2. Generate `SHA256SUMS.txt` over them.
@@ -157,11 +159,15 @@ Both commands below pin verification to the **specific repository** that's expec
 # Archive name patterns: <skill>-skill-vX.Y.Z.zip and <plugin>-plugin-vX.Y.Z.zip.
 gh attestation verify <skill-name>-skill-vX.Y.Z.zip --repo netresearch/<repo-name>
 
-# Cosign sign-blob signature on the checksums (no GitHub API needed)
+# Cosign sign-blob signature on the checksums (no GitHub API needed).
+# Pin the identity to: this exact repo + the release.yml workflow file + a
+# refs/tags/ ref. The org-wide form `https://github.com/netresearch/.*` would
+# accept signatures from any repo, branch, or workflow in the org — too loose
+# for supply-chain verification.
 cosign verify-blob \
   --certificate SHA256SUMS.txt.pem \
   --signature   SHA256SUMS.txt.sig \
-  --certificate-identity-regexp "^https://github\.com/netresearch/<repo-name>/" \
+  --certificate-identity-regexp "^https://github\.com/netresearch/<repo-name>/\.github/workflows/release\.yml@refs/tags/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   SHA256SUMS.txt
 

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -149,21 +149,30 @@ If any of those scopes is missing the job fails fast with `Resource not accessib
 
 ### Verify a downloaded release archive
 
+Both commands below pin verification to the **specific repository** that's expected to have produced the release. `--owner netresearch` and `https://github.com/netresearch/.*` are tempting shortcuts but match every workflow run in the org — meaning a compromised or unrelated netresearch repo could mint a valid-looking attestation against an artefact that was never released from this repo. Always pin to the named repo.
+
 ```bash
 # SLSA build provenance (GitHub-native attestation API)
-gh attestation verify <skill-name>-skill-vX.Y.Z.zip --owner netresearch
+# Substitute <repo-name> with the actual skill repo, e.g. matrix-skill.
+# Archive name patterns: <skill>-skill-vX.Y.Z.zip and <plugin>-plugin-vX.Y.Z.zip.
+gh attestation verify <skill-name>-skill-vX.Y.Z.zip --repo netresearch/<repo-name>
 
 # Cosign sign-blob signature on the checksums (no GitHub API needed)
 cosign verify-blob \
   --certificate SHA256SUMS.txt.pem \
   --signature   SHA256SUMS.txt.sig \
-  --certificate-identity-regexp "https://github.com/netresearch/.*" \
+  --certificate-identity-regexp "^https://github\.com/netresearch/<repo-name>/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   SHA256SUMS.txt
 
 # Then verify the archive matches the (now-signed) checksum
 sha256sum --check SHA256SUMS.txt
 ```
+
+If verification fails:
+
+- `gh attestation verify` returns `error: no attestations found` when `--repo` is wrong (or when the release predates this workflow).
+- `cosign verify-blob` returns `error: certificate identity does not match` when the regex is wrong, or `bundle verification failed` when `.sig` / `.pem` don't correspond to the file.
 
 ### Why one atomic job
 


### PR DESCRIPTION
## Summary

The previous design (#79) ran SLSA attestation in a separate `attest` job with `needs: release`. That created a **race window**: the GitHub Release published BEFORE the attestation existed, so anyone downloading in that window got an unsigned artifact even though the release later showed up as attested. GitHub Releases are effectively immutable once published — fixing this after the fact would mean redacting and re-issuing.

This PR re-shapes the workflow to match the established org-wide pattern used by [`netresearch/.github`'s `golib-create-release.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/golib-create-release.yml) and [`netresearch/typo3-ci-workflows`'s `release.yml`](https://github.com/netresearch/typo3-ci-workflows/blob/main/.github/workflows/release.yml): one job, attest BEFORE publish.

## New ordered flow (single job)

1. Build `*.zip` + `*.tar.gz` archives.
2. Generate `SHA256SUMS.txt` over them.
3. **Cosign** keyless `sign-blob` the `SHA256SUMS.txt` → `SHA256SUMS.txt.sig` + `SHA256SUMS.txt.pem`.
4. **`actions/attest-build-provenance`** over the archives + checksums.
5. **`softprops/action-gh-release`** publishes the Release with all assets at once.

No race window — either the whole bundle (archives + signature + provenance) ships, or nothing does.

## Bonus: client-side verifiable signatures

Every release now ships Cosign `sign-blob` bundles alongside the existing SLSA attestation. Two independent verification paths:

```bash
# GitHub-native attestation API
gh attestation verify <skill-name>-skill-vX.Y.Z.zip --owner netresearch

# Sigstore — works without GitHub's API
cosign verify-blob \
  --certificate SHA256SUMS.txt.pem \
  --signature   SHA256SUMS.txt.sig \
  --certificate-identity-regexp "https://github.com/netresearch/.*" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  SHA256SUMS.txt
sha256sum --check SHA256SUMS.txt
```

## Caller compatibility

**No change required.** Callers already grant `contents: write` + `id-token: write` + `attestations: write` after the org-wide rollout, and that's exactly what this workflow needs. The `attest` input stays declared as `DEPRECATED — ignored` for backward-compat.

## What changed

- `.github/workflows/release.yml`:
  - `release` job gains `id-token: write` + `attestations: write` permissions (previously on the separate `attest` job).
  - Three new steps inserted between the build step and `softprops/action-gh-release`: install Cosign, sign-blob, verify, attest-build-provenance.
  - The separate `attest` job is removed entirely.
  - Top-of-file comment rewritten to describe the new single-job flow.
- `skills/skill-repo/references/release-discipline.md`: section renamed "SLSA Build Provenance" → "Supply-Chain Attestation", lists the 5-step flow, adds the `cosign verify-blob` command, and adds a "Why one atomic job" note explaining the immutable-release race that motivated this change.

## Test plan

- [ ] CI green on this PR (yamllint + skill validation)
- [ ] After merge: ship a test release in any caller (`matrix-skill`, `github-release-skill`, etc.) and confirm:
  - `SHA256SUMS.txt`, `SHA256SUMS.txt.sig`, `SHA256SUMS.txt.pem` are all present in the GitHub Release
  - `gh attestation verify <archive>.zip --owner netresearch` passes
  - `cosign verify-blob` against `SHA256SUMS.txt.{sig,pem}` passes
  - `sha256sum --check SHA256SUMS.txt` against the downloaded archives passes
- [ ] Release publish time: should be slightly longer than before due to cosign install + sign + verify, but still well under the previous "release + separate attest job" wall-clock total