### PR TITLE
feat(ci): add actionlint step to reusable validate.yml (v1.22.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,6 +76,12 @@ jobs:
       - name: YAML lint
         uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
 
+      - name: actionlint (GitHub Actions workflows)
+        id: actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+        with:
+          fail_on_error: true
+
       - name: Validate plugin version format
         run: |
           PLUGIN_FILE=".claude-plugin/plugin.json"

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.21.1"
+  version: "1.22.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
## Summary

Adds an actionlint step to the reusable `validate.yml` workflow so all GitHub Actions workflow files in downstream skill repos get semantic linting on every CI run — not just yamllint well-formedness.

Bumps to **v1.22.0**.

## Motivation

This unblocks downstream skill repos (~42 of them) from adding the `rhysd/actionlint` hook to their `.pre-commit-config.yaml`. Until this CI gate exists, a local actionlint hook violates the CI/Hook Parity Principle declared in `netresearch/agent-harness-skill` (the local set MUST be a subset of the CI set). [agent-harness-skill #29](https://github.com/netresearch/agent-harness-skill/pull/29) explicitly dropped its local actionlint hook for exactly this reason.

After this lands and `v1.22.0` is tagged, every skill repo that adopts the standard `.pre-commit-config.yaml` template will pick up actionlint automatically — locally via the pre-commit hook, in CI via this reusable workflow.

## Implementation

`raven-actions/actionlint@205b530...` (v2.1.2) — thin wrapper around `rhysd/actionlint`. SHA-pinned per the third-party-action policy. `fail_on_error: true` so any finding blocks the workflow.

## Verification

- `actionlint v1.7.12` against the modified `validate.yml` → clean (no actionlint complaining about its own addition)
- `yamllint` against the modified `validate.yml` → clean
- `check-version-parity.sh v1.22.0` → OK
- `validate-skill.sh` → 0 errors, 0 warnings

## Release sequence

After merge: signed `git tag -s v1.22.0` → push → Release workflow.

## Follow-up

The skill-repo-skill repo itself (this PR) is the first user of the new actionlint step — its own validate.yml is checked by raven-actions/actionlint when this PR's CI runs. Any actionlint complaint about another workflow in this repo would surface now.