### PR TITLE
fix: rewrite SR-21/SR-31 for runner allowlist; update stale SR-35 prompt

### DIFF
--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -295,9 +295,18 @@ llm_reviews:
     desc: "Caller release workflow permissions must satisfy all shared workflow job requirements"
     prompt: |
       Review .github/workflows/release.yml as a caller of a reusable workflow.
-      The shared workflow requires: contents: write and pull-requests: write.
+      After the bump-job removal in skill-repo-skill PR #15, the shared workflow
+      no longer creates release PRs, so `pull-requests: write` is NOT required.
+      The release job needs:
+        - contents: write       (for publishing the GitHub Release)
+        - id-token: write       (OIDC for sigstore: cosign sign-blob + attest)
+        - attestations: write   (GitHub native attestation API for SLSA build provenance)
       GitHub validates ALL job-level permissions at startup, even for skipped jobs.
-      Check: Does the caller grant both? Flag missing permissions as error (causes startup_failure).
+      Check: Does the caller grant all three? Flag missing permissions as error
+      (missing id-token: write or attestations: write causes the cosign / attest
+      steps to fail; missing contents: write blocks release creation).
+      Note: An older revision of this checkpoint required `pull-requests: write`
+      for the now-removed auto-bump path. Do not flag its absence.
 
   - id: SR-36
     domain: release

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -158,7 +158,12 @@ mechanical:
     type: command
     # Rewritten to satisfy the runner's command allowlist (no `;`, no `$()`):
     # pipe `find` → `head` → `xargs wc -w` → `awk` for the threshold check.
-    pattern: "find . -path '*/SKILL.md' -not -path './.skill-repo-tools/*' | head -1 | xargs -r wc -w | awk '$1<=500 {exit 0} {exit 1}'"
+    # awk uses {if ($1<=500) ok=1} END {exit !ok} so empty input (no SKILL.md
+    # found, or one filtered out by `-not -path`) exits non-zero — preventing
+    # the previous vacuous-pass when no SKILL.md existed.
+    # `-not -path './node_modules/*'` matches the precondition filter so SKILL.md
+    # files inside dependencies don't trigger false positives.
+    pattern: "find . -path '*/SKILL.md' -not -path './.skill-repo-tools/*' -not -path './node_modules/*' | head -1 | xargs -r wc -w | awk '{if ($1<=500) ok=1} END {exit !ok}'"
     severity: error
     desc: "SKILL.md must be under 500 words"
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -225,7 +225,11 @@ mechanical:
   - id: SR-30
     type: regex
     target: .github/workflows/release.yml
-    pattern: "^\\s*tags:"
+    # Use POSIX bracket class instead of `\s`. The runner's YAML parser
+    # captures the raw text between double quotes, so `\\s` reaches grep
+    # as literal backslash-s and never matches. `[[:space:]]` works under
+    # both grep -E and grep -P regardless of YAML escape semantics.
+    pattern: "^[[:space:]]*tags:"
     severity: error
     desc: "Release workflow must trigger on tag push (releases require a signed annotated tag pushed locally)"
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -156,7 +156,9 @@ mechanical:
   # SKILL.md checks
   - id: SR-21
     type: command
-    pattern: "word_count=$(wc -w < $(find . -path '*/SKILL.md' -not -path './.skill-repo-tools/*' | head -1)); [ $word_count -le 500 ]"
+    # Rewritten to satisfy the runner's command allowlist (no `;`, no `$()`):
+    # pipe `find` → `head` → `xargs wc -w` → `awk` for the threshold check.
+    pattern: "find . -path '*/SKILL.md' -not -path './.skill-repo-tools/*' | head -1 | xargs -r wc -w | awk '$1<=500 {exit 0} {exit 1}'"
     severity: error
     desc: "SKILL.md must be under 500 words"
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -236,10 +236,17 @@ mechanical:
   - id: SR-31
     type: command
     # Strip full-line comments before scanning so the docstring describing
-    # the historical anti-pattern doesn't trip the check.
-    pattern: "! awk 'NF && $0 !~ /^[[:space:]]*#/' .github/workflows/release.yml | grep -qE '^[[:space:]]*workflow_dispatch:|--admin'"
+    # the historical anti-pattern doesn't trip the check. The previous
+    # `awk 'NF && $0 !~ /…/'` form contained `&&`, which the runner's
+    # allowlist rejects as a command-chaining metacharacter — replaced
+    # with a `grep -v` comment-strip pipeline that uses only `|`.
+    # Policy enforced (per skill-repo-skill PR #15, which removed the
+    # bump-job): no `workflow_dispatch:` trigger and no `--admin` merge
+    # in the caller release workflow. Manual dispatch on the wrapper
+    # would re-introduce the unsigned-tag bug the bump-job removal fixed.
+    pattern: "! grep -v '^[[:space:]]*#' .github/workflows/release.yml | grep -qE '^[[:space:]]*workflow_dispatch:|--admin'"
     severity: warning
