### PR TITLE
chore(release): v1.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.19.1"
+  version: "1.20.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
## Release v1.20.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/skill-repo/SKILL.md` frontmatter `metadata.version` from `1.19.1` to `1.20.0`.

### Highlights since v1.19.1

- **Release workflow hardened end-to-end** — bump-via-API path removed, signed annotated tags now required, cosign sign-blob migrated to v3 bundle format, attest+publish folded into one atomic job, cosign cert identity pinned to the reusable workflow (not the caller). Net effect: consumers get a verifiable release pipeline with no race window where unattested artefacts are downloadable.
- **SLSA build provenance is always-on** for every release archive; consumers can verify with `gh attestation verify`.
- **npm distribution** — `skill-repo-skill` itself now ships as an npm package via `@netresearch/agent-skill-coordinator`, and `templates/package.json.template` bakes that default in so new skill repos don't drift.
- **Skill quality rules + audit script** — `scripts/audit-skills.sh` and a 500-word body cap with structured frontmatter rules; cited across the docs.
- **retro-skill integration** — materialization contract + templates that downstream skill repos consume.
- **GitHub Pages policy + canonical category enum** documented; related-skills can now be marked `planned` / `external`.
- **Checkpoint quality fixes** — SR-21, SR-30, SR-31, SR-35 rewrites to satisfy command allowlists, runner regex compat, and stale prompts.

### Release plan

After merge: tag main with a signed annotated tag, push, the reusable workflow at `netresearch/skill-repo-skill/.github/workflows/release.yml@main` publishes archives + SHA256SUMS with cosign + SLSA attestation, then narrative notes get applied via `gh release edit --notes-file`.

Part of the coordinated rollout across all Netresearch skill repos.