### PR TITLE
chore(release): v1.23.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.22.1"
+  version: "1.23.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Release **v1.23.0** (minor bump, conventional commits since v1.22.1).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 1.23.0.

Changes since v1.22.1:
- chore(ci): add zizmor config and fix template-injection + dependabot cooldown
- 
- - Add .github/zizmor.yml: unpinned-uses uses ref-pin for first-party
-   netresearch/* refs (they track @main by policy); third-party actions
-   stay hash-pin enforced.
- - ci-python.yml: bind ${{ inputs.bandit-args }} to an env var; mark the
-   caller-supplied ${{ inputs.test-command }} run with a justified
-   template-injection ignore (runs verbatim by design, trusted caller).
- - release.yml: bind ${{ github.ref_name }} to an env var before echoing
-   into GITHUB_OUTPUT; also fix a pre-existing shellcheck SC2035 glob
-   (sha256sum ./*.zip) that the actionlint pre-commit hook flagged.
- - dependabot.yml: add cooldown: default-days: 7.
- 
- Clears all template-injection findings and the first-party unpinned-uses
- highs. Remaining findings (artipacked persist-credentials, excessive
- permissions, pull_request_target) are review items tracked as follow-ups.
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- feat(ci): run zizmor via shared reusable workflow
- 

After merge: a signed tag `v1.23.0` on `main` triggers the release workflow.