### PR TITLE
docs(readme): make repo layout sections accurate and de-duplicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,31 @@ The skill triggers on keywords like:
 
 ### Repository Layout
 
+The standard layout for a Netresearch skill repository (one or more skills per repo):
+
 ```
-{skill-name}/
-├── SKILL.md              # AI instructions
-├── README.md             # Human documentation
-├── LICENSE-MIT           # Code license (MIT)
-├── LICENSE-CC-BY-SA-4.0  # Content license (CC-BY-SA-4.0)
-├── composer.json         # PHP distribution
-├── references/           # Extended docs
-├── scripts/              # Automation
-├── assets/               # Templates
-└── .github/workflows/    # CI/CD
+{name}-skill/
+├── AGENTS.md                        # Agent rules / harness index
+├── README.md                        # Human documentation
+├── LICENSE-MIT                      # Code license (MIT)
+├── LICENSE-CC-BY-SA-4.0             # Content license (CC-BY-SA-4.0)
+├── composer.json                    # PHP distribution
+├── package.json                     # Node distribution (optional)
+├── renovate.json                    # Dependency automation
+├── .claude-plugin/
+│   └── plugin.json                  # Marketplace metadata
+├── .github/workflows/               # CI (typically calls reusable workflows)
+├── Build/                           # Build scripts and git hooks
+├── docs/                            # Architecture, ADRs, dashboards
+├── scripts/                         # Repo-level automation
+└── skills/
+    └── {skill-name}/
+        ├── SKILL.md                 # AI instructions
+        ├── checkpoints.yaml         # Assessment checkpoints (optional)
+        ├── evals/                   # Skill evaluations
+        ├── references/              # Extended docs
+        ├── scripts/                 # Skill automation
+        └── templates/               # Bootstrap templates
 ```
 
 ### Installation Methods
@@ -131,26 +145,38 @@ The skill triggers on keywords like:
 - `"require": {"netresearch/composer-agent-skill-plugin": "*"}`
 - `"extra": {"ai-agent-skill": "SKILL.md"}`
 
