### PR TITLE
feat: ship as npm package via @netresearch/agent-skill-coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,14 @@ The skill triggers on keywords like:
 └── .github/workflows/    # CI/CD
 ```
 
-### Three Installation Methods
+### Installation Methods
 
 1. **Marketplace** - `/plugin marketplace add netresearch/claude-code-marketplace`
-2. **Release Download** - GitHub Releases (skill files only)
-3. **Composer** - `composer require netresearch/agent-{skill-name}`
+2. **npx (skills.sh)** - `npx skills add <repo-url> --skill <name>`
+3. **Release Download** - GitHub Releases (skill files only)
+4. **Git Clone** - Direct repository clone
+5. **Composer** - `composer require netresearch/agent-{skill-name}` (PHP projects)
+6. **npm** - `npm install --save-dev @netresearch/agent-skill-coordinator github:<org>/<repo>` (Node projects)
 
 ### Composer Package Requirements
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ composer require netresearch/skill-repo-skill
 ```
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
+
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/skill-repo-skill
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
 ## Usage
 
 The skill triggers on keywords like:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@netresearch/skill-repo-skill",
+  "version": "0.0.0-source",
+  "description": "Guide for structuring Netresearch skill repositories with multi-channel distribution.",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
+  "homepage": "https://github.com/netresearch/skill-repo-skill",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/netresearch/skill-repo-skill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/netresearch/skill-repo-skill/issues"
+  },
+  "keywords": [
+    "ai-agent-skill",
+    "skill-repo",
+    "skill-creator",
+    "release-workflow",
+    "anthropic",
+    "claude-code"
+  ],
+  "aiAgentSkill": "skills/skill-repo/SKILL.md",
+  "files": [
+    "skills/skill-repo/",
+    "scripts/",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "@netresearch/agent-skill-coordinator": "^0.1"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `package.json` so the skill is npm-installable straight from this GitHub repo (no npm-registry publication required to start).
- README gains a parallel **npm (Node Projects)** section under Installation, mirroring the existing **Composer (PHP Projects)** section.

## How discovery works (consumer side)

```bash
npm install --save-dev \
  @netresearch/agent-skill-coordinator \
  github:netresearch/skill-repo-skill
```

After install, the coordinator's `postinstall` walks `node_modules`, finds this package via `aiAgentSkill: skills/skill-repo/SKILL.md`, validates the frontmatter, and writes a `<skills_system>` block into the project's `AGENTS.md`. Same shape as the Composer plugin's output.

## Why version stays at `0.0.0-source`

Versioning still lives in git tags and the existing Composer release workflow. A real npm version would be set at publish time; until then, `0.0.0-source` is the standard "this manifest exists for tooling, not as a release marker" placeholder.

## Sibling PRs (merged)
- https://github.com/netresearch/git-workflow-skill/pull/39
- https://github.com/netresearch/github-project-skill/pull/67
- https://github.com/netresearch/security-audit-skill/pull/67

Coordinator: https://github.com/netresearch/node-agent-skill-coordinator (`@netresearch/agent-skill-coordinator@0.1.2`)