### PR TITLE
docs(skill-repo): GitHub Pages policy + canonical category enum (follow-up to #96)

### DIFF
--- a/skills/skill-repo/references/repository-quality-rules.md
+++ b/skills/skill-repo/references/repository-quality-rules.md
@@ -80,3 +80,53 @@ Bei Änderungen an Discovery-Inhalten: siehe [`marketplace-integration.md`](mark
 - **PASS:** At least **one** stack tag (`typo3`, `php`, `docker`, …) or domain tag (`testing`, `security`, `frontend`, …) matching the skill.
 - **FAIL:** Irrelevant trending tags just for visibility (keyword stuffing).
 - Document proposed topics in README under `## Repository extras` if maintainers cannot edit Topics immediately.
+
+---
+
+## GitHub Pages policy
+
+The [marketplace](https://github.com/netresearch/claude-code-marketplace) is the canonical public discovery and storytelling layer for all Netresearch Agent Skills. Repository Pages are **secondary, skill-specific documentation surfaces**.
+
+### Default: Pages disabled
+
+Skill repositories **must not** enable GitHub Pages by default.
+
+- **PASS:** `gh api repos/netresearch/<repo>/pages` returns **HTTP 404** (Pages disabled).
+- **FAIL:** Pages is enabled without satisfying the criteria below.
+
+### When Pages is appropriate
+
+Enable GitHub Pages only when the repository contains standalone public material that is too large, too visual, too navigational, or too strategically important to live well in `README.md`. **At least one** of the following must be true:
+
+- the documentation requires multiple pages,
+- the skill has a gallery of examples, reports, dashboards, screenshots or demos,
+- the skill publishes generated reference documentation,
+- the skill provides versioned documentation,
+- the skill is a public reference implementation,
+- the skill explains a reusable methodology or assessment model,
+- the skill has a specific SEO target that the marketplace landing cannot cover without becoming too broad.
+
+### When Pages is NOT appropriate
+
+Do not enable Pages if the site would only duplicate:
+
+- the README,
+- the marketplace detail page (`https://github.com/netresearch/claude-code-marketplace#<slug>` or the future landing),
+- installation instructions,
+- `SKILL.md`,
+- the basic example prompts.
+
+### Mandatory artefacts when Pages is enabled
+
+If Pages is enabled, the repository **must** include:
+
+- a short justification block in `README.md` (which criterion above is satisfied),
+- a documented canonical URL pointing at the Pages site,
+- a clear source path (default: `docs/`),
+- documented build and deployment commands (`make docs`, `npm run docs`, or equivalent — referenced from the README),
+- link-checking or equivalent validation in CI,
+- a note explaining which content belongs on Pages vs. README vs. marketplace.
+
+### Mirroring rule
+
+Skill-specific metadata originates in the skill repository (`metadata/discovery.yaml`, README sections, `agents/openai.yaml`, GitHub settings). The marketplace consumes it. Do not duplicate the same metadata across README, Pages site and marketplace landing — pick one canonical surface per fact and link from the others.

--- a/skills/skill-repo/references/skill-discovery-metadata.md
+++ b/skills/skill-repo/references/skill-discovery-metadata.md
@@ -62,10 +62,11 @@ Fields:
 
 - **`slug`**: stable id; usually matches plugin/skill name.
 - **`display_name`**: public title (may differ from `name` in `SKILL.md`).
-- **`summary.en` / `summary.de`**: one short paragraph each; `de` optional unless DACH/TYPO3/Oro focus.
-- **`category` / `tags` / `use_cases`**: for README tables and marketplace sync.
+- **`summary.en` / `summary.de`**: one short paragraph each; `de` optional unless DACH/TYPO3/Oro focus. **`summary.en` should be ≤ 300 chars** (snippet-friendly target; the marketplace enforces a hard cap of 500).
+- **`category`**: **one of** the canonical marketplace categories — `development`, `devops`, `security`, `design`, `workflow`, `productivity`. Keep this in sync with the marketplace `AGENTS.md` canonical list; do not invent ad-hoc values.
+- **`tags` / `use_cases`**: for README tables and marketplace sync.
 - **`expected_outputs` / `context_requirements`**: must mirror README sections (single source: generate README from this file or maintain parity explicitly).
-- **`related_skills`**: slugs or full GitHub URLs; see [`repository-quality-rules.md`](repository-quality-rules.md).
+- **`related_skills`**: slugs or full GitHub URLs; see [`repository-quality-rules.md`](repository-quality-rules.md). Entries that don't yet exist in the catalog can be tagged `(planned)` or `(external)` — never invent fake links for SEO.
 - **`example_prompts`**: align with README **Example prompts** (≥3 in README per checklist).
 - **`primary_keywords`**: align with GitHub Topics + first sentence of summaries.
 

--- a/skills/skill-repo/references/validation-checklist.md
+++ b/skills/skill-repo/references/validation-checklist.md
@@ -32,6 +32,11 @@ Marketplace-only checks live in **`netresearch/claude-code-marketplace`/`AGENTS.
 - [ ] Repository **Description** ≤ **160** characters, names concrete tech or use case — not generic “AI assistant”.
 - [ ] **Topics** include `agent-skill` plus relevant tech/domain tags; no irrelevant stuffing.
 
+## GitHub Pages
+
+- [ ] `gh api repos/netresearch/<repo>/pages` returns **HTTP 404** (Pages disabled — the default).
+- [ ] **If Pages is enabled:** the PR description names which `repository-quality-rules.md` Pages criterion is satisfied, and the README contains the mandatory artefacts (justification, canonical URL, source path, build/deploy commands, link-checking, content-split note).
+
 ## Related skills
 
 - [ ] Related skills list is **honest** (exists, planned, or external) — see [`repository-quality-rules.md`](repository-quality-rules.md).


### PR DESCRIPTION
## Summary

Layered on top of [#96](https://github.com/netresearch/skill-repo-skill/pull/96) (which already shipped `repository-quality-rules.md`, `skill-discovery-metadata.md`, `readme-template.md`, `validation-checklist.md`). Addresses two follow-up rule sets without duplicating the scaffolding.

## What changes

### `references/repository-quality-rules.md`

New top-level **GitHub Pages policy** section:

- Default state: Pages **disabled** (`gh api repos/netresearch/<repo>/pages` → HTTP 404).
- Seven *when-appropriate* criteria: multi-page docs, gallery, generated reference, versioned docs, public reference implementation, methodology/assessment model, distinct SEO target.
- Explicit *not appropriate* list (README, marketplace landing, install instructions, `SKILL.md`, basic example prompts).
- Mandatory artefacts when enabled: justification, canonical URL, source path, build/deploy commands, link-checking, README/Pages/marketplace content-split note.
- Mirroring rule: discovery metadata originates in the skill repo; no triple duplication across surfaces.

### `references/skill-discovery-metadata.md`

- `summary.en` ≤ 300 chars (snippet-friendly target; marketplace hard cap is 500).
- `category` restricted to the canonical marketplace enum (`development`, `devops`, `security`, `design`, `workflow`, `productivity`, `document`).
- `related_skills` may be tagged `(planned)` or `(external)`; fake SEO links are not allowed.

### `references/validation-checklist.md`

- New **GitHub Pages** checklist section enforcing default-disabled state and PR-description justification when intentionally enabled.

## Paired PR

Marketplace consumer rules: [`netresearch/claude-code-marketplace#43`](https://github.com/netresearch/claude-code-marketplace/pull/43).

## Test plan

- [x] `bash skills/skill-repo/scripts/validate-skill.sh .` exits 0 with 0 warnings.