-## Structure
+## This Repository
+
+`skill-repo-skill` dogfoods the layout above and additionally hosts reusable CI workflows consumed by other Netresearch skill repos:
 
 ```
 skill-repo-skill/
-├── SKILL.md                      # AI instructions
-├── README.md                     # This file
-├── LICENSE-MIT                   # Code license (MIT)
-├── LICENSE-CC-BY-SA-4.0          # Content license (CC-BY-SA-4.0)
-├── composer.json                 # PHP distribution
-├── templates/
-│   ├── README.md.template        # README template for skills
-│   ├── composer.json.template    # Composer template
-│   └── release.yml.template      # Release workflow template
-├── references/
-│   ├── installation-methods.md   # Detailed install guides
-│   ├── composer-setup.md         # Composer integration
-│   └── marketplace-integration.md
-└── scripts/
-    └── validate-skill.sh         # Validation script
+├── .claude-plugin/plugin.json
+├── .github/workflows/             # Reusable workflows (validate, release,
+│                                  #   auto-merge-deps, npm-pack-smoke, ...)
+├── Build/
+│   ├── Scripts/check-plugin-version.sh
+│   └── hooks/                     # pre-commit, pre-push
+├── docs/
+│   ├── ARCHITECTURE.md
+│   └── dashboard/                 # Cross-skill metrics dashboard
+├── scripts/                       # Repo-level: generate-dashboard, run-ab-evals,
+│                                  #   verify-harness
+├── tests/                         # Eval fixtures
+└── skills/skill-repo/
+    ├── SKILL.md
+    ├── checkpoints.yaml
+    ├── evals/evals.json
+    ├── references/                # composer-setup, installation-methods,
+    │                              #   marketplace-integration, release-discipline,
+    │                              #   review-replies
+    ├── scripts/                   # validate-skill, validate-evals,
+    │                              #   migrate-licensing, check-version-parity
+    └── templates/                 # README, composer.json, package.json,
+                                   #   release.yml, pr-quality.yml, licenses, hooks
 ```
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for component responsibilities.
 
 ## Extends Anthropic's Skill Creator
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ The standard layout for a Netresearch skill repository (one or more skills per r
 
 - `"type": "ai-agent-skill"`
 - `"require": {"netresearch/composer-agent-skill-plugin": "*"}`
-- `"extra": {"ai-agent-skill": "SKILL.md"}`
+- `"extra": {"ai-agent-skill": "skills/{skill-name}/SKILL.md"}` (path to the
+  nested `SKILL.md`; for single-skill repos this is `skills/{repo-slug}/SKILL.md`)
 
 ## This Repository
 
@@ -151,29 +152,43 @@ The standard layout for a Netresearch skill repository (one or more skills per r
 
 ```
 skill-repo-skill/
+├── AGENTS.md
+├── README.md
+├── LICENSE-MIT
+├── LICENSE-CC-BY-SA-4.0
+├── SECURITY-AUDIT.md
+├── composer.json
+├── package.json
+├── renovate.json
 ├── .claude-plugin/plugin.json
-├── .github/workflows/             # Reusable workflows (validate, release,
-│                                  #   auto-merge-deps, npm-pack-smoke, ...)
+├── .github/workflows/             # Reusable workflows hosted here:
+│                                  #   validate, release, pr-quality,
+│                                  #   harness-verify, eval-validate,
+│                                  #   validate-agents, dependency-audit,
+│                                  #   npm-pack-smoke, ci-python
+│                                  # (auto-merge runs via a thin caller that
+│                                  #  delegates to netresearch/.github)
 ├── Build/
 │   ├── Scripts/check-plugin-version.sh
 │   └── hooks/                     # pre-commit, pre-push
 ├── docs/
 │   ├── ARCHITECTURE.md
 │   └── dashboard/                 # Cross-skill metrics dashboard
-├── scripts/                       # Repo-level: generate-dashboard, run-ab-evals,
-│                                  #   verify-harness
+├── scripts/                       # Repo-level: generate-dashboard,
+│                                  #   run-ab-evals, verify-harness
 ├── tests/                         # Eval fixtures
 └── skills/skill-repo/
     ├── SKILL.md
     ├── checkpoints.yaml
     ├── evals/evals.json
     ├── references/                # composer-setup, installation-methods,
-    │                              #   marketplace-integration, release-discipline,
-    │                              #   review-replies
+    │                              #   marketplace-integration,
+    │                              #   release-discipline, review-replies
     ├── scripts/                   # validate-skill, validate-evals,
     │                              #   migrate-licensing, check-version-parity
     └── templates/                 # README, composer.json, package.json,
-                                   #   release.yml, pr-quality.yml, licenses, hooks
+                                   #   release.yml, pr-quality.yml,
+                                   #   licenses, hooks
 ```
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for component responsibilities.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,8 +15,16 @@ skill-repo-skill defines the standard structure for all Netresearch skill reposi
 Located in `.github/workflows/`, these are called by other skill repos via `uses: netresearch/skill-repo-skill/.github/workflows/<name>.yml@main`:
 
 - **`validate.yml`** -- Main validation pipeline. Runs structure checks, frontmatter validation, licensing, metadata consistency, markdown/YAML lint, ShellCheck, Python lint, and checkpoint schema validation.
-- **`auto-merge-deps.yml`** -- Auto-merges Dependabot/Renovate PRs after CI passes.
 - **`release.yml`** -- Triggered on `v*` tags. Validates tag matches `plugin.json` version, packages each skill standalone and full plugin with checksums.
+- **`pr-quality.yml`** -- PR quality gates (auto-approve coordination, etc.).
+- **`harness-verify.yml`** -- Verifies AGENTS.md / harness consistency.
+- **`eval-validate.yml`** -- Validates skill evaluation files.
+- **`validate-agents.yml`** -- Validates `AGENTS.md` content.
+- **`dependency-audit.yml`** -- Composer audit, SAST, dependency review.
+- **`npm-pack-smoke.yml`** -- Verifies the npm tarball ships the right files.
+- **`ci-python.yml`** -- Reusable Python lint/test pipeline.
+
+Auto-merge for Dependabot/Renovate PRs is delegated to `netresearch/.github/.github/workflows/auto-merge-deps.yml@main` via the local caller `auto-merge-deps-caller.yml`; it is **not** hosted in this repo.
 
 ### Validation Scripts
 

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -94,23 +94,27 @@ The skill triggers on keywords like:
 ## Structure
 
 ```
-{skill-name}/
-├── SKILL.md              # AI instructions
-├── README.md             # This file
-├── LICENSE-MIT           # Code license (MIT)
-├── LICENSE-CC-BY-SA-4.0  # Content license (CC-BY-SA-4.0)
-├── composer.json         # PHP distribution
-├── references/           # Extended documentation
-│   └── ...
-├── scripts/              # Automation scripts
-│   └── ...
-└── assets/               # Templates, configs
-    └── ...
+{repo-name}/
+├── AGENTS.md                       # Agent rules / harness index
+├── README.md                       # This file
+├── LICENSE-MIT                     # Code license (MIT)
+├── LICENSE-CC-BY-SA-4.0            # Content license (CC-BY-SA-4.0)
+├── composer.json                   # PHP distribution
+├── package.json                    # Node distribution (optional)
+├── renovate.json                   # Dependency automation
+├── .claude-plugin/plugin.json      # Marketplace metadata
+├── .github/workflows/              # CI (typically calls reusable workflows)
+└── skills/
+    └── {skill-name}/
+        ├── SKILL.md                # AI instructions
+        ├── references/             # Extended documentation
+        ├── scripts/                # Automation scripts
+        └── templates/              # Bootstrap templates
 ```
 
 ## References
 
-- `references/example.md` - Description
+- `skills/{skill-name}/references/example.md` - Description
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

The README had two near-duplicate file-tree sections (`### Repository Layout` and `## Structure`) that both described an outdated single-skill-per-repo layout — top-level `SKILL.md`, top-level `references/`/`scripts/`/`templates/`, and a fictional `assets/` directory. None of the 29+ Netresearch skill repos actually use that layout; they all nest under `skills/{skill-name}/`.

- **`### Repository Layout`** now shows the canonical multi-skill layout with `skills/{skill-name}/` nesting and the real top-level files (`AGENTS.md`, `.claude-plugin/plugin.json`, `Build/`, `docs/`, `renovate.json`, `package.json`).
- **`## Structure`** renamed to **`## This Repository`** and rewritten to list what this repo actually contains — including the reusable CI workflows it hosts for other skill repos. Adds a pointer to [`docs/ARCHITECTURE.md`](../blob/main/docs/ARCHITECTURE.md).
- Drops the fictional `assets/` directory.

The two sections now serve distinct purposes (generic standard vs. dogfooded instance) instead of being two stale copies of the same tree.

## Test plan

- [x] Verified actual layout matches new "Repository Layout" against `git-workflow-skill`, `github-project-skill`, `go-development-skill`, `agent-harness-skill`, and `skill-repo-skill` itself
- [x] Cross-checked `## This Repository` against `find skills/skill-repo` and `docs/ARCHITECTURE.md`
- [x] `markdownlint-cli2 README.md` passes (0 errors)
- [x] CI green