### PR TITLE
feat(templates): bake npm package.json defaults to prevent retrofit drift

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -90,17 +90,18 @@ uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 
 Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml`.
 
-Auto-merge and pr-quality callers must use `pull_request_target` trigger (not `pull_request`). Never define actions directly in skill repos — always call reusable workflows so action version bumps happen in one place.
+Auto-merge and pr-quality callers must use `pull_request_target` trigger. Never define actions directly — always call reusable workflows.
 
 ## Releasing
 
-Open bump PR → merge → pull main → verify version parity → signed tag → push tag → monitor Release workflow. **Tag only after the bump PR is merged** (tag-before-bump runs Release against the wrong version). Never edit installed skill paths (`~/.claude/skills/**`, `~/.claude/plugins/**`); always the worktree. Multi-repo releases (>3) require a dry-run manifest + approval. See `references/release-discipline.md`.
+Open bump PR → merge → pull main → verify version parity → signed tag → push tag → monitor Release workflow. **Tag only after the bump PR is merged**. Never edit installed skill paths (`~/.claude/skills/**`, `~/.claude/plugins/**`); always the worktree. Multi-repo releases (>3) require dry-run + approval. See `references/release-discipline.md`.
 
 ## Installation
 
 1. **Marketplace**: `/plugin marketplace add netresearch/claude-code-marketplace`
 2. **Release**: Download to `~/.claude/skills/{name}/`
 3. **Composer**: `composer require netresearch/{repo-name}`
+4. **npm**: `npm i -D @netresearch/agent-skill-coordinator github:netresearch/{repo-name}`. Use `templates/package.json.template` (bakes in `private: true` + `files` allowlist with `.claude-plugin/`, `hooks/`, `commands/`, `outputStyles/`, `assets/`, `AGENTS.md`). See `references/installation-methods.md`.
 
 ## Validation
 
@@ -110,9 +111,9 @@ scripts/validate-skill.sh
 
 ## Cross-platform Compatibility
 
-- Use `grep -E` not `grep -P` (macOS BSD grep lacks `-P`)
-- Use `bash` in shebangs (macOS default is zsh)
-- Use `[[ ]]` for conditionals
+- `grep -E` not `grep -P` (macOS BSD grep)
+- `bash` in shebangs (macOS default is zsh)
+- `[[ ]]` for conditionals
 
 ## References
 

--- a/skills/skill-repo/references/installation-methods.md
+++ b/skills/skill-repo/references/installation-methods.md
@@ -1,6 +1,6 @@
 # Installation Methods
 
-Three methods for installing Netresearch skills.
+Four methods for installing Netresearch skills.
 
 ## Method 1: Netresearch Marketplace (Recommended)
 
@@ -91,6 +91,77 @@ composer require netresearch/{repo-name}
 - Project-specific skill sets
 - Easy updates with `composer update`
 
+## Method 4: npm (Node Projects)
+
+For Node.js / TypeScript projects, install skills as npm packages discovered by `@netresearch/agent-skill-coordinator`.
+
+### Prerequisites
+
+1. Node.js 18+ and npm 9+ (or pnpm/yarn equivalent)
+2. [`@netresearch/agent-skill-coordinator`](https://github.com/netresearch/node-agent-skill-coordinator) — peer dependency that scans `node_modules` and registers skills in `AGENTS.md`
+
+### Installation
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/{repo-name}
+```
+
+For pnpm, allowlist the coordinator's `postinstall` so it can write `AGENTS.md`:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
+### How It Works
+
+1. Coordinator's `postinstall` walks `node_modules` for packages declaring `aiAgentSkill: skills/<name>/SKILL.md`
+2. Validates frontmatter, then writes a `<skills_system>` block into the project's `AGENTS.md`
+3. Skill content is then visible to any agent reading `AGENTS.md`
+
+### What ships in the npm tarball
+
+The `files` allowlist in `package.json` controls what npm packs. **Always include** anything the SKILL.md content references at repo root, plus `.claude-plugin/` (so consumers who later switch to the marketplace install see the same files):
+
+```json
+{
+  "files": [
+    "skills/{skill-name}/",
+    ".claude-plugin/",
+    "hooks/",
+    "scripts/",
+    "commands/",
+    "outputStyles/",
+    "assets/",
+    "AGENTS.md",
+    "LICENSE-MIT",
+    "LICENSE-CC-BY-SA-4.0",
+    "README.md"
+  ]
+}
+```
+
+Drop entries whose dir/file does not exist in your repo. Reviewers (Copilot/Gemini) flag missing entries that are referenced from SKILL.md or `.claude-plugin/plugin.json`.
+
+### `"private": true` on `0.0.0-source`
+
+Skill repos use the placeholder version `0.0.0-source` and **must** set `"private": true` to guard against accidental `npm publish` of the placeholder. Real publishes (when/if added later) flip `private` to `false` (or remove it) at release time and set a real semver.
+
+### Limitation: SKILL.md content only
+
+The npm path registers only `SKILL.md` content into `AGENTS.md`. **Slash commands** (defined under `commands/`) and **PreToolUse / PostToolUse hooks** (defined under `.claude-plugin/`) are loaded by Claude Code's plugin mechanism — not by the coordinator scanning `node_modules`. Repos that ship those features should document this explicitly in their README (a `> **Limitation:**` callout immediately after the npm install snippet) so consumers know they need the marketplace install for the full skill.
+
+### Benefits
+
+- Lock-file pinning via `package-lock.json` / `pnpm-lock.yaml`
+- Renovate / Dependabot can bump skill versions like any other dep
+- No PHP / Composer required for Node-only projects
+
 ## Choosing a Method
 
 | Scenario | Recommended Method |
@@ -98,7 +169,8 @@ composer require netresearch/{repo-name}
 | General Claude Code use | Marketplace |
 | Offline/air-gapped | Release download |
 | PHP project | Composer |
-| CI/CD automation | Composer |
+| Node / TypeScript project | npm |
+| CI/CD automation | Composer or npm |
 | Quick trial | Marketplace |
 
 ## Directory Locations
@@ -108,3 +180,4 @@ composer require netresearch/{repo-name}
 | Marketplace | Managed by Claude Code |
 | Release | `~/.claude/skills/{skill-name}/` |
 | Composer | `vendor/netresearch/{repo-name}/` |
+| npm | `node_modules/@netresearch/{repo-name}/` |

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -63,12 +63,18 @@ Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/n
 }
 ```
 
-<!-- Include the Limitation callout below ONLY if this skill ships slash commands
-     (commands/) or PreToolUse/PostToolUse hooks via .claude-plugin/.
-     The npm-coordinator path only registers SKILL.md content into AGENTS.md;
-     plugin-mechanism features (slash commands, hooks) require the marketplace install. -->
+<!-- If this skill ships slash commands (commands/) or PreToolUse/PostToolUse hooks
+     via .claude-plugin/, uncomment the callout below by removing the surrounding
+     LIMITATION-CALLOUT-START / LIMITATION-CALLOUT-END markers so npm consumers
+     know they need the marketplace install for full functionality. The
+     npm-coordinator path only registers SKILL.md content into AGENTS.md;
+     plugin-mechanism features (slash commands, hooks) require Claude Code's
+     plugin loader, not the coordinator's node_modules scanner. -->
 
+<!-- LIMITATION-CALLOUT-START
 > **Limitation:** The npm install path registers only `SKILL.md` content via the coordinator's `postinstall` (it writes a `<skills_system>` block into `AGENTS.md`). Slash commands defined in `commands/` and PreToolUse hooks defined in `.claude-plugin/` are loaded by Claude Code's plugin mechanism, **not** by the coordinator scanning `node_modules`. For the full skill (commands + hooks), install via the [Marketplace](#marketplace-recommended) or download the release directly.
+LIMITATION-CALLOUT-END -->
+
 
 ## Usage
 

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -45,6 +45,31 @@ composer require netresearch/{repo-name}
 
 Requires [netresearch/composer-agent-skill-plugin](https://github.com/netresearch/composer-agent-skill-plugin).
 
+### npm (Node Projects)
+
+```bash
+npm install --save-dev \
+  @netresearch/agent-skill-coordinator \
+  github:netresearch/{repo-name}
+```
+
+Requires [@netresearch/agent-skill-coordinator](https://github.com/netresearch/node-agent-skill-coordinator), which discovers the skill in `node_modules` and registers it in `AGENTS.md` via a `postinstall` hook. For pnpm, also allowlist the coordinator's postinstall:
+
+```json
+{
+  "pnpm": {
+    "onlyBuiltDependencies": ["@netresearch/agent-skill-coordinator"]
+  }
+}
+```
+
+<!-- Include the Limitation callout below ONLY if this skill ships slash commands
+     (commands/) or PreToolUse/PostToolUse hooks via .claude-plugin/.
+     The npm-coordinator path only registers SKILL.md content into AGENTS.md;
+     plugin-mechanism features (slash commands, hooks) require the marketplace install. -->
+
+> **Limitation:** The npm install path registers only `SKILL.md` content via the coordinator's `postinstall` (it writes a `<skills_system>` block into `AGENTS.md`). Slash commands defined in `commands/` and PreToolUse hooks defined in `.claude-plugin/` are loaded by Claude Code's plugin mechanism, **not** by the coordinator scanning `node_modules`. For the full skill (commands + hooks), install via the [Marketplace](#marketplace-recommended) or download the release directly.
+
 ## Usage
 
 The skill triggers on keywords like:

--- a/skills/skill-repo/templates/package.json.template
+++ b/skills/skill-repo/templates/package.json.template
@@ -1,31 +1,34 @@
 {
-  "name": "@netresearch/skill-repo-skill",
+  "name": "@netresearch/{repo-name}",
   "version": "0.0.0-source",
   "private": true,
-  "description": "Guide for structuring Netresearch skill repositories with multi-channel distribution.",
+  "description": "{Skill description}",
   "license": "(MIT AND CC-BY-SA-4.0)",
   "author": "Netresearch DTT GmbH (https://www.netresearch.de/)",
-  "homepage": "https://github.com/netresearch/skill-repo-skill",
+  "homepage": "https://github.com/netresearch/{repo-name}",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/netresearch/skill-repo-skill.git"
+    "url": "git+https://github.com/netresearch/{repo-name}.git"
   },
   "bugs": {
-    "url": "https://github.com/netresearch/skill-repo-skill/issues"
+    "url": "https://github.com/netresearch/{repo-name}/issues"
   },
   "keywords": [
     "ai-agent-skill",
-    "skill-repo",
-    "skill-creator",
-    "release-workflow",
+    "{topical-tag-1}",
+    "{topical-tag-2}",
     "anthropic",
     "claude-code"
   ],
-  "aiAgentSkill": "skills/skill-repo/SKILL.md",
+  "aiAgentSkill": "skills/{skill-name}/SKILL.md",
   "files": [
-    "skills/skill-repo/",
+    "skills/{skill-name}/",
     ".claude-plugin/",
+    "hooks/",
     "scripts/",
+    "commands/",
+    "outputStyles/",
+    "assets/",
     "AGENTS.md",
     "LICENSE-MIT",
     "LICENSE-CC-BY-SA-4.0",


### PR DESCRIPTION
## Summary

Adds `skills/skill-repo/templates/package.json.template` and updates the README template, the installation-methods reference doc, and SKILL.md so any new skill repo created from this scaffold ships the npm-installable shape that 14 existing repos had to retrofit by hand.

Also aligns this skill's own `package.json` (just landed in #82) with the new template — adds `\"private\": true` and `.claude-plugin/` to `files` so the skill-repo-skill ships a self-consistent example.

## Why

The recent rollout of `@netresearch/agent-skill-coordinator`-based npm install landed 11 PRs across the skill collection (`skill-repo-skill` #82, `netresearch-branding-skill`, `github-release-skill` #19 plus 8 earlier repos). Six of those needed manual fix-up commits for the same review comments from Copilot and Gemini:

1. **`files` allowlist missing `.claude-plugin/`** — flagged on every repo with that dir (it holds `plugin.json` + slash-command metadata)
2. **`files` allowlist missing `commands/`, `outputStyles/`, `assets/`, `AGENTS.md`** — anything SKILL.md content references at repo root
3. **`\"private\": true` missing on `0.0.0-source` placeholders** — Copilot guard against accidental `npm publish`
4. **README markdownlint** — missing blank line before `### npm (Node Projects)` heading

The root cause was scaffolding drift in this very skill. Baking these defaults in here removes the drift at the source and stops reviewers (and humans) from doing the same dance N more times.

## Changes

| File | Change |
|---|---|
| `skills/skill-repo/templates/package.json.template` | **NEW** — Full template with `private: true`, full `files` allowlist, `peerDependencies`, etc. |
| `skills/skill-repo/templates/README.md.template` | Adds `### npm (Node Projects)` section (with mandatory blank line before heading) and a conditional `> **Limitation:**` callout per [github-release-skill #19](https://github.com/netresearch/github-release-skill/pull/19) — wrapped in an HTML comment instructing authors to keep it only if the skill ships slash commands or PreToolUse hooks via `.claude-plugin/`. |
| `skills/skill-repo/references/installation-methods.md` | Adds **Method 4: npm** with prerequisites, install snippet, pnpm allowlisting, `files` allowlist guidance, the `\"private\": true` rationale, the SKILL.md-only limitation, and the new row in the choosing/locations tables. |
| `skills/skill-repo/SKILL.md` | Adds installation bullet 4 (npm) referencing the new template. Tightened 'Reusable Workflow Callers' + 'Releasing' to keep under the 500-word limit (now 496). |
| `package.json` (this repo) | Adds `\"private\": true` and adds `.claude-plugin/` + `AGENTS.md` to `files` so the skill ships consistent with its own template. |

## Conditional handling

A static template can't say *\"include if dir exists\"*. Resolution:

- `package.json.template` lists every candidate path; the SKILL.md note and the new *What ships in the npm tarball* section in the reference doc instruct authors to drop entries whose dir/file does not exist in their repo.
- README template's `> **Limitation:**` callout sits inside an HTML comment with explicit instructions on when to keep it.

## Verification

- `bash skills/skill-repo/scripts/validate-skill.sh .` passes (0 errors, 0 warnings)
- `python3 -c \"import json; json.load(...)\"` parses both `package.json` and the new template cleanly
- Word count on SKILL.md: 496 / 500

## Sibling PRs (rollout context)

- [`skill-repo-skill` #82](https://github.com/netresearch/skill-repo-skill/pull/82) (the manifest this PR builds on)
- [`github-release-skill` #19](https://github.com/netresearch/github-release-skill/pull/19) (origin of the Limitation callout pattern)
- [`git-workflow-skill` #39](https://github.com/netresearch/git-workflow-skill/pull/39)
- [`github-project-skill` #67](https://github.com/netresearch/github-project-skill/pull/67)
- [`security-audit-skill` #67](https://github.com/netresearch/security-audit-skill/pull/67)
- 6 more across the @netresearch/* skill repos in the same rollout window

## Test plan

- [ ] Copilot / Gemini review: confirm the new template plus the README/installation-methods changes address the four recurring review patterns
- [ ] Spot-check a future new skill repo: scaffold with this template, run `npm pack --dry-run`, confirm the tarball contains `.claude-plugin/`, `commands/`, etc. when those dirs exist, and excludes them when they don't (after the author drops the missing entries per the doc)
- [ ] Confirm `validate-skill.sh` continues to pass (already verified locally on this branch)

## Notes

- Did not touch `scripts/validate-skill.sh` — adding `package.json` validation is out of scope for this PR (would require teaching the script about npm semantics). Worth a follow-up.
- Did not change the skill version. This is template/docs-only with one self-consistency tweak; release-discipline.md doesn't require a bump for non-functional skill content. Defer to maintainer judgement.