### PR TITLE
fix(release): migrate cosign sign-blob to v3 bundle format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ name: Release Skill
 #   1. Build the archives (zip + tar.gz).
 #   2. Generate SHA256SUMS.txt over them.
 #   3. Cosign sign-blob (keyless / Sigstore) the SHA256SUMS.txt
-#      → SHA256SUMS.txt.sig + SHA256SUMS.txt.pem.
+#      → SHA256SUMS.txt.bundle (Sigstore bundle format: cert + sig + Rekor
+#      inclusion proof in a single self-contained file; cosign v3+ default).
 #   4. SLSA build-provenance attest the archives + SHA256SUMS.txt via
 #      actions/attest-build-provenance → published to GitHub's attestation API.
 #   5. softprops/action-gh-release creates the Release with all assets at once.
@@ -47,7 +48,7 @@ name: Release Skill
 # (this reusable workflow), NOT the caller; pin the regex to skill-repo-skill,
 # not the consuming repo:
 #   cosign verify-blob \
-#     --certificate SHA256SUMS.txt.pem --signature SHA256SUMS.txt.sig \
+#     --bundle SHA256SUMS.txt.bundle \
 #     --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
 #     SHA256SUMS.txt
@@ -242,9 +243,12 @@ jobs:
         working-directory: dist/releases
         run: |
           set -euo pipefail
+          # Cosign v3+ emits a single self-contained Sigstore bundle (cert +
+          # signature + Rekor inclusion proof) via --bundle. The legacy two-file
+          # output (--output-certificate / --output-signature) is deprecated and
+          # silently ignored when --new-bundle-format is the default.
           cosign sign-blob --yes \
-            --output-certificate SHA256SUMS.txt.pem \
-            --output-signature SHA256SUMS.txt.sig \
+            --bundle SHA256SUMS.txt.bundle \
             SHA256SUMS.txt
 
       - name: Verify Cosign signature
@@ -266,8 +270,7 @@ jobs:
           # character. We don't pin a specific ref because the reusable may be
           # referenced via `@main`, a SHA, or a future tag of skill-repo-skill.
           cosign verify-blob \
-            --certificate SHA256SUMS.txt.pem \
-            --signature SHA256SUMS.txt.sig \
+            --bundle SHA256SUMS.txt.bundle \
             --certificate-identity-regexp "^https://github\.com/${SIGNER_REPO}/\.github/workflows/release\.yml@" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             SHA256SUMS.txt

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -130,7 +130,7 @@ All of this happens in the SAME job that publishes the GitHub Release, BEFORE th
 
 1. Build `*.zip` and `*.tar.gz` archives.
 2. Generate `SHA256SUMS.txt` over them.
-3. **Cosign** keyless `sign-blob` the `SHA256SUMS.txt` → produces `SHA256SUMS.txt.sig` + `SHA256SUMS.txt.pem`.
+3. **Cosign** keyless `sign-blob` the `SHA256SUMS.txt` → produces `SHA256SUMS.txt.bundle` (Sigstore bundle format: cert + signature + Rekor inclusion proof in a single self-contained file; cosign v3+ default).
 4. **`actions/attest-build-provenance`** generates a SLSA build-provenance attestation for the archives + checksums file → published to GitHub's attestation API.
 5. **`softprops/action-gh-release`** publishes the GitHub Release with all assets attached at once.
 
@@ -167,8 +167,7 @@ gh attestation verify <skill-name>-skill-vX.Y.Z.zip --repo netresearch/<repo-nam
 # `https://github.com/netresearch/.*` would accept signatures from any repo,
 # branch, or workflow in the org — too loose for supply-chain verification.
 cosign verify-blob \
-  --certificate SHA256SUMS.txt.pem \
-  --signature   SHA256SUMS.txt.sig \
+  --bundle SHA256SUMS.txt.bundle \
   --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   SHA256SUMS.txt
@@ -180,7 +179,7 @@ sha256sum --check SHA256SUMS.txt
 If verification fails:
 
 - `gh attestation verify` returns `error: no attestations found` when `--repo` is wrong (or when the release predates this workflow).
-- `cosign verify-blob` returns `error: certificate identity does not match` when the regex is wrong, or `bundle verification failed` when `.sig` / `.pem` don't correspond to the file.
+- `cosign verify-blob` returns `error: certificate identity does not match` when the regex is wrong, or `bundle verification failed` when `.bundle` doesn't correspond to the file.
 
 ### Why one atomic job
 


### PR DESCRIPTION
Closes #93. Alternative to #92.

## Problem

`cosign sign-blob` fails in the release workflow with:

```
Error: signing SHA256SUMS.txt: create bundle file: open : no such file or directory
```

`sigstore/cosign-installer@v4.1.1` without a pinned `cosign-release` installs cosign v3.x, which switched `sign-blob` to `--new-bundle-format` by default. Under the new default, `--output-certificate` and `--output-signature` are silently ignored, and the workflow does not pass `--bundle`, so the bundle path is empty and the file-open fails.

## Why bundle migration over the v2.6.0 pin (#92)

[#92](https://github.com/netresearch/skill-repo-skill/pull/92) pins `cosign-release: v2.6.0` to restore the legacy two-file output. That works as an immediate unblock, but it leaves us on a cosign line that is on the deprecation track and trades a release outage today for a forced migration later. The actual migration (this PR) is small enough to do now: 9 lines of diff in `release.yml`, 3 lines in the consumer doc.

| | Pin v2.6.0 (#92) | This PR |
|---|---|---|
| Lines changed | 9 | 22 (incl. comments) |
| Unblocks releases | ✅ | ✅ |
| Future-proof | ❌ — v2.x is deprecation-track | ✅ — Sigstore's recommended format |
| Consumer breaking change | None | Yes — see migration note below |
| Maintenance burden | Need to track v2.x CVEs and revisit | Done |

## Changes

`.github/workflows/release.yml`:
- Sign step: `cosign sign-blob --bundle SHA256SUMS.txt.bundle SHA256SUMS.txt` (single self-contained Sigstore bundle: cert + signature + Rekor inclusion proof).
- Verify step: `cosign verify-blob --bundle SHA256SUMS.txt.bundle …` — replaces the v2 `--certificate` + `--signature` pair.
- Header comment + inline verify recipe updated to the bundle form.
- Cosign installer remains unpinned (no `cosign-release`) — v3+ is now what we want.

`skills/skill-repo/references/release-discipline.md`:
- Step 3 of the supply-chain attestation flow now reflects `SHA256SUMS.txt.bundle`.
- Consumer-facing `cosign verify-blob` recipe uses `--bundle`.
- Verification-error description updated.

`softprops/action-gh-release` already uses `files: dist/releases/*`, so the new `.bundle` artifact is attached to the GitHub Release automatically — no change needed there.

## Migration note for downstream consumers

> ⚠️ Any scripted verification that downloads `SHA256SUMS.txt.pem` + `SHA256SUMS.txt.sig` from prior releases must switch to `SHA256SUMS.txt.bundle` and the `--bundle` flag. Past releases keep their original `.pem`/`.sig` artifacts; only releases produced after this PR ship the bundle.

Inside this org, the only consumer that pinned to the v2 form is the `release-discipline.md` recipe in this same PR, so the migration is self-contained.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, cut a test release on a non-critical skill and confirm:
  - [ ] Sign step succeeds
  - [ ] Verify step succeeds against the new `.bundle`
  - [ ] `SHA256SUMS.txt.bundle` is attached to the GitHub Release
  - [ ] `gh attestation verify` still passes against the archives (separate from cosign — unchanged here)