### PR TITLE
chore(ci): add zizmor config + fix template-injection and dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -54,7 +54,11 @@ jobs:
           enable-cache: true
 
       - name: Run Bandit
-        run: uv run --with bandit bandit ${{ inputs.bandit-args }}
+        env:
+          BANDIT_ARGS: ${{ inputs.bandit-args }}
+        run: |
+          # shellcheck disable=SC2086  # intentional: BANDIT_ARGS is a list of flags
+          uv run --with bandit bandit $BANDIT_ARGS
 
   test:
     name: Test (Python ${{ matrix.python }})
@@ -81,6 +85,10 @@ jobs:
       - name: Run tests
         env:
           PYTHON_VERSION: ${{ matrix.python }}
+        # zizmor: ignore[template-injection] -- caller-supplied test command; this reusable
+        # workflow runs it verbatim by design. Input comes from the trusted calling repo, not
+        # external/untrusted context, and may be a compound command (a && b) so env indirection
+        # would change behaviour.
         run: ${{ inputs.test-command }}
 
       - name: Upload coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,9 @@ jobs:
 
       - name: Determine tag version
         id: version
-        run: echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Checkout at tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -234,7 +236,7 @@ jobs:
           echo "Created ${PLUGIN_NAME}-plugin-${TAG_VERSION}.zip/.tar.gz"
 
           # --- Checksums ---
-          (cd dist/releases && sha256sum *.zip *.tar.gz > SHA256SUMS.txt)
+          (cd dist/releases && sha256sum ./*.zip ./*.tar.gz > SHA256SUMS.txt)
           echo ""
           echo "=== Release packages ==="
           ls -lh dist/releases/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,3 +21,9 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+
+  zizmor:
+    permissions:
+      contents: read
+      security-events: write
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the audit reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin


### PR DESCRIPTION
Adds a [zizmor](https://zizmor.sh) config tuned to NR conventions and fixes the genuinely actionable findings a baseline audit surfaced.

## Changes

**`.github/zizmor.yml` (new)** — `unpinned-uses` uses the `ref-pin` policy for first-party `netresearch/*` refs (they track `@main` by standing convention so fixes propagate); all third-party actions remain `hash-pin` enforced.

**`ci-python.yml` — template injection (HIGH)** — `${{ inputs.bandit-args }}` is now bound to an `env:` var. `${{ inputs.test-command }}` is marked with a justified `# zizmor: ignore[template-injection]`: this reusable workflow runs the caller-supplied command verbatim **by design**, the input comes from the trusted calling repo (not external context), and it may be a compound command (`a && b`) that env indirection would break.

**`release.yml` — template injection (HIGH)** — `${{ github.ref_name }}` bound to an `env:` var before being echoed into `GITHUB_OUTPUT` (tag names can contain shell metacharacters). Also fixes a **pre-existing** shellcheck SC2035 (`sha256sum ./*.zip ./*.tar.gz`) that the actionlint pre-commit hook required to pass.

**`dependabot.yml` — cooldown (MEDIUM)** — added `cooldown: { default-days: 7 }`.

## Result

All template-injection highs and the first-party `unpinned-uses` highs are cleared.

## Out of scope (follow-ups)

Remaining findings are review items, not blind fixes:
- `artipacked` (15×) — `persist-credentials: false` sweep on `actions/checkout` (must confirm no step pushes with the token first).
- `excessive-permissions` (3×) — add least-privilege `permissions:` to `security.yml`.
- `dangerous-triggers` (1×) — `pull_request_target` in `auto-merge-deps-caller.yml`; confirm-then-annotate.

Verified locally with `actionlint`; all pre-commit hooks pass.