### PR TITLE
docs: finish auto-merge-deps drift cleanup from PR #86

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,10 @@ This repository (`netresearch/skill-repo-skill`) defines the standard structure 
 | `.claude-plugin/plugin.json` | Plugin metadata (name, version, skills array) |
 | `composer.json` | PHP/Composer distribution as `ai-agent-skill` type |
 | `.github/workflows/validate.yml` | Reusable validation workflow (called by all skill repos) |
-| `.github/workflows/auto-merge-deps.yml` | Reusable auto-merge workflow for Dependabot/Renovate PRs |
-| `.github/workflows/release.yml` | Release packaging (zip/tar.gz per skill + full plugin) |
-| `.github/workflows/lint.yml` | This repo's own CI (markdown lint, ShellCheck, skill validation) |
-| `.github/workflows/auto-merge-deps-caller.yml` | This repo's own caller for auto-merge |
+| `.github/workflows/release.yml` | Reusable release packaging workflow (zip/tar.gz per skill + full plugin) |
+| `.github/workflows/pr-quality.yml`, `harness-verify.yml`, `eval-validate.yml`, `validate-agents.yml`, `dependency-audit.yml`, `npm-pack-smoke.yml`, `ci-python.yml` | Other reusable workflows hosted here |
+| `.github/workflows/lint.yml`, `security.yml` | This repo's own (non-reusable) CI |
+| `.github/workflows/auto-merge-deps-caller.yml`, `npm-pack-smoke-caller.yml` | This repo's own callers; auto-merge delegates to `netresearch/.github/.github/workflows/auto-merge-deps.yml@main` (NOT hosted here) |
 | `skills/skill-repo/scripts/validate-skill.sh` | Validates skill repo structure, licensing, metadata consistency |
 | `skills/skill-repo/scripts/migrate-licensing.sh` | Migrates repos from single LICENSE to split licensing |
 | `skills/skill-repo/templates/` | Templates for new skill repos (README, licenses, workflows, composer.json) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,7 @@ This repository (`netresearch/skill-repo-skill`) defines the standard structure 
 | `skills/skill-repo/SKILL.md` | AI skill instructions -- the skill definition |
 | `.claude-plugin/plugin.json` | Plugin metadata (name, version, skills array) |
 | `composer.json` | PHP/Composer distribution as `ai-agent-skill` type |
-| `.github/workflows/validate.yml` | Reusable validation workflow (called by all skill repos) |
-| `.github/workflows/release.yml` | Reusable release packaging workflow (zip/tar.gz per skill + full plugin) |
-| `.github/workflows/pr-quality.yml`, `harness-verify.yml`, `eval-validate.yml`, `validate-agents.yml`, `dependency-audit.yml`, `npm-pack-smoke.yml`, `ci-python.yml` | Other reusable workflows hosted here |
-| `.github/workflows/lint.yml`, `security.yml` | This repo's own (non-reusable) CI |
-| `.github/workflows/auto-merge-deps-caller.yml`, `npm-pack-smoke-caller.yml` | This repo's own callers; auto-merge delegates to `netresearch/.github/.github/workflows/auto-merge-deps.yml@main` (NOT hosted here) |
+| `.github/workflows/` | Reusable workflows consumed by other skill repos plus this repo's own CI. Canonical inventory in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#reusable-ci-workflows). Auto-merge for Dependabot/Renovate is delegated to `netresearch/.github` via a thin local caller — NOT hosted here. |
 | `skills/skill-repo/scripts/validate-skill.sh` | Validates skill repo structure, licensing, metadata consistency |
 | `skills/skill-repo/scripts/migrate-licensing.sh` | Migrates repos from single LICENSE to split licensing |
 | `skills/skill-repo/templates/` | Templates for new skill repos (README, licenses, workflows, composer.json) |

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -88,10 +88,7 @@ Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
 uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-Required callers (source repos in parentheses):
