### PR TITLE
ci: set persist-credentials: false on artifact-uploading workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -48,6 +48,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -77,6 +79,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -28,6 +28,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
 
   shellcheck:
@@ -21,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: warning
@@ -32,4 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: bash skills/skill-repo/scripts/validate-skill.sh .

--- a/.github/workflows/npm-pack-smoke.yml
+++ b/.github/workflows/npm-pack-smoke.yml
@@ -32,6 +32,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -62,7 +64,7 @@ jobs:
           # `grep` returns 1 when no match — we WANT no match, so invert with `if`.
           if leaks=$(grep -E "$leak_pattern" tarball-files.txt); then
             echo "::error::Repo-internal files leaked into npm tarball:"
-            sed 's/^/  /' <<< "$leaks"
+            while IFS= read -r line; do echo "  $line"; done <<< "$leaks"
             echo "Tighten the \`files\` allowlist in package.json. See skills/skill-repo/references/installation-methods.md."
             exit 1
           fi

--- a/.github/workflows/validate-agents.yml
+++ b/.github/workflows/validate-agents.yml
@@ -31,6 +31,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -86,6 +88,8 @@ jobs:
                 echo "::error::Blank table rows in $name/AGENTS.md"
                 FAILED=1
               fi
+              # The `$` end-anchor and backticks below are literal regex, not shell expansion:
+              # shellcheck disable=SC2016
               if grep -qE '(^|[^`])``([^`]|$)' "$fixture/AGENTS.md"; then
                 echo "::error::Empty backticks in $name/AGENTS.md"
                 FAILED=1
@@ -111,6 +115,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate AGENTS.md structure
         env:


### PR DESCRIPTION
## Summary

Sets `persist-credentials: false` on the five workflows zizmor flags for *credential persistence through GitHub Actions artifacts* — they both check out the repo and upload artifacts, the combination zizmor's rule targets (artifact-poisoning risk). None of these jobs push or reuse the checkout token, so disabling credential persistence is safe and clears the code-scanning alerts.

This is the root-cause fix for the 9 zizmor alerts currently blocking #113 (the Renovate `actions/checkout` v6.0.3 bump). Once this lands, #113 rebases clean and its alerts clear.

## Workflows changed

`lint.yml`, `npm-pack-smoke.yml`, `validate-agents.yml`, `ci-python.yml`, `dependency-audit.yml`. `release.yml` is intentionally left untouched — it needs the token.

## Also

Resolved the two pre-existing shellcheck findings the local actionlint pre-commit hook flagged in these files (CI uses `fail_level: error`, so they were never CI-blocking, but the local hook fails on info/style):

- `npm-pack-smoke.yml`: indent leaked-path output with a bash `read` loop instead of `sed` (SC2001).
- `validate-agents.yml`: annotate the literal-regex `grep` pattern with `# shellcheck disable=SC2016` — the `$` end-anchor and backticks are regex, not shell expansion.