### PR TITLE
fix(skill-validation): silence cache-dependency-glob warning in setup-uv

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,18 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # Skill repos are documentation/markdown packages and never ship Python
+          # dependency files (requirements*.txt, pyproject.toml, uv.lock). Setting
+          # the glob to empty skips dependency-file discovery entirely, which:
+          #   1. Silences the "No file matched to [...]" warning that otherwise
+          #      surfaces as an annotation on every consumer PR.
+          #   2. Preserves the cache key suffix (-no-dependency-glob) the action
+          #      already falls back to today, so cache hit/miss behavior is
+          #      unchanged for repos without lockfiles.
+          # uv is used here for ad-hoc `uvx ruff` / `uv run --with pyyaml`
+          # invocations that don't depend on a project lockfile.
+          cache-dependency-glob: ""
 
       - name: Run skill validation
         run: bash .skill-repo-tools/skills/skill-repo/scripts/validate-skill.sh .


### PR DESCRIPTION
## Summary

Adds `cache-dependency-glob: ""` to the `astral-sh/setup-uv` step in the reusable Skill Validation workflow so it stops emitting the `No file matched to [...]` warning on every consumer skill repo CI run.

## Reproduce

The warning surfaces as a `warning`-level annotation on every consumer PR running the reusable validate workflow. Example:

- [netresearch/git-workflow-skill#42 — Lint run 25402462409](https://github.com/netresearch/git-workflow-skill/actions/runs/25402462409) → `Skill Validation` job

Annotation text (verified via `gh api repos/netresearch/git-workflow-skill/check-runs/74505216035/annotations`):

> No file matched to [.../**/*requirements*.txt, .../**/*requirements*.in, .../**/*constraints*.txt, .../**/*constraints*.in, .../**/pyproject.toml, .../**/uv.lock, .../**/*.py.lock]. The cache will never get invalidated. Make sure you have checked out the target repository and configured the cache-dependency-glob input correctly.

## Root cause

`astral-sh/setup-uv` defaults `cache-dependency-glob` to a fixed list of Python lockfile globs. Skill repos are documentation/markdown packages — none of those files exist — so the glob always matches zero files and the action emits a warning on every run.

## Fix

Set `cache-dependency-glob: ""`. Per [`src/cache/restore-cache.ts`](https://github.com/astral-sh/setup-uv/blob/main/src/cache/restore-cache.ts) in setup-uv, the warning is gated by `cacheDependencyGlob !== ""`, so an empty glob skips dependency-file discovery entirely and silences the warning at its source.

## Why not the alternatives

- **`ignore-nothing-to-cache: true`** — does NOT gate this warning. Per the action source, that input only suppresses a different post-run "no cache paths found" error in `save-cache.ts`. Verified by reading the source before committing.
- **Custom inclusive glob (`**/SKILL.md`, etc.)** — would invalidate the cache on every skill content change for no benefit; the cache is for uv's tool installs, not for skill content.
- **`enable-cache: false`** — would force `uvx ruff` / `uv run --with pyyaml` to redownload every run (~5-10s slower per consumer). Worth keeping the cache.
- **Removing `Set up uv` entirely** — uv is genuinely used for `uvx ruff check/format` (Python lint step) and `uv run --with pyyaml` (checkpoint schema validation), so it must stay.

## Behavior verification

- **Repos WITHOUT lockfiles (today's reality, all skill repos):** Cache key suffix in production logs is `setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-pruned-no-dependency-glob`. With this PR, the same `-no-dependency-glob` suffix is produced (the action's `computeKeys()` falls through to that suffix when the hash is `-`), so cache hit/miss behavior is byte-identical to today — minus the warning.
- **Repos WITH a lockfile:** Skill repos do not ship Python lockfiles by design (verified by tree-grep across all `*-skill` repos). If that ever changes, the empty glob will skip caching — a deliberate trade-off; the validate workflow is shared across all consumers and should optimize for the common case.

## Test plan

- [ ] CI on this PR is green with no `cache-dependency-glob` annotation
- [ ] After merge, re-run `Lint` workflow on `netresearch/git-workflow-skill` (PR #42 / latest main) and confirm the warning annotation is gone
- [ ] Spot-check `netresearch/github-project-skill` (PR #71 / latest main) for the same

## Coordination

Touches only the `Set up uv` step block. Does NOT touch `gitleaks/gitleaks-action` or `actions/dependency-review-action` references — those belong to a parallel PR bumping them to Node-24.