### PR TITLE
fix(ci): pin cosign to v2.6.0 to restore sign-blob output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,15 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          # Pin to cosign v2.x. Cosign v3.x switched `sign-blob` to
+          # `--new-bundle-format` by default, which deprecates
+          # `--output-certificate` / `--output-signature` and instead
+          # requires `--bundle <path>`. Until this workflow is migrated
+          # to emit a single bundle file (and the verify step + caller
+          # release artifacts updated to match), stay on v2.x where
+          # the legacy two-file output is still the default.
+          cosign-release: v2.6.0
 
       - name: Sign SHA256SUMS with Cosign (keyless)
         working-directory: dist/releases


### PR DESCRIPTION
Closes #93

## Problem

`cosign sign-blob` fails in the release workflow with:

```
Error: signing SHA256SUMS.txt: create bundle file: open : no such file or directory
```

Cosign v3.x (installed via `sigstore/cosign-installer@v4.1.1` without a pinned version) changed `sign-blob` to emit a **single bundle file** by default (`--new-bundle-format`). This silently ignores `--output-certificate` and `--output-signature`, and instead expects `--bundle <path>`. Since neither flag is passed, the bundle path is empty → the file-open fails.

## Fix

Pin `cosign-release: v2.6.0` in the installer step. In v2.x the two-file output (`SHA256SUMS.txt.pem` + `SHA256SUMS.txt.sig`) is still the default, so the existing sign and verify steps work without any other changes.

## Why a workaround instead of migrating to v3 bundle format?

Migrating to the bundle format would also require updating:
- the `cosign verify-blob` step (replace `--certificate` + `--signature` with `--bundle`)
- the `Create GitHub Release` step (attach `.bundle` instead of `.pem`/`.sig`)
- documentation in skill READMEs and any consumer tooling

That is a larger change worth a dedicated PR. This fix unblocks all skill releases immediately.