### PR TITLE
feat: dogfood pre-commit hooks via .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+# Pre-commit hooks — embodies the CI/Hook Parity Principle for this repo.
+#
+# Every hook below ALSO runs in CI; CI is the authoritative backstop. Local
+# hooks are pinned by `rev:` and Renovate bumps them automatically. There is
+# a small drift window between a Renovate bump in CI and the local config
+# catching up; this is the standard pre-commit pattern.
+#
+# This repo dogfoods its own hooks (validate-skill, check-version-parity from
+# skill-repo-skill itself).
+#
+# See netresearch/agent-harness-skill references/enforcement-mechanisms.md
+# for the CI/Hook Parity Principle in full.
+#
+# Install once after clone: `pre-commit install` (auto-runs via package.json's
+# `prepare` script when contributors run `npm install`).
+# Bypass (use sparingly): `git commit --no-verify`. If you need this often,
+# the hook is wrong — fix it; don't tolerate the bypass.
+
+default_install_hook_types: [pre-commit]
+default_stages: [pre-commit]
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-added-large-files
+      - id: check-json
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+
+  - repo: https://github.com/netresearch/skill-repo-skill
+    rev: v1.22.0
+    hooks:
+      - id: validate-skill
+      - id: check-version-parity
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+        files: '\.md$'
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: [-c, .yamllint.yml]
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.14
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,12 @@
+# Match the default config CI injects when no local file is present.
+# See netresearch/skill-repo-skill .github/workflows/validate.yml.
+extends: default
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  indentation: disable
+  line-length:
+    max: 200
+  truthy:
+    allowed-values: ['true', 'false', 'on']

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   ],
   "peerDependencies": {
     "@netresearch/agent-skill-coordinator": "^0.1"
+  },
+  "scripts": {
+    "prepare": "command -v pre-commit >/dev/null && pre-commit install --install-hooks 2>/dev/null || true"
   }
 }


### PR DESCRIPTION
## Summary

This repo now consumes its own [v1.22.0](https://github.com/netresearch/skill-repo-skill/releases/tag/v1.22.0) pre-commit hooks (`validate-skill`, `check-version-parity`) via a top-level `.pre-commit-config.yaml`. Embodies the CI/Hook Parity Principle declared in [`netresearch/agent-harness-skill`](https://github.com/netresearch/agent-harness-skill).

First in a pilot rollout (skill-repo-skill self → go-development-skill → security-audit-skill → php-modernization-skill) before fleet-wide back-port to the remaining ~38 NR skill repos.

## Files

- **`.pre-commit-config.yaml`** — standard NR skill-repo hook set:
  - `pre-commit-hooks`: `trailing-whitespace`, `end-of-file-fixer`, `check-merge-conflict`, `check-added-large-files`, `check-json`, `check-yaml`
  - `netresearch/skill-repo-skill@v1.22.0`: `validate-skill`, `check-version-parity` (self-consumed)
  - `markdownlint-cli2`, `yamllint`, `actionlint`, `ruff` (+ format), `shellcheck`
- **`.yamllint.yml`** — matches the default CI injects in `validate.yml`, so local and CI lint identically (no longer relying on CI's lazy fallback). Single source of truth.
- **`package.json`** — adds `scripts.prepare` running `pre-commit install --install-hooks` if pre-commit is on PATH; silent no-op otherwise. Auto-activates hooks on `npm install`.

## Verification

End-to-end against this branch:

```
$ pre-commit run validate-skill --files .claude-plugin/plugin.json
Validate skill repo structure............................................Passed

$ pre-commit run check-version-parity --files .claude-plugin/plugin.json
Plugin/SKILL/composer version parity.....................................Passed

$ pre-commit run actionlint --files .github/workflows/validate.yml
Lint GitHub Actions workflow files.......................................Passed
```

The commit itself was made through `pre-commit install`'d hooks — all green.