### PR TITLE
feat: add SKILL.md quality rules and audit script

### DIFF
--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -3,9 +3,9 @@
 # Usage: ./audit-skills.sh [--help] [--json] [DIR ...]
 #
 # Scans SKILL.md files and reports:
-#   - DESCRIPTION length (PASS/WARN/FAIL)
-#   - BODY word count (PASS/WARN) and line metrics
-#   - CODE FENCE longest block (PASS/INFO at >30 lines)
+#   - DESCRIPTION length (PASS/WARN >500 chars/FAIL >1536 chars)
+#   - BODY word count (PASS/INFO >500/WARN >1000/FAIL >2000) and line metrics
+#   - CODE FENCE longest block (PASS/INFO at >25 lines)
 #   - REFERENCES reachability (P1 direct cite, P2 catalog convention,
 #                              P3 list-and-pick, ORPHAN otherwise)
 # Exit: 0 if no FAILs, 1 otherwise.
@@ -194,11 +194,15 @@ audit_one() {
     # --- Frontmatter & description ---
     local fm desc desc_status="PASS" desc_len=0 desc_warn_msg=""
     if ! fm=$(extract_frontmatter "$skill_md"); then
-        # Broken frontmatter - WARN, skip rest of frontmatter checks
+        # Broken frontmatter - WARN, skip rest of frontmatter checks.
+        # Pass all 17 args expected by emit_skill, with valid status strings
+        # for body/fence so $16/$17 are never unset under set -u.
         TOTAL_WARN=$((TOTAL_WARN + 1))
         emit_skill "$skill_name" "$display_path" \
             "WARN" "0" "broken or missing frontmatter" \
-            "0" "0" "0" "0" "0" "0" "0" "0" "" ""
+            "PASS" "0" "0" \
+            "PASS" "0" "0" \
+            "0" "0" "0" "0" "0" ""
         return
     fi
 

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -386,10 +386,8 @@ emit_skill() {
         # Build orphan JSON array
         local orphans_json="[]"
         if [[ -n "$olist" ]]; then
-            local IFS_BAK="$IFS"
-            IFS='|'
-            local arr=($olist)
-            IFS="$IFS_BAK"
+            local arr=()
+            IFS='|' read -r -a arr <<<"$olist"
             local items=""
             local item
             for item in "${arr[@]}"; do
@@ -432,10 +430,8 @@ emit_skill() {
     if (( rt > 0 )); then
         echo "REFERENCES: $rt total -> ${rp1}/P1 + ${rp2}/P2 + ${rp3}/P3 = ${reachable} reachable, ${rorph} ORPHAN"
         if [[ -n "$olist" ]]; then
-            local IFS_BAK="$IFS"
-            IFS='|'
-            local arr=($olist)
-            IFS="$IFS_BAK"
+            local arr=()
+            IFS='|' read -r -a arr <<<"$olist"
             local item
             for item in "${arr[@]}"; do
                 [[ -z "$item" ]] && continue

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -223,7 +223,7 @@ audit_one() {
     body=$(get_body "$skill_md")
     local body_words body_lines
     body_words=$(printf '%s' "$body" | wc -w | tr -d ' ')
-    body_lines=$(printf '%s\n' "$body" | wc -l | tr -d ' ')
+    body_lines=$(printf '%s' "$body" | grep -c '^' || echo 0)
     local body_status="PASS"
     if (( body_words > 2000 )); then
         body_status="FAIL"

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+# audit-skills.sh - Per-skill content quality audit for Claude Code skill directories
+# Usage: ./audit-skills.sh [--help] [--json] [DIR ...]
+#
+# Scans SKILL.md files and reports:
+#   - DESCRIPTION length (PASS/WARN/FAIL)
+#   - BODY word count (PASS/WARN) and line metrics
+#   - CODE FENCE longest block (PASS/INFO at >30 lines)
+#   - REFERENCES reachability (P1 direct cite, P2 catalog convention,
+#                              P3 list-and-pick, ORPHAN otherwise)
+# Exit: 0 if no FAILs, 1 otherwise.
+#
+# shellcheck disable=SC2155 # local var with command substitution is intentional
+# shellcheck disable=SC2016 # single-quoted awk/grep patterns are deliberate
+# shellcheck disable=SC2207 # word-split into array via $(...) is fine here
+# shellcheck disable=SC2034 # some color vars are unused when --json is selected
+
+set -uo pipefail
+
+# --- CLI parsing ---
+JSON_OUTPUT=0
+DIRS=()
+
+usage() {
+    cat <<'EOF'
+Usage: audit-skills.sh [--help] [--json] [DIR ...]
+
+Audits Claude Code skill directories (SKILL.md files) for content quality.
+
+Options:
+  --help    Show this help and exit.
+  --json    Emit one JSON object per skill (newline-delimited) instead of
+            human-readable text. Summary is suppressed in JSON mode.
+  DIR ...   One or more directories to scan recursively for SKILL.md.
+            If none given, defaults to:
+              ~/.claude/skills
+              ~/.claude/plugins/cache
+            Paths matching */evals/* are always skipped.
+
+Quality rules:
+  DESCRIPTION  WARN >500 chars,  FAIL >1536 chars (Claude Code truncates).
+  BODY         INFO >500 words, WARN >1000 words, FAIL >2000 words.
+               Thresholds set by per-invocation token cost (~1.4x word count).
+  CODE FENCES  INFO when longest fenced block exceeds 25 lines.
+  REFERENCES   ORPHAN when references/*.md has no reachability pattern.
+
+Exit code: 0 if no FAILs across all skills, 1 otherwise.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h) usage; exit 0 ;;
+        --json) JSON_OUTPUT=1; shift ;;
+        --) shift; while [[ $# -gt 0 ]]; do DIRS+=("$1"); shift; done ;;
+        -*) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *) DIRS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#DIRS[@]} -eq 0 ]]; then
+    DIRS=("$HOME/.claude/skills" "$HOME/.claude/plugins/cache")
+fi
+
+# --- Color codes (suppressed under --json) ---
+if [[ $JSON_OUTPUT -eq 0 ]] && [[ -t 1 ]]; then
+    RED=$'\033[0;31m'
+    YEL=$'\033[1;33m'
+    GRN=$'\033[0;32m'
+    BLU=$'\033[0;34m'
+    NC=$'\033[0m'
+else
+    RED=""; YEL=""; GRN=""; BLU=""; NC=""
+fi
+
+# --- Counters ---
+TOTAL_SKILLS=0
+TOTAL_FAIL=0
+TOTAL_WARN=0
+TOTAL_INFO=0
+TOTAL_ORPHANS=0
+SKILLS_WITH_ORPHANS=0
+
+# --- Helpers ---
+
+# json_escape: escape a string for embedding in a JSON string literal.
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+# extract_frontmatter <skill_md>: prints YAML frontmatter (between first two ---)
+# Returns nonzero if frontmatter is missing or malformed.
+extract_frontmatter() {
+    local f="$1"
+    # Must start with "---" on line 1
+    local first
+    first=$(head -n 1 "$f")
+    [[ "$first" == "---" ]] || return 1
+    # Find the closing --- after line 1
+    local close
+    close=$(awk 'NR==1 && $0=="---"{next} $0=="---"{print NR; exit}' "$f")
+    [[ -n "$close" ]] || return 1
+    # Print lines between (exclusive)
+    awk -v end="$close" 'NR>1 && NR<end' "$f"
+    return 0
+}
+
+# get_description <frontmatter>: print description value, stripped of surrounding
+# quotes and leading/trailing whitespace. Empty output => not found.
+get_description() {
+    awk '
+        BEGIN { collecting=0; val="" }
+        /^[a-zA-Z_][a-zA-Z0-9_-]*:/ {
+            if (collecting) { print val; exit }
+        }
+        /^description:/ {
+            sub(/^description:[[:space:]]*/, "", $0)
+            val = $0
+            collecting = 1
+            next
+        }
+        collecting && /^[[:space:]]+/ {
+            sub(/^[[:space:]]+/, " ", $0)
+            val = val $0
+        }
+        END { if (collecting) print val }
+    ' <<<"$1" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/'
+}
+
+# get_body <skill_md>: print SKILL.md content excluding frontmatter.
+get_body() {
+    local f="$1"
+    local first
+    first=$(head -n 1 "$f")
+    if [[ "$first" == "---" ]]; then
+        local close
+        close=$(awk 'NR==1 && $0=="---"{next} $0=="---"{print NR; exit}' "$f")
+        if [[ -n "$close" ]]; then
+            awk -v start="$((close+1))" 'NR>=start' "$f"
+            return
+        fi
+    fi
+    cat "$f"
+}
+
+# fence_stats <body_text>: prints "<count> <longest_lines>"
+fence_stats() {
+    awk '
+        BEGIN { in_fence=0; count=0; cur=0; longest=0 }
+        /^[[:space:]]*```/ {
+            if (in_fence) {
+                if (cur > longest) longest = cur
+                in_fence = 0
+                cur = 0
+            } else {
+                in_fence = 1
+                count++
+                cur = 0
+            }
+            next
+        }
+        in_fence { cur++ }
+        END {
+            if (in_fence && cur > longest) longest = cur
+            print count, longest
+        }
+    ' <<<"$1"
+}
+
+# audit_one <skill_md_path>
+audit_one() {
+    local skill_md="$1"
+    local skill_dir
+    skill_dir=$(dirname "$skill_md")
+    local skill_name
+    skill_name=$(basename "$skill_dir")
+
+    # Path display: relative to cwd if it's inside cwd, else absolute.
+    local display_path="$skill_md"
+    local cwd_abs
+    cwd_abs=$(pwd -P)
+    if [[ "$skill_md" == "$cwd_abs"/* ]]; then
+        display_path="${skill_md#"$cwd_abs"/}"
+    fi
+
+    TOTAL_SKILLS=$((TOTAL_SKILLS + 1))
+
+    # --- Frontmatter & description ---
+    local fm desc desc_status="PASS" desc_len=0 desc_warn_msg=""
+    if ! fm=$(extract_frontmatter "$skill_md"); then
+        # Broken frontmatter - WARN, skip rest of frontmatter checks
+        TOTAL_WARN=$((TOTAL_WARN + 1))
+        emit_skill "$skill_name" "$display_path" \
+            "WARN" "0" "broken or missing frontmatter" \
+            "0" "0" "0" "0" "0" "0" "0" "0" "" ""
+        return
+    fi
+
+    desc=$(get_description "$fm")
+    if [[ -z "$desc" ]]; then
+        desc_status="FAIL"
+        desc_warn_msg="missing description field"
+        TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    else
+        desc_len=${#desc}
+        if (( desc_len > 1536 )); then
+            desc_status="FAIL"
+            TOTAL_FAIL=$((TOTAL_FAIL + 1))
+        elif (( desc_len > 500 )); then
+            desc_status="WARN"
+            TOTAL_WARN=$((TOTAL_WARN + 1))
+        fi
+    fi
+
+    # --- Body metrics ---
+    local body
+    body=$(get_body "$skill_md")
+    local body_words body_lines
+    body_words=$(printf '%s' "$body" | wc -w | tr -d ' ')
+    body_lines=$(printf '%s\n' "$body" | wc -l | tr -d ' ')
+    local body_status="PASS"
+    if (( body_words > 2000 )); then
+        body_status="FAIL"
+        TOTAL_FAIL=$((TOTAL_FAIL + 1))
+    elif (( body_words > 1000 )); then
+        body_status="WARN"
+        TOTAL_WARN=$((TOTAL_WARN + 1))
+    elif (( body_words > 500 )); then
+        body_status="INFO"
+        TOTAL_INFO=$((TOTAL_INFO + 1))
+    fi
+
+    # --- Code fences ---
+    local fence_line fence_count fence_longest
+    fence_line=$(fence_stats "$body")
+    fence_count=$(awk '{print $1}' <<<"$fence_line")
+    fence_longest=$(awk '{print $2}' <<<"$fence_line")
+    [[ -z "$fence_count" ]] && fence_count=0
+    [[ -z "$fence_longest" ]] && fence_longest=0
+    local fence_status="PASS"
+    if (( fence_longest > 25 )); then
+        fence_status="INFO"
+        TOTAL_INFO=$((TOTAL_INFO + 1))
+    fi
+
+    # --- References reachability ---
+    local refs_dir="$skill_dir/references"
+    local ref_total=0 ref_p1=0 ref_p2=0 ref_p3=0 ref_orphan=0
+    local orphan_list=""
+    if [[ -d "$refs_dir" ]]; then
+        # Detect Pattern 3 (list-and-pick) once for the whole SKILL.md
+        local p3_hit=0
+        if grep -qE -i \
+'list[[:space:]]+`?references/`?|browse[[:space:]]+(the[[:space:]]+)?references/?[[:space:]]+(directory|dir|folder)|read[[:space:]]+the[[:space:]]+(relevant|appropriate|matching)[[:space:]]+(file|files)[[:space:]]+in[[:space:]]+`?references/`?|see[[:space:]]+`?references/`?[[:space:]]+for' \
+            "$skill_md"; then
+            p3_hit=1
+        fi
+
+        # Detect Pattern 2 (catalog-with-convention).
+        # Look for a heading or paragraph mentioning references/ or "in references";
+        # then within the next ~30 lines look for a parenthetical convention like
+        # (*-foo) or (.md implied).
+        # Capture suffixes from "(*-suffix)" patterns.
+        local p2_suffixes=()
+        local p2_md_implied=0
+        local awk_p2
+        awk_p2=$(awk '
+            BEGIN { trigger=0; window=0 }
+            function scan_line(    line, tok) {
+                line=$0
+                # Extract (*-suffix) or (`*-suffix`) patterns; allow optional backticks
+                while (match(line, /\(`?\*-[A-Za-z0-9_-]+`?\)/)) {
+                    tok=substr(line, RSTART+1, RLENGTH-2)  # strip leading "(" and trailing ")"
+                    gsub(/`/, "", tok)                      # strip optional backticks
+                    sub(/^\*-/, "", tok)                    # strip leading "*-"
+                    print "SUFFIX:" tok
+                    line=substr(line, RSTART+RLENGTH)
+                }
+                # Detect ".md implied" inside a parenthetical (allowing backticks/extra text)
+                if (tolower($0) ~ /\([^)]*\.md[^)]*implied[^)]*\)/ || tolower($0) ~ /\(`?\.md`?\)/) {
+                    print "MDIMPLIED"
+                }
+            }
+            tolower($0) ~ /references\// || tolower($0) ~ /in[[:space:]]+references\>/ {
+                trigger=1; window=30
+                scan_line()
+                next
+            }
+            trigger && window>0 {
+                window--
+                scan_line()
+                if (window==0) { trigger=0 }
+            }
+        ' "$skill_md" 2>/dev/null || true)
+        while IFS= read -r p2line; do
+            [[ -z "$p2line" ]] && continue
+            case "$p2line" in
+                SUFFIX:*) p2_suffixes+=("${p2line#SUFFIX:}") ;;
+                MDIMPLIED) p2_md_implied=1 ;;
+            esac
+        done <<<"$awk_p2"
+
+        # Iterate through references/*.md
+        local refpath base
+        while IFS= read -r refpath; do
+            [[ -z "$refpath" ]] && continue
+            ref_total=$((ref_total + 1))
+            base=$(basename "$refpath" .md)
+
+            # Pattern 1: direct cite "references/<name>.md"
+            if grep -qF "references/${base}.md" "$skill_md"; then
+                ref_p1=$((ref_p1 + 1))
+                continue
+            fi
+
+            # Pattern 2: matches a captured suffix
+            local matched_p2=0
+            if (( ${#p2_suffixes[@]} > 0 )); then
+                local sfx
+                for sfx in "${p2_suffixes[@]}"; do
+                    if [[ "$base" == *"-${sfx}" ]] || [[ "$base" == *"${sfx}" ]]; then
+                        matched_p2=1
+                        break
+                    fi
+                done
+            fi
+            # Or: "(.md implied)" convention + base name appears as a bullet-ish word
+            if (( matched_p2 == 0 )) && (( p2_md_implied == 1 )); then
+                if grep -qE "(^|[[:space:]\`*-])${base}([[:space:]\`,.)]|$)" "$skill_md"; then
+                    matched_p2=1
+                fi
+            fi
+            if (( matched_p2 == 1 )); then
+                ref_p2=$((ref_p2 + 1))
+                continue
+            fi
+
+            # Pattern 3: SKILL.md instructs listing references/
+            if (( p3_hit == 1 )); then
+                ref_p3=$((ref_p3 + 1))
+                continue
+            fi
+
+            # Otherwise: ORPHAN
+            ref_orphan=$((ref_orphan + 1))
+            if [[ -z "$orphan_list" ]]; then
+                orphan_list="$(basename "$refpath")"
+            else
+                orphan_list="${orphan_list}|$(basename "$refpath")"
+            fi
+        done < <(find "$refs_dir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | sort)
+
+        if (( ref_orphan > 0 )); then
+            TOTAL_ORPHANS=$((TOTAL_ORPHANS + ref_orphan))
+            SKILLS_WITH_ORPHANS=$((SKILLS_WITH_ORPHANS + 1))
+        fi
+    fi
+
+    emit_skill "$skill_name" "$display_path" \
+        "$desc_status" "$desc_len" "$desc_warn_msg" \
+        "$body_status" "$body_words" "$body_lines" \
+        "$fence_status" "$fence_count" "$fence_longest" \
+        "$ref_total" "$ref_p1" "$ref_p2" "$ref_p3" \
+        "$ref_orphan" "$orphan_list"
+}
+
+# emit_skill: prints results in either text or JSON form.
+# Args: name path desc_status desc_len desc_msg
+#       body_status body_words body_lines
+#       fence_status fence_count fence_longest
+#       ref_total ref_p1 ref_p2 ref_p3 ref_orphan orphan_list
+emit_skill() {
+    local name="$1" path="$2"
+    local ds="$3" dl="$4" dm="$5"
+    local bs="$6" bw="$7" bln="$8"
+    local fs="$9" fc="${10}" fl="${11}"
+    local rt="${12}" rp1="${13}" rp2="${14}" rp3="${15}" rorph="${16}" olist="${17}"
+
+    if [[ $JSON_OUTPUT -eq 1 ]]; then
+        # Build orphan JSON array
+        local orphans_json="[]"
+        if [[ -n "$olist" ]]; then
+            local IFS_BAK="$IFS"
+            IFS='|'
+            local arr=($olist)
+            IFS="$IFS_BAK"
+            local items=""
+            local item
+            for item in "${arr[@]}"; do
+                [[ -z "$item" ]] && continue
+                if [[ -z "$items" ]]; then
+                    items="\"$(json_escape "$item")\""
+                else
+                    items="$items,\"$(json_escape "$item")\""
+                fi
+            done
+            orphans_json="[$items]"
+        fi
+        printf '{"name":"%s","path":"%s","description":{"status":"%s","chars":%s,"message":"%s"},"body":{"status":"%s","words":%s,"lines":%s},"code_fences":{"status":"%s","count":%s,"longest_lines":%s},"references":{"total":%s,"p1_direct":%s,"p2_catalog":%s,"p3_listpick":%s,"reachable":%s,"orphans":%s,"orphan_files":%s}}\n' \
+            "$(json_escape "$name")" "$(json_escape "$path")" \
+            "$ds" "$dl" "$(json_escape "$dm")" \
+            "$bs" "$bw" "$bln" \
+            "$fs" "$fc" "$fl" \
+            "$rt" "$rp1" "$rp2" "$rp3" "$((rp1 + rp2 + rp3))" "$rorph" "$orphans_json"
+        return
+    fi
+
+    # Text output
+    echo "=========================================="
+    echo "SKILL: $name"
+    echo "PATH: $path"
+    echo "=========================================="
+    local ds_color="$GRN"
+    case "$ds" in WARN) ds_color="$YEL" ;; FAIL) ds_color="$RED" ;; esac
+    if [[ -n "$dm" ]]; then
+        echo "DESCRIPTION: $dl chars [${ds_color}${ds}${NC}] - $dm"
+    else
+        echo "DESCRIPTION: $dl chars [${ds_color}${ds}${NC}]"
+    fi
+    local bs_color="$GRN"
+    case "$bs" in INFO) bs_color="$BLU" ;; WARN) bs_color="$YEL" ;; FAIL) bs_color="$RED" ;; esac
+    echo "BODY: $bw words, $bln lines [${bs_color}${bs}${NC}]"
+    local fs_color="$GRN"; [[ "$fs" == "INFO" ]] && fs_color="$BLU"
+    echo "CODE FENCES: $fc fenced blocks, longest $fl lines [${fs_color}${fs}${NC}]"
+    local reachable=$((rp1 + rp2 + rp3))
+    if (( rt > 0 )); then
+        echo "REFERENCES: $rt total -> ${rp1}/P1 + ${rp2}/P2 + ${rp3}/P3 = ${reachable} reachable, ${rorph} ORPHAN"
+        if [[ -n "$olist" ]]; then
+            local IFS_BAK="$IFS"
+            IFS='|'
+            local arr=($olist)
+            IFS="$IFS_BAK"
+            local item
+            for item in "${arr[@]}"; do
+                [[ -z "$item" ]] && continue
+                echo "  ORPHAN: $item"
+            done
+        fi
+    else
+        echo "REFERENCES: 0 total (no references/ directory)"
+    fi
+    echo ""
+}
+
+# --- Find SKILL.md files across DIRS ---
+# Skip */evals/* paths.
+SKILL_FILES=()
+for d in "${DIRS[@]}"; do
+    if [[ ! -d "$d" ]]; then
+        if [[ $JSON_OUTPUT -eq 0 ]]; then
+            echo "${YEL}WARN:${NC} directory not found, skipping: $d" >&2
+        fi
+        continue
+    fi
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && SKILL_FILES+=("$f")
+    done < <(find "$d" -type f -name 'SKILL.md' -not -path '*/evals/*' 2>/dev/null | sort -u)
+done
+
+if [[ ${#SKILL_FILES[@]} -eq 0 ]]; then
+    if [[ $JSON_OUTPUT -eq 0 ]]; then
+        echo "No SKILL.md files found in: ${DIRS[*]}" >&2
+    fi
+    exit 0
+fi
+
+# --- Audit each skill ---
+for sf in "${SKILL_FILES[@]}"; do
+    audit_one "$sf"
+done
+
+# --- Summary (text only) ---
+if [[ $JSON_OUTPUT -eq 0 ]]; then
+    echo "SUMMARY: $TOTAL_SKILLS skills, $TOTAL_FAIL FAIL, $TOTAL_WARN WARN, $TOTAL_INFO INFO, $TOTAL_ORPHANS ORPHAN refs across $SKILLS_WITH_ORPHANS skills"
+fi
+
+if (( TOTAL_FAIL > 0 )); then
+    exit 1
+fi
+exit 0

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -40,7 +40,7 @@ Standards for Netresearch skill repository layout and distribution.
 | `scripts/**`, `.github/workflows/**`, `*.sh`, `*.py`, `*.php` | MIT |
 | `composer.json`, `plugin.json`, config files | MIT |
 
-SPDX expression: `(MIT AND CC-BY-SA-4.0)`. Copyright: `Netresearch DTT GmbH`. No bare `LICENSE` file — use split files only.
+SPDX: `(MIT AND CC-BY-SA-4.0)`. Copyright: `Netresearch DTT GmbH`. No bare `LICENSE` — split files only.
 
 ## SKILL.md Frontmatter
 
@@ -51,35 +51,7 @@ description: "Use when <trigger conditions>"
 ---
 ```
 
-Body: max 500 words. Use `references/` for extended content. Full quality rules: [`references/skill-quality.md`](references/skill-quality.md).
-
-## SKILL.md Quality Rules
-
-Three categories. Detail and examples in [`references/skill-quality.md`](references/skill-quality.md). Audit with `scripts/audit-skills.sh`.
-
-### Description
-
-- Hard cap **1,536 chars** (`skillListingMaxDescChars`); target 100–300 chars; primary trigger first.
-- No marketing language ("comprehensive", "powerful"), vagueness, or restating the skill name.
-
-### Body
-
-Body loads on invocation and persists for the session. Thresholds set by per-invocation token cost (≈ 1.4× word count):
-
-- **INFO above 500 words** (~700 tokens) — review for split candidates.
-- **WARN above 1000 words** (~1400 tokens) — almost any skill at this size has content that could move to `references/`.
-- **FAIL above 2000 words** (~2800 tokens) — body is acting as a manual; split required.
-- **Bloat signals**: code fences >25 lines (long examples are the prime lazy-load target).
-
-### References (model-discoverable)
-
-Every `.md` in `references/` must be reachable from SKILL.md via:
-
-1. **Direct cite** — `references/foo.md` mentioned by path. Best for ≤10 refs.
-2. **Catalog-with-convention** — short names under topic headings, with the directory + filename pattern stated once. Best for 10+ topic-grouped refs (see `security-audit` skill).
-3. **List-and-pick** — explicit instruction to enumerate the directory.
-
-Anti-patterns: **hub-and-spoke** (SKILL.md → hub → leaves; multi-hop traversal isn't reliable) and **orphan refs** (files in `references/` with no discovery path — model never reads them).
+Body ≤500 words; description ≤1,536 chars (target 100–300, trigger first). Every `references/*.md` must be reachable from SKILL.md (direct cite, catalog-with-convention, or list-and-pick — no orphans). Audit: `scripts/audit-skills.sh`. See [`references/skill-quality.md`](references/skill-quality.md).
 
 ## plugin.json (`.claude-plugin/plugin.json`)
 
@@ -95,7 +67,7 @@ Anti-patterns: **hub-and-spoke** (SKILL.md → hub → leaves; multi-hop travers
 
 ## composer.json
 
-Name **must match GitHub repo name**. Type must be `ai-agent-skill`. No `version` field (derived from git tags). No `composer.lock`.
+Name **must match GitHub repo**. Type `ai-agent-skill`. No `version` field (from git tags). No `composer.lock`.
 
 ```json
 {
@@ -116,13 +88,11 @@ Skill repos MUST delegate CI to skill-repo-skill reusable workflows:
 uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
 ```
 
-Callers: `validate.yml`, `release.yml` from `netresearch/skill-repo-skill`; `auto-merge-deps.yml` from `netresearch/.github`. Domain-specific reusables: see `docs/ARCHITECTURE.md`.
-
-Auto-merge and pr-quality callers must use `pull_request_target` trigger. Never define actions directly — always call reusable workflows.
+Callers: `validate.yml`, `release.yml` (from `skill-repo-skill`); `auto-merge-deps.yml` (from `netresearch/.github`). Auto-merge and pr-quality callers must use `pull_request_target`. Never define actions directly. Domain-specific reusables: `docs/ARCHITECTURE.md`.
 
 ## Releasing
 
-Open bump PR → merge → pull main → verify version parity → signed tag → push tag → monitor Release workflow. **Tag only after the bump PR is merged**. Never edit installed skill paths (`~/.claude/skills/**`, `~/.claude/plugins/**`); always the worktree. Multi-repo releases (>3) require dry-run + approval. See `references/release-discipline.md`.
+Bump PR → merge → pull main → verify parity → signed tag → push → monitor Release. **Tag only after bump PR merges.** Never edit installed paths (`~/.claude/skills/**`, `~/.claude/plugins/**`); always the worktree. Multi-repo (>3) needs dry-run + approval. See `references/release-discipline.md`.
 
 ## Installation
 
@@ -139,18 +109,16 @@ scripts/validate-skill.sh
 
 ## Cross-platform Compatibility
 
-- `grep -E` not `grep -P` (macOS BSD grep)
-- `bash` in shebangs (macOS default is zsh)
-- `[[ ]]` for conditionals
+`grep -E` (not `-P`); `bash` shebangs (zsh on macOS); `[[ ]]` for conditionals.
 
 ## References
 
 - `references/installation-methods.md`
 - `references/composer-setup.md`
-- `references/release-discipline.md` — version-parity check, cache safety, multi-repo dry-run
-- `references/review-replies.md` — canonical replies for recurring reviewer comments
-- `references/skill-quality.md` — description, body, and reference patterns; rationale for `scripts/audit-skills.sh`
-- `references/marketplace-integration.md` — sync architecture between skill repos and marketplace
+- `references/release-discipline.md` — version parity, cache safety, multi-repo dry-run
+- `references/review-replies.md` — canonical replies for reviewer comments
+- `references/skill-quality.md` — description/body/reference rules; audit-skills.sh rationale
+- `references/marketplace-integration.md` — marketplace sync architecture
 
 ## See Also
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -51,7 +51,35 @@ description: "Use when <trigger conditions>"
 ---
 ```
 
-Body: max 500 words. Use `references/` for extended content.
+Body: max 500 words. Use `references/` for extended content. Full quality rules: [`references/skill-quality.md`](references/skill-quality.md).
+
+## SKILL.md Quality Rules
+
+Three categories. Detail and examples in [`references/skill-quality.md`](references/skill-quality.md). Audit with `scripts/audit-skills.sh`.
+
+### Description
+
+- Hard cap **1,536 chars** (`skillListingMaxDescChars`); target 100–300 chars; primary trigger first.
+- No marketing language ("comprehensive", "powerful"), vagueness, or restating the skill name.
+
+### Body
+
+Body loads on invocation and persists for the session. Thresholds set by per-invocation token cost (≈ 1.4× word count):
+
+- **INFO above 500 words** (~700 tokens) — review for split candidates.
+- **WARN above 1000 words** (~1400 tokens) — almost any skill at this size has content that could move to `references/`.
+- **FAIL above 2000 words** (~2800 tokens) — body is acting as a manual; split required.
+- **Bloat signals**: code fences >25 lines (long examples are the prime lazy-load target).
+
+### References (model-discoverable)
+
+Every `.md` in `references/` must be reachable from SKILL.md via:
+
+1. **Direct cite** — `references/foo.md` mentioned by path. Best for ≤10 refs.
+2. **Catalog-with-convention** — short names under topic headings, with the directory + filename pattern stated once. Best for 10+ topic-grouped refs (see `security-audit` skill).
+3. **List-and-pick** — explicit instruction to enumerate the directory.
+
+Anti-patterns: **hub-and-spoke** (SKILL.md → hub → leaves; multi-hop traversal isn't reliable) and **orphan refs** (files in `references/` with no discovery path — model never reads them).
 
 ## plugin.json (`.claude-plugin/plugin.json`)
 
@@ -121,6 +149,8 @@ scripts/validate-skill.sh
 - `references/composer-setup.md`
 - `references/release-discipline.md` — version-parity check, cache safety, multi-repo dry-run
 - `references/review-replies.md` — canonical replies for recurring reviewer comments
+- `references/skill-quality.md` — description, body, and reference patterns; rationale for `scripts/audit-skills.sh`
+- `references/marketplace-integration.md` — sync architecture between skill repos and marketplace
 
 ## See Also
 

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -52,11 +52,13 @@ description: "A comprehensive solution for managing your repository state with a
 
 Body loads on invocation and persists for the rest of the session. The threshold goal is **per-invocation token cost** — every additional word in the body is paid every time the skill is invoked. Move what isn't strictly needed at decision time into `references/` (lazy-loaded when SKILL.md instructs).
 
-Word count translates to tokens at roughly 1.4× (English prose; code fences run higher). Three tiers:
+Word count translates to tokens at roughly 1.4× (English prose; code fences run higher). `audit-skills.sh` reports three tiers:
 
 - **INFO above 500 words** (~700 tokens) — modest cost; skim for split candidates.
 - **WARN above 1,000 words** (~1,400 tokens) — almost any body at this size has lookup content that could move to references.
 - **FAIL above 2,000 words** (~2,800 tokens) — body is acting as a manual; split required.
+
+These tiers are advisory across the wider skill ecosystem. **This repo enforces a stricter 500-word hard cap on its own SKILL.md** (via `scripts/validate-skill.sh`) — that is the per-skill house rule, not a universal claim. Treat the audit tiers as triage levels for any skill repo; treat the 500-word cap as policy for the canonical skill-repo template.
 
 Empirical anchor: the Netresearch skill corpus (n=52) has p95 ≈ 994 words. WARN at 1,000 catches the actual outliers in our own work. Anthropic's longer skills (e.g., `writing-skills` at 3,193 words) FAIL under this rule — that's the honest signal: even shipped skills can have content moved out. We can't fix theirs; we hold ourselves to the rule.
 
@@ -147,7 +149,7 @@ Run `scripts/audit-skills.sh` from the repo root. It scans SKILL.md files for:
 - Long code fences (info >25 lines — primary lazy-load candidate)
 - Orphan refs (files in `references/` not reachable by any pattern)
 
-Pattern 2 detection is heuristic — uncertain cases mark as "likely-reachable" rather than ORPHAN.
+Pattern 2 detection is heuristic: a reference file counts as P2 when its stem matches a convention stated in SKILL.md (filename suffix or topic-list pattern). Files outside any P1/P2/P3 path are reported as ORPHAN.
 
 ## Sources
 

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -1,0 +1,156 @@
+# SKILL.md Quality Rules — Detail and Examples
+
+Detailed guidance backing the summary in [`SKILL.md`](../SKILL.md) (§ SKILL.md Quality Rules).
+
+## Why these rules exist
+
+Claude Code skills have two distinct context costs:
+
+- **Listing cost (per turn):** Only `name`, `description`, and optional `when_to_use` from each skill's frontmatter enter context on every assistant turn — whether the skill is invoked or not. Per-skill cap: 1,536 chars (`skillListingMaxDescChars`). Total listing cap: `skillListingBudgetFraction × context_window` (default `0.01`).
+- **Body cost (per invocation):** The full SKILL.md body loads when the skill is invoked, and persists for the rest of the session. Reference files (`references/*.md`) are **not** auto-loaded — the model only reads files it sees referenced.
+
+Description bytes are the always-on tax; body bytes are the on-demand tax. References are free unless the model knows they exist and decides to read them.
+
+## Description rules
+
+### Caps
+
+- **Hard cap: 1,536 chars** — Claude Code truncates above this regardless of budget.
+- **Target: 100–300 chars** — fits comfortably in the listing, leaves headroom for other skills.
+- **Justify above ~500 chars** — long descriptions are reasonable when they enumerate triggers (e.g., ticket-key prefixes, file-extension lists). Keep the structure tight.
+
+### Position matters
+
+Truncation is position-based. Put your primary trigger first. The convention is `Use when <trigger>` as the opener.
+
+### Anti-patterns
+
+| Anti-pattern | Example |
+|---|---|
+| Marketing language | "blazingly fast", "powerful", "comprehensive" |
+| Vagueness | "a tool to help with X", "general-purpose helper" |
+| Restating the skill name | `description: "The frobnicator skill frobnicates."` |
+| Redundancy with body | duplicating the skill's intro paragraph in both fields |
+
+### Examples
+
+**Good:**
+
+```yaml
+description: "Use when reviewing your diff, writing a commit message, or asking what changed. Summarizes uncommitted changes and flags risky patterns."
+```
+
+**Bad:**
+
+```yaml
+description: "A comprehensive solution for managing your repository state with advanced semantic understanding"
+```
+
+## Body rules
+
+### Size
+
+Body loads on invocation and persists for the rest of the session. The threshold goal is **per-invocation token cost** — every additional word in the body is paid every time the skill is invoked. Move what isn't strictly needed at decision time into `references/` (lazy-loaded when SKILL.md instructs).
+
+Word count translates to tokens at roughly 1.4× (English prose; code fences run higher). Three tiers:
+
+- **INFO above 500 words** (~700 tokens) — modest cost; skim for split candidates.
+- **WARN above 1,000 words** (~1,400 tokens) — almost any body at this size has lookup content that could move to references.
+- **FAIL above 2,000 words** (~2,800 tokens) — body is acting as a manual; split required.
+
+Empirical anchor: the Netresearch skill corpus (n=52) has p95 ≈ 994 words. WARN at 1,000 catches the actual outliers in our own work. Anthropic's longer skills (e.g., `writing-skills` at 3,193 words) FAIL under this rule — that's the honest signal: even shipped skills can have content moved out. We can't fix theirs; we hold ourselves to the rule.
+
+- **Bloat signals**: body >3 KB, body >150 lines, single fenced code block >25 lines (long code examples are the primary lazy-load target).
+
+### When to split to `references/`
+
+Move to `references/<topic>.md` when content is:
+
+- Long examples (>20 lines)
+- Configuration templates
+- API/syntax tables
+- Migration matrices
+- Detailed checklists
+- Repository directory trees (often the worst offenders)
+
+Keep in SKILL.md body:
+
+- High-level workflow
+- The "what does this skill do" summary
+- A reference catalog (see Pattern 2 below) when there are many topic-files
+- One canonical quick example
+
+## Reference patterns
+
+Every `.md` file in `references/` must be discoverable to the model **from SKILL.md**. Three acceptable patterns:
+
+### Pattern 1: Direct cite
+
+```markdown
+For form validation, see [`references/forms.md`](references/forms.md).
+For multi-profile auth, see [`references/multi-profile.md`](references/multi-profile.md).
+```
+
+Best for **≤10 reference files**. Each gets a one-line cite with the path. The model sees the path on invocation and reads on demand.
+
+### Pattern 2: Catalog-with-convention
+
+```markdown
+## Reference Files (in `references/`, `.md` implied)
+
+- **Frameworks** (`*-security`): react, vue, angular, nextjs, nuxt
+- **Languages** (`*-security-features`): php, python, go, rust, javascript-typescript
+- **Cloud** (`*-security`): aws, azure, gcp
+```
+
+Best for **10+ topic-grouped files**. The model sees:
+
+- The directory (`references/`)
+- The filename suffix convention (`-security`, `-security-features`)
+- The list of stems
+
+It can resolve any combination on demand. The `security-audit` skill uses this pattern for ~60 reference files in ~12 lines of body content.
+
+### Pattern 3: List-and-pick
+
+```markdown
+For language-specific guidance, list `references/` and read the file matching your stack.
+```
+
+Use sparingly — burns a tool call (the model has to enumerate the directory). Useful when there's no naming convention but the directory is small.
+
+### Anti-pattern: Hub-and-spoke
+
+```markdown
+# DON'T DO THIS
+
+In SKILL.md:
+> See [references/index.md](references/index.md) for the catalog of references.
+
+In references/index.md:
+> - [forms.md](forms.md)
+> - [auth.md](auth.md)
+```
+
+Multi-hop traversal isn't reliable. Anthropic's docs phrase the rule as "Reference supporting files from SKILL.md so Claude knows what each file contains" — direct visibility from SKILL.md is the model. The hub gets read but its leaves aren't deeply traversed. Anthropic's published skills use flat / catalog patterns, never hub-and-spoke.
+
+### Anti-pattern: Orphan refs
+
+Files in `references/` with no path to discovery from SKILL.md (no direct cite, no catalog mention, no list-and-pick instruction). The model never reads them. Either cite them or delete them — they consume disk and signal "stale" to readers without contributing to the skill's behavior.
+
+## Auditing
+
+Run `scripts/audit-skills.sh` from the repo root. It scans SKILL.md files for:
+
+- Description length violations (warn >500 chars, fail >1,536)
+- Body length tiers (info >500 words, warn >1,000, fail >2,000)
+- Long code fences (info >25 lines — primary lazy-load candidate)
+- Orphan refs (files in `references/` not reachable by any pattern)
+
+Pattern 2 detection is heuristic — uncertain cases mark as "likely-reachable" rather than ORPHAN.
+
+## Sources
+
+- Anthropic Claude Code docs on skills: <https://code.claude.com/docs/en/skills>
+- Anthropic published skills: <https://github.com/anthropics/skills>
+- Settings schema: `skillListingBudgetFraction`, `skillListingMaxDescChars` (Claude Code settings.json)


### PR DESCRIPTION
## Summary
- New `scripts/audit-skills.sh` audits per-skill content quality (description length, body word count, code fence length, references reachability).
- New "SKILL.md Quality Rules" section in SKILL.md with thresholds calibrated by per-invocation token cost.
- New `references/skill-quality.md` with rationale and pattern examples.

## Reference patterns (from skill-quality.md)
1. **Direct cite** — best for ≤10 refs
2. **Catalog-with-convention** — best for 10+ topic-grouped refs (see security-audit skill)
3. **List-and-pick** — explicit instruction to enumerate

## Test plan
- [x] `bash -n scripts/audit-skills.sh` (syntax)
- [x] `./scripts/audit-skills.sh --help`
- [x] `./scripts/audit-skills.sh skills/skill-repo` (self-audit: 0 ORPHAN)
- [x] Tested against 14 source skills: all clean (0 ORPHAN)