### PR TITLE
fix(release): use .sigstore.json extension for cosign signature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,11 @@ name: Release Skill
 #   1. Build the archives (zip + tar.gz).
 #   2. Generate SHA256SUMS.txt over them.
 #   3. Cosign sign-blob (keyless / Sigstore) the SHA256SUMS.txt
-#      → SHA256SUMS.txt.bundle (Sigstore bundle format: cert + sig + Rekor
-#      inclusion proof in a single self-contained file; cosign v3+ default).
+#      → SHA256SUMS.txt.sigstore.json (Sigstore bundle format: cert + sig +
+#      Rekor inclusion proof in a single self-contained JSON; cosign v3+
+#      default). The `.sigstore.json` extension is chosen so OSSF Scorecard's
+#      signed-releases probe recognises it — content is identical to cosign's
+#      `--bundle` default output; only the file name differs.
 #   4. SLSA build-provenance attest the archives + SHA256SUMS.txt via
 #      actions/attest-build-provenance → published to GitHub's attestation API.
 #   5. softprops/action-gh-release creates the Release with all assets at once.
@@ -48,7 +51,7 @@ name: Release Skill
 # (this reusable workflow), NOT the caller; pin the regex to skill-repo-skill,
 # not the consuming repo:
 #   cosign verify-blob \
-#     --bundle SHA256SUMS.txt.bundle \
+#     --bundle SHA256SUMS.txt.sigstore.json \
 #     --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
 #     SHA256SUMS.txt
@@ -248,7 +251,7 @@ jobs:
           # output (--output-certificate / --output-signature) is deprecated and
           # silently ignored when --new-bundle-format is the default.
           cosign sign-blob --yes \
-            --bundle SHA256SUMS.txt.bundle \
+            --bundle SHA256SUMS.txt.sigstore.json \
             SHA256SUMS.txt
 
       - name: Verify Cosign signature
@@ -270,7 +273,7 @@ jobs:
           # character. We don't pin a specific ref because the reusable may be
           # referenced via `@main`, a SHA, or a future tag of skill-repo-skill.
           cosign verify-blob \
-            --bundle SHA256SUMS.txt.bundle \
+            --bundle SHA256SUMS.txt.sigstore.json \
             --certificate-identity-regexp "^https://github\.com/${SIGNER_REPO}/\.github/workflows/release\.yml@" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             SHA256SUMS.txt

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -130,7 +130,7 @@ All of this happens in the SAME job that publishes the GitHub Release, BEFORE th
 
 1. Build `*.zip` and `*.tar.gz` archives.
 2. Generate `SHA256SUMS.txt` over them.
-3. **Cosign** keyless `sign-blob` the `SHA256SUMS.txt` → produces `SHA256SUMS.txt.bundle` (Sigstore bundle format: cert + signature + Rekor inclusion proof in a single self-contained file; cosign v3+ default).
+3. **Cosign** keyless `sign-blob` the `SHA256SUMS.txt` → produces `SHA256SUMS.txt.sigstore.json` (Sigstore bundle format: cert + signature + Rekor inclusion proof in a single self-contained JSON; cosign v3+ default). The `.sigstore.json` extension is chosen so OSSF Scorecard's `signed-releases` probe recognises the signature — the content is identical to cosign's `--bundle` default output.
 4. **`actions/attest-build-provenance`** generates a SLSA build-provenance attestation for the archives + checksums file → published to GitHub's attestation API.
 5. **`softprops/action-gh-release`** publishes the GitHub Release with all assets attached at once.
 
@@ -167,7 +167,7 @@ gh attestation verify <skill-name>-skill-vX.Y.Z.zip --repo netresearch/<repo-nam
 # `https://github.com/netresearch/.*` would accept signatures from any repo,
 # branch, or workflow in the org — too loose for supply-chain verification.
 cosign verify-blob \
-  --bundle SHA256SUMS.txt.bundle \
+  --bundle SHA256SUMS.txt.sigstore.json \
   --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   SHA256SUMS.txt
@@ -179,7 +179,7 @@ sha256sum --check SHA256SUMS.txt
 If verification fails:
 
 - `gh attestation verify` returns `error: no attestations found` when `--repo` is wrong (or when the release predates this workflow).
-- `cosign verify-blob` returns `error: certificate identity does not match` when the regex is wrong, or `bundle verification failed` when `.bundle` doesn't correspond to the file.
+- `cosign verify-blob` returns `error: certificate identity does not match` when the regex is wrong, or `bundle verification failed` when `.sigstore.json` doesn't correspond to the file.
 
 ### Why one atomic job
 


### PR DESCRIPTION
## Summary

OSSF Scorecard's `signed-releases` probe scores `0/high` for every skill-repo release despite shipping a valid Sigstore bundle. Root cause: the probe is purely suffix-based and the recognised extensions are:

> `.asc`, `.minisig`, `.sig`, `.sign`, `.sigstore`, `.sigstore.json`

— see [`ossf/scorecard probes/releasesAreSigned/impl.go#L43`](https://github.com/ossf/scorecard/blob/main/probes/releasesAreSigned/impl.go#L43).

We were emitting `SHA256SUMS.txt.bundle` (cosign's `--bundle` default file name), which is not in that list.

## Change

Rename the output of `cosign sign-blob --bundle SHA256SUMS.txt.bundle` to `SHA256SUMS.txt.sigstore.json`. The bundle content is **identical** — still cosign's Sigstore bundle JSON (cert + signature + Rekor inclusion proof in one self-contained file). Only the filename extension changes.

Verification still works without any caller change:

```bash
cosign verify-blob --bundle SHA256SUMS.txt.sigstore.json …
```

Files changed:

- `.github/workflows/release.yml` — header comment + `cosign sign-blob` call + `cosign verify-blob` call
- `skills/skill-repo/references/release-discipline.md` — documentation snippets

## Impact

- **All current skill-repo consumers** (matrix-skill, github-project-skill, jira-skill, etc.) get a passing Scorecard `Signed-Releases` score on their next tag.
- **Existing releases**: unaffected (already published, immutable). Historical `SHA256SUMS.txt.bundle` assets remain valid Sigstore bundles, just unrecognised by Scorecard.

## Sibling PR

netresearch/.github#129 applies the same fix to `release-go-app.yml`. `typo3-ci-workflows` was already correct (`.sigstore.json`).

## Test plan

- [ ] CI passes
- [ ] Next skill-repo release (via consumer tag-push) publishes `SHA256SUMS.txt.sigstore.json` instead of `SHA256SUMS.txt.bundle`
- [ ] Re-run OSSF Scorecard on a consumer repo after the next release → `Signed-Releases` score moves from 0 to non-zero