-    desc: "Release workflow should not declare workflow_dispatch or use --admin merges — the auto-bump path produced unsigned tags. Use signed tag-push only."
+    desc: "Release workflow should not declare workflow_dispatch or use --admin merges — the auto-bump path produced unsigned tags. Use signed tag-push only (see skill-repo-skill PR #15)."
 
 llm_reviews:
   - id: SR-32


### PR DESCRIPTION
## Summary

Four targeted fixes to `skills/skill-repo/checkpoints.yaml`. Three checkpoints (SR-21, SR-30, SR-31) were reporting failures that were not actual policy violations but artefacts of how the assessment runner parses YAML and validates commands; SR-35's LLM-review prompt still encoded a permission requirement that was retired by #15 (bump-job removal).

Baseline (before): 27 pass, 5 fail
Final (after): 30 pass, 2 fail

The two remaining failures (SR-16, SR-28) are about `.github/workflows/auto-merge-deps.yml` not existing in this repo — unrelated to this PR.

## Changes (one commit each)

### c5ca8e6 SR-21 — runner allowlist

`pattern` used `wc -w < $(find ...)` and `;` to chain a threshold compare. The runner's allowlist (`is_safe_eval_command` in `automated-assessment/scripts/run-checkpoints.sh`) rejects both `$(` substring and `;` chaining metacharacter. Result: "Command rejected" before policy was even evaluated.

Rewrite as `find … | head -1 | xargs -r wc -w | awk '$1<=500 {exit 0} {exit 1}'` — pure pipeline, only `|` chaining. Same form proven in netresearch/agent-harness-skill PR #20.

Severity unchanged (`error`): the 500-word SKILL.md cap is intentional.

### 222bf5e SR-30 — regex syntax for the runner

`pattern: "^\\s*tags:"` was failing against a release.yml that does contain `    tags:` at line 57. Investigation: the runner's YAML "parser" is a bash regex over the raw line; the captured `current_pattern` is the literal text between the quotes (`^\\s*tags:`, with two backslashes), which `grep -P` then interprets as `\` + `s` rather than the whitespace metacharacter. Switching to `^[[:space:]]*tags:` works under both `grep -P` and `grep -E` and is unaffected by YAML-escape semantics.

This was a runner-quirk + YAML-quoting interaction, not a real policy failure. Policy and severity (`error`) unchanged: signed-tag-push remains the sole release trigger after #15.

### 05e80a4 SR-31 — runner allowlist (preserve policy)

`pattern` used `awk 'NF && $0 !~ /^[[:space:]]*#/'` to strip full-line comments before searching. The literal `&&` inside the awk program is rejected by the runner's chaining-metacharacter check (it cannot tell awk-internal `&&` from shell chaining). Result: "Command rejected" before policy evaluation.

Replace with `! grep -v '^[[:space:]]*#' release.yml | grep -qE 'BAD_PATTERN'` — only `|` chaining. Negative test confirmed: when a synthetic `workflow_dispatch:` is present, the new command exits 1 (fails the checkpoint, as it should).

Policy unchanged: per #15 (bump-job removal), caller release workflows must not introduce a `workflow_dispatch:` trigger or `--admin` merges that would re-introduce the unsigned-tag bug. Severity unchanged (`warning`). Description now references PR #15 for context.

### df46b57 SR-35 — stale LLM-review prompt

The prompt told the reviewer the shared release workflow requires `contents: write` and `pull-requests: write`. That has not been true since #15 removed the bump job — the reusable workflow no longer creates release PRs, so `pull-requests: write` is not needed. The current shared workflow needs three permissions on the calling job:

- `contents: write` — publish the GitHub Release
- `id-token: write` — OIDC for cosign sign-blob + attest
- `attestations: write` — GitHub native attestation API for SLSA build provenance

Updated the prompt to check for the right set and explicitly told the reviewer not to flag absence of `pull-requests: write`. Severity unchanged (`error`): missing any of the three actually-required permissions causes the release job to fail at startup or mid-run.

## Test plan

- [x] Run baseline before changes — confirmed 5 failures (SR-16, SR-21, SR-28, SR-30, SR-31)
- [x] After each commit, re-run runner — verified targeted checkpoint moves to pass without regressing others
- [x] After all four commits — final state 30 pass, 2 fail (SR-16, SR-28; both unrelated to this PR)
- [x] Negative test SR-31 — synthetic release.yml with `workflow_dispatch:` correctly fails the new check
- [x] Verified SR-30 regex matches with both `grep -P` and `grep -E`
- [ ] Reviewer to confirm SR-35 prompt rewording matches current shared-workflow expectations