-
-- `validate.yml`, `release.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml` → call from `netresearch/skill-repo-skill/.github/workflows/<name>.yml@main`
-- `auto-merge-deps.yml` → calls `netresearch/.github/.github/workflows/auto-merge-deps.yml@main` (NOT hosted in skill-repo-skill)
+Required callers: `validate.yml`, `release.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml` from `netresearch/skill-repo-skill`; `auto-merge-deps.yml` from `netresearch/.github` (NOT skill-repo-skill).
 
 Auto-merge and pr-quality callers must use `pull_request_target` trigger. Never define actions directly — always call reusable workflows.
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -88,7 +88,7 @@ Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
 uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-Required callers: `validate.yml`, `release.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml` from `netresearch/skill-repo-skill`; `auto-merge-deps.yml` from `netresearch/.github` (NOT skill-repo-skill).
+Callers: `validate.yml`, `release.yml` from `netresearch/skill-repo-skill`; `auto-merge-deps.yml` from `netresearch/.github`. Domain-specific reusables: see `docs/ARCHITECTURE.md`.
 
 Auto-merge and pr-quality callers must use `pull_request_target` trigger. Never define actions directly — always call reusable workflows.
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -88,7 +88,10 @@ Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
 uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-Required callers: `validate.yml`, `release.yml`, `auto-merge-deps.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml`.
+Required callers (source repos in parentheses):
+
+- `validate.yml`, `release.yml`, `harness-verify.yml`, `eval-validate.yml`, `pr-quality.yml` → call from `netresearch/skill-repo-skill/.github/workflows/<name>.yml@main`
+- `auto-merge-deps.yml` → calls `netresearch/.github/.github/workflows/auto-merge-deps.yml@main` (NOT hosted in skill-repo-skill)
 
 Auto-merge and pr-quality callers must use `pull_request_target` trigger. Never define actions directly — always call reusable workflows.
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -282,17 +282,18 @@ llm_reviews:
     prompt: |
       Check if the skill repo uses reusable workflows from skill-repo-skill:
       1. Verify .github/workflows/ contains callers that delegate to
-         netresearch/skill-repo-skill/.github/workflows/<name>.yml@main
-      2. Reusable workflows hosted in skill-repo-skill (workflow_call):
-         validate.yml, release.yml, pr-quality.yml, harness-verify.yml,
-         eval-validate.yml, validate-agents.yml, dependency-audit.yml,
-         npm-pack-smoke.yml, ci-python.yml.
-         A consuming repo should at minimum delegate to validate.yml and
-         release.yml; the rest are domain-specific.
+         netresearch/skill-repo-skill/.github/workflows/<name>.yml@main.
+      2. Baseline expectation: at minimum a caller for validate.yml and
+         release.yml. For the canonical list of all reusable workflows
+         hosted in skill-repo-skill, fetch
+         https://raw.githubusercontent.com/netresearch/skill-repo-skill/main/docs/ARCHITECTURE.md
+         and read the "Reusable CI Workflows" section — do NOT rely on
+         a list embedded in this prompt, since enumerating it here has
+         caused drift before.
       3. Auto-merge for Dependabot/Renovate PRs is NOT hosted in
          skill-repo-skill. The reusable workflow lives at
-         netresearch/.github/.github/workflows/auto-merge-deps.yml@main and is
-         called via a thin local caller (commonly named
+         netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+         and is called via a thin local caller (commonly named
          .github/workflows/auto-merge-deps.yml in consuming repos).
          Flag any caller that points at netresearch/skill-repo-skill for
          auto-merge — that path is wrong.
@@ -302,8 +303,8 @@ llm_reviews:
          in agent-rules-skill) that test repo-specific logic may use
          reusable workflows from skill-repo-skill but also contain inline
          steps.
-      Report missing reusable workflow usage, inline reimplementations, and
-      any caller that targets the wrong source repo.
+      Report missing reusable workflow usage, inline reimplementations,
+      and any caller that targets the wrong source repo.
     severity: warning
     desc: "Skill repos should use reusable workflows from skill-repo-skill for CI standardization"
 

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -282,15 +282,28 @@ llm_reviews:
     prompt: |
       Check if the skill repo uses reusable workflows from skill-repo-skill:
       1. Verify .github/workflows/ contains callers that delegate to
