### PR TITLE
feat: expose scripts as pre-commit hooks via .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,57 @@
+# Pre-commit hooks exposed by netresearch/skill-repo-skill.
+#
+# Consume from a skill repo's .pre-commit-config.yaml:
+#
+#   repos:
+#     - repo: https://github.com/netresearch/skill-repo-skill
+#       rev: vX.Y.Z   # pin a tag; Renovate / Dependabot will bump
+#       hooks:
+#         - id: validate-skill
+#         - id: validate-evals
+#         - id: check-version-parity
+#
+# Each hook is a thin wrapper around the corresponding script in
+# skills/skill-repo/scripts/. The hooks intentionally do NOT receive the
+# staged-file list (pass_filenames: false) — the underlying scripts operate
+# on the whole repo state, not the diff. The `files:` filter only controls
+# WHEN the hook fires.
+
+- id: validate-skill
+  name: Validate skill repo structure
+  description: >-
+    Run validate-skill.sh against the repo when skill metadata changes
+    (SKILL.md, checkpoints.yaml, plugin.json, composer.json).
+  entry: bash skills/skill-repo/scripts/validate-skill.sh
+  language: script
+  pass_filenames: false
+  files: >-
+    (^skills/.+/SKILL\.md$|^SKILL\.md$|
+    ^skills/.+/checkpoints\.yaml$|^checkpoints\.yaml$|
+    ^\.claude-plugin/plugin\.json$|
+    ^composer\.json$)
+  require_serial: true
+
+- id: validate-evals
+  name: Validate evals.json structure
+  description: >-
+    Run validate-evals.sh when any evals.json changes (schema, IDs, grading).
+  entry: bash skills/skill-repo/scripts/validate-evals.sh
+  language: script
+  pass_filenames: false
+  files: '(^skills/.+/evals/evals\.json$|^evals/evals\.json$)'
+  require_serial: true
+
+- id: check-version-parity
+  name: Plugin/SKILL/composer version parity
+  description: >-
+    Run check-version-parity.sh when a versioned artefact changes.
+    composer.json must NOT have a version field; plugin.json is the source
+    of truth and SKILL.md metadata.version must match.
+  entry: bash skills/skill-repo/scripts/check-version-parity.sh
+  language: script
+  pass_filenames: false
+  files: >-
+    (^\.claude-plugin/plugin\.json$|
+    ^skills/.+/SKILL\.md$|^SKILL\.md$|
+    ^composer\.json$)
+  require_serial: true


### PR DESCRIPTION
## Summary

Adds `.pre-commit-hooks.yaml` at the repo root so downstream skill repos can consume `validate-skill`, `validate-evals`, and `check-version-parity` as pre-commit hooks instead of curling the scripts from `@main` or vendoring copies that drift.

## Motivation

Closes the "validate-skill.sh stays CI-only" gap that was load-bearing in the agent-harness-skill rollout ([#27](https://github.com/netresearch/agent-harness-skill/pull/27) and [#28](https://github.com/netresearch/agent-harness-skill/pull/28)): with this PR plus a release tag, downstream skill repos pin the validator by `rev:` and Renovate / Dependabot bump it like any other pre-commit hook. Stays inside the Python pre-commit ecosystem skill repos already standardised on — no composer / PHP runtime dependency added.

## Consumption pattern

Once this lands and a release is tagged, any skill repo's `.pre-commit-config.yaml` adds:

```yaml
repos:
  - repo: https://github.com/netresearch/skill-repo-skill
    rev: vX.Y.Z
    hooks:
      - id: validate-skill
      - id: validate-evals
      - id: check-version-parity
```

## Design choices

- **`pass_filenames: false`** on all three hooks. The underlying scripts operate on the whole repo state (frontmatter + word count + cross-file consistency for validate-skill; multi-file search for validate-evals; multi-artefact version parity for check-version-parity). Passing the staged-file list would either be ignored or — worse — silently change the script's behaviour
- **`files:` filters** control WHEN each hook fires:
  - `validate-skill` → SKILL.md / checkpoints.yaml / plugin.json / composer.json
  - `validate-evals` → `**/evals/evals.json`
  - `check-version-parity` → any versioned artefact (plugin.json / SKILL.md / composer.json)
- **`require_serial: true`** because the scripts mutate state files (some inject defaults), so parallel runs against the same repo state are unsafe
- **`migrate-licensing.sh` intentionally NOT exposed** — it's a one-time migration tool, not a pre-commit gate. Wrong shape for hook semantics

## Verification

- `yamllint` under the CI default config (`line-length: max 200`) → clean
- `python3 -c "import yaml; yaml.safe_load(...)"` → 3 hooks parsed, all expected IDs
- Each `entry:` script exists at the path stated
- Each script runs cleanly against this repo (0 errors): `validate-skill`, `validate-evals` (43/0/0), `check-version-parity` (parity OK at 1.20.0)
- `pre-commit try-repo` against the committed branch recognises and runs the hooks

## Follow-ups (separate PRs)

1. **Tag a release** after merge so downstream consumers have a stable `rev:` to pin (the netresearch/agent-harness-skill `.pre-commit-config.yaml` adds the entry once a tag exists)
2. **Add `.pre-commit-config.yaml` to skill-repo-skill itself** dogfooding its own newly-exposed hooks (separate PR; needs `lefthook` / `pre-commit` choice review since this repo has its own composer.json — likely still `.pre-commit-config.yaml` for consistency with the rest of the skill fleet)
3. **Back-port to the ~40 downstream skill repos** once a tag is cut