### PR TITLE
fix(ci): rename fail_on_error → fail-on-error in validate.yml (v1.22.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,7 +80,7 @@ jobs:
         id: actionlint
         uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
         with:
-          fail_on_error: true
+          fail-on-error: true
 
       - name: Validate plugin version format
         run: |

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.22.0"
+  version: "1.22.1"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---
@@ -121,4 +121,4 @@ scripts/validate-skill.sh
 
 ---
 
-> **Contributing:** https://github.com/netresearch/skill-repo-skill
+> **Contributing:** <https://github.com/netresearch/skill-repo-skill>


### PR DESCRIPTION
## Summary

Two small fixes bundled for v1.22.1:

1. **`fail_on_error` → `fail-on-error`** in the reusable `validate.yml`'s actionlint step. raven-actions/actionlint expects the dashed name; v1.22.0 shipped the underscored form, which surfaced as a warning on every consumer PR across the deployed fleet (38 NR skill repos pulling `validate.yml@main`). Behaviour was already correct (action defaults `fail-on-error` to `true`), but the noise was visible everywhere.

2. **Wrap bare URL** in `skills/skill-repo/SKILL.md:124` in autolink syntax (`<https://...>`). Pre-existing — not related to the actionlint typo. Surfaced by the local `markdownlint-cli2` pre-commit hook (now available via [#109](https://github.com/netresearch/skill-repo-skill/pull/109) v1.21.1) blocking my commit. Exactly the CI/Hook Parity Principle paying off: local hook catches MD034 before CI would.

Bumps to **v1.22.1**.

## Verification

- `actionlint .github/workflows/validate.yml` → clean
- `yamllint -c .yamllint.yml .github/workflows/validate.yml` → clean
- `check-version-parity.sh v1.22.1` → OK
- `validate-skill.sh` → 0 errors, 0 warnings
- All local pre-commit hooks → Passed (including `markdownlint-cli2`)

## Release sequence

After merge: signed `git tag -s v1.22.1` → push → Release workflow.