### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.20.0"
+  version: "1.21.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
## Summary

Release bump: plugin.json and SKILL.md `metadata.version` from `1.20.0` to `1.21.0`.

## Headline change since v1.20.0

**[#105](https://github.com/netresearch/skill-repo-skill/pull/105) — Expose scripts as pre-commit hooks via `.pre-commit-hooks.yaml`.** Downstream skill repos can now consume `validate-skill`, `validate-evals`, and `check-version-parity` as pre-commit hooks pinned by `rev:`, closing the "validate-skill.sh stays CI-only" gap that was load-bearing in the agent-harness-skill CI/Hook Parity rollout. Stays inside the Python pre-commit ecosystem — no composer / PHP dependency added.

After this PR merges, a signed `v1.21.0` tag will trigger the Release workflow (notes, archives, sigstore signatures, attestations) and unlock consumption from downstream skill repos:

```yaml
repos:
  - repo: https://github.com/netresearch/skill-repo-skill
    rev: v1.21.0
    hooks:
      - id: validate-skill
      - id: validate-evals
      - id: check-version-parity
```

## Other since v1.20.0

- chore(deps): harden-runner v2.19.4 ([#104](https://github.com/netresearch/skill-repo-skill/pull/104))
- chore(deps): codecov-action v6.0.1 ([#103](https://github.com/netresearch/skill-repo-skill/pull/103))
- fix(release): `.sigstore.json` extension for cosign signature ([#102](https://github.com/netresearch/skill-repo-skill/pull/102))

## Verification

`check-version-parity.sh v1.21.0` → OK. `validate-skill.sh` → 0 errors, 0 warnings.