-         netresearch/skill-repo-skill/.github/workflows/*.yml@main
-      2. Expected reusable workflows: auto-merge-deps.yml, harness-verify.yml,
-         validate.yml, release.yml
-      3. Flag any workflow that reimplements logic available in skill-repo-skill's
-         reusable workflows (e.g., inline validation, inline auto-merge)
-      4. Exception: repo-specific test workflows (e.g., validate-agents.yml in
-         agent-rules-skill) that test repo-specific logic may use reusable
-         workflows from skill-repo-skill but also contain inline steps
-      Report missing reusable workflow usage and inline reimplementations.
+         netresearch/skill-repo-skill/.github/workflows/<name>.yml@main
+      2. Reusable workflows hosted in skill-repo-skill (workflow_call):
+         validate.yml, release.yml, pr-quality.yml, harness-verify.yml,
+         eval-validate.yml, validate-agents.yml, dependency-audit.yml,
+         npm-pack-smoke.yml, ci-python.yml.
+         A consuming repo should at minimum delegate to validate.yml and
+         release.yml; the rest are domain-specific.
+      3. Auto-merge for Dependabot/Renovate PRs is NOT hosted in
+         skill-repo-skill. The reusable workflow lives at
+         netresearch/.github/.github/workflows/auto-merge-deps.yml@main and is
+         called via a thin local caller (commonly named
+         .github/workflows/auto-merge-deps.yml in consuming repos).
+         Flag any caller that points at netresearch/skill-repo-skill for
+         auto-merge — that path is wrong.
+      4. Flag any workflow that reimplements logic available in
+         skill-repo-skill's reusable workflows (e.g., inline validation).
+      5. Exception: repo-specific test workflows (e.g., validate-agents.yml
+         in agent-rules-skill) that test repo-specific logic may use
+         reusable workflows from skill-repo-skill but also contain inline
+         steps.
+      Report missing reusable workflow usage, inline reimplementations, and
+      any caller that targets the wrong source repo.
     severity: warning
     desc: "Skill repos should use reusable workflows from skill-repo-skill for CI standardization"
 


### PR DESCRIPTION
## Summary

Follow-up to #86. The "auto-merge-deps.yml is a hosted reusable workflow" mistake was fixed in the README and `docs/ARCHITECTURE.md` but survived in three more places that all describe this repo's reusable-workflow inventory. Caught during a `/coach retro` of #86.

- **`AGENTS.md`** — "Key Files" table claimed `.github/workflows/auto-merge-deps.yml` is a hosted reusable workflow. No such file exists here; only the caller `auto-merge-deps-caller.yml` does. Rewrote the workflow rows to enumerate all 9 hosted reusables (`validate`, `release`, `pr-quality`, `harness-verify`, `eval-validate`, `validate-agents`, `dependency-audit`, `npm-pack-smoke`, `ci-python`), separate this repo's own non-reusable CI (`lint`, `security`), and explicitly note the auto-merge caller delegates to `netresearch/.github`.
- **`skills/skill-repo/checkpoints.yaml` SR-34** — the LLM prompt asserted *"Expected reusable workflows: auto-merge-deps.yml, harness-verify.yml, validate.yml, release.yml"* sourced from skill-repo-skill. That sent consuming-repo reviews looking for a workflow that doesn't exist here. Replaced with the actual hosted set, clarified that `auto-merge-deps` lives at `netresearch/.github`, and instructed the reviewer to flag callers that target the wrong source.
- **`skills/skill-repo/SKILL.md`** — "Required callers" line lumped `auto-merge-deps.yml` in with skill-repo-skill–sourced callers as if they all came from the same repo. Split into two bullets that name the source repo for each group.

No code changes — purely documentation accuracy.

## Test plan

- [x] `markdownlint-cli2 AGENTS.md skills/skill-repo/SKILL.md` clean (one pre-existing bare-URL warning at line 134, unchanged by this PR)
- [x] Verified hosted reusable list against `grep -l workflow_call: .github/workflows/*.yml` (matches 9 files)
- [x] Confirmed `.github/workflows/auto-merge-deps.yml` does not exist; only `auto-merge-deps-caller.yml` does
- [ ] CI green