### PR TITLE
fix(release): cosign cert identity points at the reusable, not the caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,15 @@ name: Release Skill
 # Callers must grant `id-token: write` and `attestations: write` on the calling
 # job (in addition to `contents: write`). All netresearch skill-repo callers do;
 # fork this workflow only after granting those scopes.
-# Verify a downloaded archive with (pin to the SPECIFIC repo + workflow file +
-# tag ref — `--owner` and an org-wide identity regex would accept attestations
-# from any other repo or branch in the org):
+# Verify a downloaded archive:
 #   gh attestation verify <archive>.zip --repo <org>/<repo-name>
 #   sha256sum --check SHA256SUMS.txt   # after verifying the signature below
-# Verify the checksums signature with:
+# Verify the checksums signature with cosign. The cert SAN reflects the SIGNER
+# (this reusable workflow), NOT the caller; pin the regex to skill-repo-skill,
+# not the consuming repo:
 #   cosign verify-blob \
 #     --certificate SHA256SUMS.txt.pem --signature SHA256SUMS.txt.sig \
-#     --certificate-identity-regexp "^https://github\.com/<org>/<repo-name>/\.github/workflows/release\.yml@refs/tags/" \
+#     --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
 #     SHA256SUMS.txt
 
@@ -250,19 +250,25 @@ jobs:
       - name: Verify Cosign signature
         working-directory: dist/releases
         env:
-          REPO: ${{ github.repository }}
+          # The cosign keyless cert's Subject Alternative Name is the path of
+          # the workflow that ran `cosign sign-blob` — that's THIS reusable
+          # workflow, not the caller. For a reusable workflow invoked via
+          # `uses: …@main`, the SAN looks like
+          #   https://github.com/netresearch/skill-repo-skill/.github/workflows/release.yml@refs/heads/main
+          # (the ref reflects how the reusable was referenced, NOT the tag that
+          # triggered the caller). Pin against the reusable's own path,
+          # NOT ${{ github.repository }} (which is the caller's repo).
+          SIGNER_REPO: netresearch/skill-repo-skill
         run: |
           set -euo pipefail
-          # Pin the cert identity to: this exact repo, the release.yml workflow
-          # file, on a tag ref (refs/tags/). `^` anchors the start so a
-          # substring match can't sneak through. `\.` escapes the dot so it
-          # matches a literal period instead of any character. Caller's
-          # release.yml triggers on `push: tags: 'v*'`, so refs/tags/ is the
-          # only legitimate ref a release-time signature could carry.
+          # Anchored regex: must START with the reusable's full URL plus an `@`.
+          # `\.` escapes the dot so it matches a literal period instead of any
+          # character. We don't pin a specific ref because the reusable may be
+          # referenced via `@main`, a SHA, or a future tag of skill-repo-skill.
           cosign verify-blob \
             --certificate SHA256SUMS.txt.pem \
             --signature SHA256SUMS.txt.sig \
-            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/release\.yml@refs/tags/" \
+            --certificate-identity-regexp "^https://github\.com/${SIGNER_REPO}/\.github/workflows/release\.yml@" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             SHA256SUMS.txt
 

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -160,14 +160,16 @@ Both commands below pin verification to the **specific repository** that's expec
 gh attestation verify <skill-name>-skill-vX.Y.Z.zip --repo netresearch/<repo-name>
 
 # Cosign sign-blob signature on the checksums (no GitHub API needed).
-# Pin the identity to: this exact repo + the release.yml workflow file + a
-# refs/tags/ ref. The org-wide form `https://github.com/netresearch/.*` would
-# accept signatures from any repo, branch, or workflow in the org — too loose
-# for supply-chain verification.
+# The cert SAN reflects the SIGNER, which is the shared reusable release
+# workflow (`netresearch/skill-repo-skill`), NOT the consuming repo. Pin the
+# regex to skill-repo-skill, not the consumer. (`gh attestation verify` above
+# walks the chain automatically; cosign's verifier doesn't.) The org-wide form
+# `https://github.com/netresearch/.*` would accept signatures from any repo,
+# branch, or workflow in the org — too loose for supply-chain verification.
 cosign verify-blob \
   --certificate SHA256SUMS.txt.pem \
   --signature   SHA256SUMS.txt.sig \
-  --certificate-identity-regexp "^https://github\.com/netresearch/<repo-name>/\.github/workflows/release\.yml@refs/tags/" \
+  --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   SHA256SUMS.txt
 


### PR DESCRIPTION
## Summary

Hot bug introduced by [#80](https://github.com/netresearch/skill-repo-skill/pull/80). The `Verify Cosign signature` step (and the doc example) built the cert-identity regex from `\${{ github.repository }}` + `refs/tags/`, expecting the cert SAN to point at the consumer + release tag. But for a reusable workflow invoked via `uses: …@main`, the cosign keyless cert's Subject Alternative Name reflects the **signer** — this reusable workflow:

```
https://github.com/netresearch/skill-repo-skill/.github/workflows/release.yml@refs/heads/main
```

NOT the caller's repo or the release tag. Confirmed against the cert minted for `jira-skill v3.13.1`'s attestation (the previous attest design produced an attestation with that exact SAN).

**Without this fix, the next consumer release after PR #80 lands would have failed at the Verify Cosign signature step** — no release would actually ship, the workflow would error before publishing. Same wrong regex was in the doc verify-blob example, so end-users would be running a recipe that never matches.

## Fix

Pin the regex to the reusable's full URL with an `@` separator and no further ref constraint (the reusable can be referenced via `@main`, a SHA, or a future tag of `skill-repo-skill` — all are valid signers as long as the SAN matches this prefix):

```diff
-      env:
-        REPO: \${{ github.repository }}
+      env:
+        SIGNER_REPO: netresearch/skill-repo-skill
       …
-          --certificate-identity-regexp "^https://github\\.com/\${REPO}/\\.github/workflows/release\\.yml@refs/tags/" \\
+          --certificate-identity-regexp "^https://github\\.com/\${SIGNER_REPO}/\\.github/workflows/release\\.yml@" \\
```

Same correction applied to the file-level comment and the `release-discipline.md` example.

## Why `gh attestation verify` is unaffected

The provenance attestation generated by `actions/attest-build-provenance` records both the source (consumer) repo AND the builder (reusable) workflow. `gh attestation verify --repo <consumer>` walks that chain automatically and validates against the right thing. **That command was already working** — verified end-to-end against `jira-skill v3.13.1`. Only the parallel `cosign verify-blob` recipe needs to be told explicitly which signer to expect.

## Test plan

- [ ] CI green on this PR (yamllint + skill validation)
- [ ] After merge: any consumer release ships with `SHA256SUMS.txt.sig` + `.pem`, the in-CI Verify Cosign signature step passes, and the doc recipe verifies the signature off a downloaded archive