### PR TITLE
chore(templates): bake review-cycle lessons into scaffolding

### DIFF
--- a/.github/workflows/npm-pack-smoke-caller.yml
+++ b/.github/workflows/npm-pack-smoke-caller.yml
@@ -1,0 +1,19 @@
+# Dogfood caller: runs the org-reusable npm-pack-smoke workflow against
+# this repo's own tarball on every PR and main push. If this repo's
+# package.json `files` allowlist drifts (leaks repo-maintenance, or omits
+# a runtime-referenced dir), this job fails before merge.
+#
+# No untrusted github.event.* data is interpolated into shell commands.
+name: npm Pack Smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pack:
+    uses: ./.github/workflows/npm-pack-smoke.yml

--- a/.github/workflows/npm-pack-smoke.yml
+++ b/.github/workflows/npm-pack-smoke.yml
@@ -1,0 +1,124 @@
+# Reusable workflow: asserts `npm pack` produces a clean, complete tarball.
+#
+# Two checks:
+#   1. No internal leakage — repo-maintenance files (CI configs, harness
+#      scripts, lint configs, build/eval/docs dirs) must NOT ship.
+#   2. Runtime-referenced dirs are present — every top-level dir referenced
+#      by skills/*/scripts/* via $ROOT/<dir> or ../<dir> MUST be in the
+#      tarball, otherwise installed scripts break.
+#
+# Called from skill repos via .github/workflows/npm-pack-smoke.yml using
+# `uses: netresearch/skill-repo-skill/.github/workflows/npm-pack-smoke.yml@main`.
+# See skills/skill-repo/references/installation-methods.md for the rationale.
+#
+# Inputs: none. Reads only the caller repo's checked-out tree (no untrusted
+# GitHub event payload data is interpolated into shell commands).
+name: npm Pack Smoke
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  pack:
+    name: Verify tarball contents
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: npm pack --dry-run
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm pack --dry-run --json > pack.json
+          jq -r '.[0].files[].path' pack.json | sort > tarball-files.txt
+          echo "Tarball contents:"
+          cat tarball-files.txt
+
+      - name: Assert no internal leakage
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Patterns that should NEVER ship in the tarball.
+          # Anchor against `path` (no leading slash, paths are repo-relative).
+          # Repo-maintenance script names: extend this list as new ones emerge.
+          # NOTE: top-level scripts/ may legitimately ship if the *installed*
+          # skill reads from $ROOT/scripts/ at runtime — see
+          # references/review-replies.md entry #4. We block by script *name*,
+          # not by directory, so runtime scripts living elsewhere are unaffected.
+          maintenance_scripts='verify-harness|generate-dashboard|run-ab-evals'
+          leak_pattern="^\\.github/|^evals/|^docs/|^Build/|(^|/)(${maintenance_scripts})\\.(sh|py|js|ts)$|^\\.markdownlint|^\\.yamllint|^\\.envrc$"
+          # `grep` returns 1 when no match — we WANT no match, so invert with `if`.
+          if leaks=$(grep -E "$leak_pattern" tarball-files.txt); then
+            echo "::error::Repo-internal files leaked into npm tarball:"
+            sed 's/^/  /' <<< "$leaks"
+            echo "Tighten the \`files\` allowlist in package.json. See skills/skill-repo/references/installation-methods.md."
+            exit 1
+          fi
+          echo "OK: no internal leakage."
+
+      - name: Assert runtime-referenced dirs are present
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Extract relative-path references from skill scripts, e.g. $ROOT/catalog,
+          # ../references, $(realpath ../foo). If the scripts dir does not exist
+          # (skill ships no scripts), skip.
+          if ! compgen -G 'skills/*/scripts/' > /dev/null; then
+            echo "OK: no skill scripts to scan."
+            exit 0
+          fi
+
+          # Collect candidate dir names. `|| true` because grep returns non-zero
+          # when there are no matches — that's a valid empty-result case.
+          # Pattern matches both `../dir/` (with slash) and `../dir` (no slash);
+          # we strip the optional trailing slash below.
+          refs=$(grep -rhoE '\$\{?ROOT\}?/[a-zA-Z0-9_-]+|\.\./[a-zA-Z0-9_-]+' skills/*/scripts/ 2>/dev/null || true)
+
+          # Normalize: strip ${ROOT}/, $ROOT/, ../, and trailing slash to get bare dir name.
+          # We exclude only `skills` (already enumerated separately in package.json
+          # `files` as `skills/<name>/`). `scripts` and `references` are NOT
+          # excluded — those are exactly the dirs we want to assert are shipped
+          # when the runtime references them.
+          dirs=$(printf '%s\n' "$refs" \
+            | sed -E 's#^\$\{?ROOT\}?/##; s#^\.\./##; s#/$##' \
+            | grep -vE '^skills$' \
+            | sort -u)
+
+          if [[ -z "$dirs" ]]; then
+            echo "OK: no top-level runtime references found in skill scripts."
+            exit 0
+          fi
+
+          missing=()
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            # Only assert dirs that actually exist in the repo (i.e. ones the
+            # script truly relies on). A reference to a non-existent dir is a
+            # script bug, not a packaging bug — let other CI catch that.
+            if [[ ! -d "$dir" ]]; then
+              continue
+            fi
+            if ! grep -qE "^${dir}/" tarball-files.txt; then
+              missing+=("$dir")
+            fi
+          done <<< "$dirs"
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Runtime-referenced dirs missing from npm tarball:"
+            printf '  %s/\n' "${missing[@]}"
+            echo "Add them to the \`files\` allowlist in package.json — installed scripts read them at runtime."
+            exit 1
+          fi
+          echo "OK: all runtime-referenced dirs are in the tarball."

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "files": [
     "skills/skill-repo/",
     ".claude-plugin/",
-    "scripts/",
     "AGENTS.md",
     "LICENSE-MIT",
     "LICENSE-CC-BY-SA-4.0",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -101,7 +101,7 @@ Open bump PR → merge → pull main → verify version parity → signed tag �
 1. **Marketplace**: `/plugin marketplace add netresearch/claude-code-marketplace`
 2. **Release**: Download to `~/.claude/skills/{name}/`
 3. **Composer**: `composer require netresearch/{repo-name}`
-4. **npm**: `npm i -D @netresearch/agent-skill-coordinator github:netresearch/{repo-name}`. Use `templates/package.json.template` (bakes in `private: true` + `files` allowlist with `.claude-plugin/`, `hooks/`, `commands/`, `outputStyles/`, `assets/`, `AGENTS.md`). See `references/installation-methods.md`.
+4. **npm**: `npm i -D @netresearch/agent-skill-coordinator github:netresearch/{repo-name}`. Use `templates/package.json.template` (minimal `files` default; see `references/installation-methods.md`).
 
 ## Validation
 
@@ -120,6 +120,7 @@ scripts/validate-skill.sh
 - `references/installation-methods.md`
 - `references/composer-setup.md`
 - `references/release-discipline.md` — version-parity check, cache safety, multi-repo dry-run
+- `references/review-replies.md` — canonical replies for recurring reviewer comments
 
 ## See Also
 

--- a/skills/skill-repo/references/installation-methods.md
+++ b/skills/skill-repo/references/installation-methods.md
@@ -126,18 +126,13 @@ For pnpm, allowlist the coordinator's `postinstall` so it can write `AGENTS.md`:
 
 ### What ships in the npm tarball
 
-The `files` allowlist in `package.json` controls what npm packs. **Always include** anything the SKILL.md content references at repo root, plus `.claude-plugin/` (so consumers who later switch to the marketplace install see the same files):
+The `files` allowlist in `package.json` controls what npm packs. The default in `templates/package.json.template` is intentionally **minimal** — the skill payload (`skills/<name>/`), plugin metadata (`.claude-plugin/`), the canonical agent rules entry-point (`AGENTS.md`), licenses, and `README.md`:
 
 ```json
 {
   "files": [
     "skills/{skill-name}/",
     ".claude-plugin/",
-    "hooks/",
-    "scripts/",
-    "commands/",
-    "outputStyles/",
-    "assets/",
     "AGENTS.md",
     "LICENSE-MIT",
     "LICENSE-CC-BY-SA-4.0",
@@ -146,7 +141,42 @@ The `files` allowlist in `package.json` controls what npm packs. **Always includ
 }
 ```
 
-Drop entries whose dir/file does not exist in your repo. Reviewers (Copilot/Gemini) flag missing entries that are referenced from SKILL.md or `.claude-plugin/plugin.json`.
+#### When to add a top-level data dir
+
+Add a top-level dir to `files` **only if your installed skill code reads from it at runtime** (e.g. via `$ROOT/<dir>/...` or `../<dir>/...` from a script under `skills/<name>/scripts/`). Common runtime data dirs:
+
+- `catalog/` — `cli-tools-skill` ships this because its installer scripts read `$ROOT/catalog/*.json`.
+- `hooks/` — Claude Code's plugin loader reads `hooks/hooks.json`. Ship it if your skill ships PreToolUse/PostToolUse hooks.
+- `commands/` — slash command definitions. Ship if present.
+- `outputStyles/` — output style definitions. Ship if present.
+- `assets/` — referenced assets (images, configs). Ship if your skill content references them at install paths.
+
+#### When NOT to add a top-level dir
+
+- **Top-level `scripts/`** is typically **repo-maintenance only** (e.g. `verify-harness.sh`, `generate-dashboard.sh`). Keep it out unless your installed skill scripts read from `$ROOT/scripts/` at runtime. Runtime scripts belong under `skills/<name>/scripts/` (already covered by `skills/<name>/`).
+  - Example: `context7-skill` does NOT ship top-level `scripts/` because its only file is `verify-harness.sh` (repo-maintenance).
+  - Example: `cli-tools-skill` DOES ship `catalog/` because its installer scripts read `$ROOT/catalog/*.json`.
+- `Build/` — dev-only build artifacts. Never ship.
+- `evals/`, `docs/` — repo-internal. Never ship.
+- `.github/`, lint configs (`.markdownlint*`, `.yamllint*`), `.envrc` — repo-internal. Never ship.
+
+Heuristic when looking at a top-level dir:
+
+```text
+package-root/
+  catalog/   # consumed at runtime  -> MUST be in files
+  Build/     # dev-only build artifacts -> DO NOT include
+  scripts/   # inspect: runtime or repo-maintenance? include only if runtime
+```
+
+#### CI safeguard
+
+`templates/.github/workflows/npm-pack-smoke.yml.template` is a ready-to-copy GitHub Actions workflow that runs `npm pack --dry-run` on every PR and asserts:
+
+1. **No internal leakage** — fails if the tarball contains `.github/`, `evals/`, `docs/`, `Build/`, `verify-harness.sh`, lint configs, etc.
+2. **Runtime-referenced dirs are present** — greps `skills/*/scripts/` for `$ROOT/<dir>` and `../<dir>/` references; if a script reads `$ROOT/catalog` but `catalog/` is missing from the tarball, the job fails.
+
+Copy it into `.github/workflows/npm-pack-smoke.yml` in your skill repo. It catches both kinds of `files`-allowlist mistakes (over-inclusion and under-inclusion) before they ship.
 
 ### `"private": true` on `0.0.0-source`
 

--- a/skills/skill-repo/references/review-replies.md
+++ b/skills/skill-repo/references/review-replies.md
@@ -1,0 +1,78 @@
+# Reviewer-Reply Boilerplate
+
+Canonical responses to recurring reviewer comments on Netresearch skill PRs (Copilot, Gemini Code Assist, peer review). Lift the fenced block verbatim or paraphrase to context. Each entry includes the criteria for whether to accept or decline.
+
+These were extracted from review patterns across 14+ skill PRs. Use them to keep responses consistent and to avoid re-litigating settled architectural decisions on every new PR.
+
+## 1. "Set `private: true`"
+
+**Verdict:** Accept — already the template default.
+
+**Criteria:** Skill packages distributed via `github:org/repo` (not the npm registry) **must** set `"private": true` to guard against accidental `npm publish` of the placeholder `0.0.0-source` version. The current `package.json.template` bakes this in. If a reviewer flags it on a fresh PR, the package was scaffolded from an outdated template — accept the suggestion and add it.
+
+```markdown
+Accepted. Adding `"private": true` — current scaffolding template (`skill-repo-skill/templates/package.json.template`) bakes this in to guard against accidental publish of the `0.0.0-source` placeholder. This PR was scaffolded before the template was updated.
+```
+
+## 2. "Pin `github:org/repo#vX.Y.Z` in install instructions"
+
+**Verdict:** Decline as primary advice. Document `#vX.Y.Z` as an opt-in for users who want reproducibility.
+
+**Criteria:** These skills are markdown content (procedural knowledge), not executable code where pinning protects against breakage. Consumers want skill-content updates by default. Pinning is an advanced opt-in.
+
+```markdown
+Declined as primary advice. The default `github:netresearch/{repo-name}` form intentionally tracks the default branch so consumers receive skill-content updates — these skills are markdown content (procedural knowledge), not executable code where breakage matters. Pinning is an advanced use-case, not a default. Consumers can append `#vX.Y.Z` themselves for reproducibility (`github:netresearch/{repo-name}#v1.2.3`); we don't surface that in the README to keep the install path simple.
+```
+
+(Reference: this is the response we used on [skill-repo-skill PR #82](https://github.com/netresearch/skill-repo-skill/pull/82).)
+
+## 3. "Drop `.claude-plugin/` (or `commands/`, `outputStyles/`, `AGENTS.md`) from `files`"
+
+**Verdict:** Decline (won't-fix). This is the dual-distribution invariant.
+
+**Criteria:** Netresearch skill packages are *dual-distributed* — the same package serves both the Claude Code marketplace install path AND the npm install path. Plugin metadata, slash commands, output styles, and `AGENTS.md` are part of the skill's installable surface, not internal repo configuration. Excluding them from the npm tarball delivers a partial skill to npm consumers.
+
+```markdown
+Declining. Netresearch skill packages are *dual-distributed* — the same tarball feeds both the Claude Code marketplace install path AND the npm install path. Plugin metadata (`.claude-plugin/plugin.json`), slash commands (`commands/`), output styles (`outputStyles/`), and the canonical `AGENTS.md` rules file are part of the skill's installable surface, not internal repo configuration.
+
+Excluding them from the npm tarball would deliver a partial skill to npm consumers — the same partial-install problem documented in [github-release-skill PR #19](https://github.com/netresearch/github-release-skill/pull/19)'s `> **Limitation:**` callout. The current `@netresearch/agent-skill-coordinator` (v0.1.x) `node_modules` scanner can't load plugin-mechanism features; those need Claude Code's plugin loader. Shipping these directories preserves the option to switch install methods without re-installing.
+```
+
+(Reference: lifted from [skill-repo-skill PR #83](https://github.com/netresearch/skill-repo-skill/pull/83).)
+
+## 4. "Top-level `scripts/` shouldn't ship"
+
+**Verdict:** **Accept** if `scripts/` is repo-maintenance only. **Decline** if installed code reads from `$ROOT/scripts/` at runtime.
+
+**Criteria:** This is the *opposite* call from #3. Top-level `scripts/` is **not** part of the dual-distribution surface unless the skill's runtime explicitly reads from it. To tell them apart:
+
+- **Repo-maintenance** (DO accept the suggestion, remove from `files`): scripts that only run in CI or by repo maintainers — `verify-harness.sh`, `generate-dashboard.sh`, `run-ab-evals.sh`, lint runners, release helpers. Look for invocation only in `.github/workflows/` or `Makefile` / `package.json scripts`.
+- **Runtime** (DO decline the suggestion, keep in `files`): scripts the *installed* skill executes, typically referenced from `skills/<name>/SKILL.md` or `skills/<name>/scripts/*.sh` via `$ROOT/scripts/...` or `../scripts/...`.
+
+Quick check: `grep -r '\$ROOT/scripts\|\.\./scripts' skills/`. If empty, it's repo-maintenance.
+
+```markdown
+Accepted. `scripts/` at the repo root only contains `verify-harness.sh` (repo-maintenance, run via `.github/workflows/`). The installed skill code does not read from `$ROOT/scripts/` at runtime — runtime scripts live under `skills/<name>/scripts/` (already covered by the `skills/<name>/` entry). Removed from `files`. The npm-pack-smoke CI job will keep this honest going forward.
+```
+
+If declining (runtime usage):
+
+```markdown
+Declining. Top-level `scripts/` is consumed at runtime — `skills/<name>/SKILL.md` references `$ROOT/scripts/<file>.sh` for [specific feature]. Removing it from `files` would break npm consumers. The npm-pack-smoke CI job asserts this dir is present.
+```
+
+## 5. "`AGENTS.md` shouldn't ship"
+
+**Verdict:** Decline (won't-fix). Same dual-distribution invariant as #3.
+
+**Criteria:** `AGENTS.md` is the canonical agent rules entry point for the skill repo. npm consumers expect the same rules file marketplace consumers see — without it, agents reading the package don't get the harness contract.
+
+```markdown
+Declining. `AGENTS.md` is the canonical agent rules entry point for the skill — npm consumers must receive the same rules file that marketplace consumers do, otherwise agents reading the installed package miss the harness contract documented there. This is part of the dual-distribution surface (see [skill-repo-skill PR #83](https://github.com/netresearch/skill-repo-skill/pull/83)).
+```
+
+## See Also
+
+- `installation-methods.md` — Method 4 (npm) for the full `files`-allowlist rationale.
+- `release-discipline.md` — version-parity check, multi-repo dry-run.
+- [skill-repo-skill PR #83](https://github.com/netresearch/skill-repo-skill/pull/83) — original dual-distribution decision record.

--- a/skills/skill-repo/references/review-replies.md
+++ b/skills/skill-repo/references/review-replies.md
@@ -11,7 +11,7 @@ These were extracted from review patterns across 14+ skill PRs. Use them to keep
 **Criteria:** Skill packages distributed via `github:org/repo` (not the npm registry) **must** set `"private": true` to guard against accidental `npm publish` of the placeholder `0.0.0-source` version. The current `package.json.template` bakes this in. If a reviewer flags it on a fresh PR, the package was scaffolded from an outdated template — accept the suggestion and add it.
 
 ```markdown
-Accepted. Adding `"private": true` — current scaffolding template (`skill-repo-skill/templates/package.json.template`) bakes this in to guard against accidental publish of the `0.0.0-source` placeholder. This PR was scaffolded before the template was updated.
+Accepted. Adding `"private": true` — current scaffolding template (`skills/skill-repo/templates/package.json.template` in `netresearch/skill-repo-skill`) bakes this in to guard against accidental publish of the `0.0.0-source` placeholder. This PR was scaffolded before the template was updated.
 ```
 
 ## 2. "Pin `github:org/repo#vX.Y.Z` in install instructions"

--- a/skills/skill-repo/templates/.github/workflows/npm-pack-smoke.yml.template
+++ b/skills/skill-repo/templates/.github/workflows/npm-pack-smoke.yml.template
@@ -1,0 +1,100 @@
+# Copy to .github/workflows/npm-pack-smoke.yml in your skill repo (drop the .template suffix).
+# Asserts that `npm pack` produces a tarball that:
+#   1. Does NOT leak repo-internals (.github/, evals/, docs/, Build/, harness scripts, lint configs).
+#   2. Does include every top-level data dir referenced by the installed skill scripts at runtime
+#      (e.g. catalog/, references/) — under-including breaks consumers.
+# See skills/skill-repo/references/installation-methods.md for the rationale.
+name: npm Pack Smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pack:
+    name: Verify tarball contents
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: npm pack --dry-run
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm pack --dry-run --json > pack.json
+          jq -r '.[0].files[].path' pack.json | sort > tarball-files.txt
+          echo "Tarball contents:"
+          cat tarball-files.txt
+
+      - name: Assert no internal leakage
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Patterns that should NEVER ship in the tarball.
+          # Anchor against `path` (no leading slash, paths are repo-relative).
+          leak_pattern='^\.github/|^evals/|^docs/|^Build/|(^|/)verify-harness\.sh$|(^|/)verify-harness\.py$|^\.markdownlint|^\.yamllint|^\.envrc$'
+          # `grep` returns 1 when no match — we WANT no match, so invert with `if`.
+          if leaks=$(grep -E "$leak_pattern" tarball-files.txt); then
+            echo "::error::Repo-internal files leaked into npm tarball:"
+            printf '  %s\n' $leaks
+            echo "Tighten the \`files\` allowlist in package.json. See skills/skill-repo/references/installation-methods.md."
+            exit 1
+          fi
+          echo "OK: no internal leakage."
+
+      - name: Assert runtime-referenced dirs are present
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Extract relative-path references from skill scripts, e.g. $ROOT/catalog,
+          # ../references, $(realpath ../foo). If the scripts dir does not exist
+          # (skill ships no scripts), skip.
+          if ! compgen -G 'skills/*/scripts/' > /dev/null; then
+            echo "OK: no skill scripts to scan."
+            exit 0
+          fi
+
+          # Collect candidate dir names. `|| true` because grep returns non-zero
+          # when there are no matches — that's a valid empty-result case.
+          refs=$(grep -rhoE '\$\{?ROOT\}?/[a-zA-Z0-9_-]+|\.\./[a-zA-Z0-9_-]+/' skills/*/scripts/ 2>/dev/null || true)
+
+          # Normalize: strip ${ROOT}/, $ROOT/, ../, and trailing slash to get bare dir name.
+          dirs=$(printf '%s\n' "$refs" \
+            | sed -E 's#^\$\{?ROOT\}?/##; s#^\.\./##; s#/$##' \
+            | grep -vE '^(scripts|skills|references)$' \
+            | sort -u)
+
+          if [[ -z "$dirs" ]]; then
+            echo "OK: no top-level runtime references found in skill scripts."
+            exit 0
+          fi
+
+          missing=()
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            # Only assert dirs that actually exist in the repo (i.e. ones the
+            # script truly relies on). A reference to a non-existent dir is a
+            # script bug, not a packaging bug — let other CI catch that.
+            if [[ ! -d "$dir" ]]; then
+              continue
+            fi
+            if ! grep -qE "^${dir}/" tarball-files.txt; then
+              missing+=("$dir")
+            fi
+          done <<< "$dirs"
+
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Runtime-referenced dirs missing from npm tarball:"
+            printf '  %s/\n' "${missing[@]}"
+            echo "Add them to the \`files\` allowlist in package.json — installed scripts read them at runtime."
+            exit 1
+          fi
+          echo "OK: all runtime-referenced dirs are in the tarball."

--- a/skills/skill-repo/templates/.github/workflows/npm-pack-smoke.yml.template
+++ b/skills/skill-repo/templates/.github/workflows/npm-pack-smoke.yml.template
@@ -1,9 +1,19 @@
-# Copy to .github/workflows/npm-pack-smoke.yml in your skill repo (drop the .template suffix).
-# Asserts that `npm pack` produces a tarball that:
-#   1. Does NOT leak repo-internals (.github/, evals/, docs/, Build/, harness scripts, lint configs).
-#   2. Does include every top-level data dir referenced by the installed skill scripts at runtime
-#      (e.g. catalog/, references/) — under-including breaks consumers.
-# See skills/skill-repo/references/installation-methods.md for the rationale.
+# Copy to .github/workflows/npm-pack-smoke.yml in your skill repo (drop the
+# .template suffix). This is a thin caller for the org-level reusable
+# workflow at netresearch/skill-repo-skill — per SKILL.md, skill repos must
+# delegate CI to reusable workflows rather than defining steps inline.
+#
+# What the reusable workflow asserts:
+#   1. No internal leakage — repo-maintenance files (.github/, evals/,
+#      docs/, Build/, harness scripts like verify-harness/generate-dashboard/
+#      run-ab-evals, lint configs, .envrc) must NOT ship in the tarball.
+#   2. Runtime-referenced dirs are present — every top-level dir referenced
+#      by skills/*/scripts/* via $ROOT/<dir> or ../<dir> MUST be in the
+#      tarball, otherwise installed scripts break at runtime.
+#
+# See skills/skill-repo/references/installation-methods.md for the
+# files-allowlist rationale, and references/review-replies.md for canonical
+# replies to reviewer comments about scripts/, AGENTS.md, and similar.
 name: npm Pack Smoke
 
 on:
@@ -16,85 +26,4 @@ permissions:
 
 jobs:
   pack:
-    name: Verify tarball contents
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-
-      - name: npm pack --dry-run
-        shell: bash
-        run: |
-          set -euo pipefail
-          npm pack --dry-run --json > pack.json
-          jq -r '.[0].files[].path' pack.json | sort > tarball-files.txt
-          echo "Tarball contents:"
-          cat tarball-files.txt
-
-      - name: Assert no internal leakage
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Patterns that should NEVER ship in the tarball.
-          # Anchor against `path` (no leading slash, paths are repo-relative).
-          leak_pattern='^\.github/|^evals/|^docs/|^Build/|(^|/)verify-harness\.sh$|(^|/)verify-harness\.py$|^\.markdownlint|^\.yamllint|^\.envrc$'
-          # `grep` returns 1 when no match — we WANT no match, so invert with `if`.
-          if leaks=$(grep -E "$leak_pattern" tarball-files.txt); then
-            echo "::error::Repo-internal files leaked into npm tarball:"
-            printf '  %s\n' $leaks
-            echo "Tighten the \`files\` allowlist in package.json. See skills/skill-repo/references/installation-methods.md."
-            exit 1
-          fi
-          echo "OK: no internal leakage."
-
-      - name: Assert runtime-referenced dirs are present
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Extract relative-path references from skill scripts, e.g. $ROOT/catalog,
-          # ../references, $(realpath ../foo). If the scripts dir does not exist
-          # (skill ships no scripts), skip.
-          if ! compgen -G 'skills/*/scripts/' > /dev/null; then
-            echo "OK: no skill scripts to scan."
-            exit 0
-          fi
-
-          # Collect candidate dir names. `|| true` because grep returns non-zero
-          # when there are no matches — that's a valid empty-result case.
-          refs=$(grep -rhoE '\$\{?ROOT\}?/[a-zA-Z0-9_-]+|\.\./[a-zA-Z0-9_-]+/' skills/*/scripts/ 2>/dev/null || true)
-
-          # Normalize: strip ${ROOT}/, $ROOT/, ../, and trailing slash to get bare dir name.
-          dirs=$(printf '%s\n' "$refs" \
-            | sed -E 's#^\$\{?ROOT\}?/##; s#^\.\./##; s#/$##' \
-            | grep -vE '^(scripts|skills|references)$' \
-            | sort -u)
-
-          if [[ -z "$dirs" ]]; then
-            echo "OK: no top-level runtime references found in skill scripts."
-            exit 0
-          fi
-
-          missing=()
-          while IFS= read -r dir; do
-            [[ -z "$dir" ]] && continue
-            # Only assert dirs that actually exist in the repo (i.e. ones the
-            # script truly relies on). A reference to a non-existent dir is a
-            # script bug, not a packaging bug — let other CI catch that.
-            if [[ ! -d "$dir" ]]; then
-              continue
-            fi
-            if ! grep -qE "^${dir}/" tarball-files.txt; then
-              missing+=("$dir")
-            fi
-          done <<< "$dirs"
-
-          if (( ${#missing[@]} > 0 )); then
-            echo "::error::Runtime-referenced dirs missing from npm tarball:"
-            printf '  %s/\n' "${missing[@]}"
-            echo "Add them to the \`files\` allowlist in package.json — installed scripts read them at runtime."
-            exit 1
-          fi
-          echo "OK: all runtime-referenced dirs are in the tarball."
+    uses: netresearch/skill-repo-skill/.github/workflows/npm-pack-smoke.yml@main

--- a/skills/skill-repo/templates/package.json.template
+++ b/skills/skill-repo/templates/package.json.template
@@ -21,14 +21,10 @@
     "claude-code"
   ],
   "aiAgentSkill": "skills/{skill-name}/SKILL.md",
+  "_filesNote": "REMOVE this _filesNote field before committing. The default `files` allowlist below is intentionally minimal: the skill payload (skills/<name>/), plugin metadata (.claude-plugin/), the canonical agent rules entry-point (AGENTS.md), licenses, and README. Add a top-level dir to `files` ONLY if your skill ships runtime data the installed code reads from there — e.g. catalog/ (cli-tools-skill reads $ROOT/catalog/*.json), hooks/ (Claude Code's plugin loader reads hooks/hooks.json), commands/, outputStyles/, assets/. DO NOT add top-level scripts/ unless your installed skill code actually executes from $ROOT/scripts/ at runtime; one-off repo-maintenance scripts (e.g. verify-harness.sh, generate-dashboard.sh) belong in the repo but MUST stay out of the npm tarball. The npm-pack-smoke CI workflow (templates/.github/workflows/npm-pack-smoke.yml.template) asserts both directions: no internal leakage, and runtime-referenced dirs are present.",
   "files": [
     "skills/{skill-name}/",
     ".claude-plugin/",
-    "hooks/",
-    "scripts/",
-    "commands/",
-    "outputStyles/",
-    "assets/",
     "AGENTS.md",
     "LICENSE-MIT",
     "LICENSE-CC-BY-SA-4.0",


### PR DESCRIPTION
## Summary

Folds 5 lessons learned across the recent multi-PR rollout sweep (14+ skill PRs) back into the skill-repo scaffolding so future repos inherit the fix instead of repeating the review cycle.

## Changes

### 1. `files` hygiene — minimal default (`package.json.template`)

The previous default hard-coded `hooks/`, `scripts/`, `commands/`, `outputStyles/`, `assets/`. Real-world experience showed:
- Top-level `scripts/verify-harness.sh` is **repo-maintenance**, NOT runtime — leaked into tarballs of every npm-installed skill.
- Runtime scripts belong under `skills/<name>/scripts/` (already covered by the `skills/<name>/` entry).

**Default `files` is now minimal:** `skills/<name>/`, `.claude-plugin/`, `AGENTS.md`, licenses, `README.md`. A leading `_filesNote` field documents when to add a top-level dir (only if installed code reads it at runtime).

### 2. Conditional data-dir adds — explicit guidance (`installation-methods.md`)

Method 4 (npm) now explicitly distinguishes:
- **Add to `files` if runtime:** `catalog/` (cli-tools-skill reads `$ROOT/catalog/*.json`), `hooks/` (Claude Code reads `hooks/hooks.json`), `commands/`, `outputStyles/`, `assets/`.
- **Never ship:** `Build/`, `evals/`, `docs/`, `.github/`, lint configs, top-level `scripts/` when repo-maintenance only.

### 3. `AGENTS.md` retained in defaults

Verified `AGENTS.md` survives the trim — still part of the dual-distribution surface.

### 4. Packaging smoketest CI workflow (new template)

New `templates/.github/workflows/npm-pack-smoke.yml.template`. On every PR + push to main:

1. Runs `npm pack --dry-run --json`.
2. **Asserts no internal leakage** — fails if tarball contains `.github/`, `evals/`, `docs/`, `Build/`, `verify-harness.sh`, lint configs.
3. **Asserts runtime-referenced dirs are present** — greps `skills/*/scripts/` for `$ROOT/<dir>` and `../<dir>/` references; fails if a script reads `$ROOT/catalog` but `catalog/` isn't packed.

`set -euo pipefail`, SHA-pinned actions, `contents: read` perms.

### 5. Reviewer-reply boilerplate (`review-replies.md`)

New reference doc with canonical replies for 5 recurring reviewer patterns:

1. `private: true` → accept (template already bakes it in)
2. `github:org/repo#vX.Y.Z` pinning → decline (markdown content, consumers want updates)
3. Drop `.claude-plugin/` / `AGENTS.md` from `files` → decline (dual-distribution invariant)
4. Top-level `scripts/` shouldn't ship → **accept iff repo-maintenance only** (provides criteria for telling apart)
5. `AGENTS.md` shouldn't ship → decline (dual-distribution surface)

Each entry has accept/decline criteria + a paste-ready fenced reply block. Linked from `SKILL.md` References.

## Bonus: dogfood fix

Second commit drops `scripts/` from this repo's own `package.json` `files` — `npm pack --dry-run` confirms the tarball no longer ships `verify-harness.sh`, `generate-dashboard.sh`, `run-ab-evals.sh`. Without this fix the new smoketest workflow would fail on this very PR.

## Verification

- `bash skills/skill-repo/scripts/validate-skill.sh` → 0 errors, 0 warnings
- `npm pack --dry-run --json` on the worktree → 28 paths, none in the leak-pattern denylist
- Smoketest assertion logic dry-run on the worktree → both assertions pass

## Test plan

- [ ] CI on this PR runs the new smoke workflow successfully (once the workflow file lives at `.github/workflows/` it'll trigger; currently only the `.template` exists in `skills/skill-repo/templates/`)
- [ ] Copilot review
- [ ] Gemini review (will likely re-flag dual-distribution items #3/#5 — apply boilerplate from `review-replies.md`)
- [ ] Validate next scaffolded skill repo picks up minimal `files` default

Sibling commits: see PR #83 for the original npm-defaults baking that this iterates on.