### PR TITLE
feat(readme): rule — reference docs are present-tense, never narrate change

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.23.0"
+  version: "1.24.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---

--- a/skills/skill-repo/references/readme-template.md
+++ b/skills/skill-repo/references/readme-template.md
@@ -55,7 +55,7 @@ Reference docs (README, `SKILL.md`, reference files, module headers) describe **
 | `Example prompts` | ≥3 prompts. |
 | `Related skills` | ≥1 link/slug **or** justified none. |
 | `Installation` | Mentions marketplace **or** documents exclusive alternate with owner approval in README. |
-| Present-tense voice | `grep -niE 'no longer\|reframed\|previously\|used to\|derives? from\|downstream\|not its source\|is not a (router\|wrapper)'` over README/`SKILL.md` returns nothing — change-narration belongs in `CHANGELOG`/`UPGRADING`. |
+| Present-tense voice | `grep -rin -e 'no longer' -e 'reframed' -e 'previously' -e 'used to' -e 'derive' -e 'downstream' -e 'not its source' -e 'is not a router'` over README/`SKILL.md` returns nothing — change-narration belongs in `CHANGELOG`/`UPGRADING`. |
 
 ---
 

--- a/skills/skill-repo/references/readme-template.md
+++ b/skills/skill-repo/references/readme-template.md
@@ -36,6 +36,17 @@ Use **exact** level-2 headings so agents can grep them:
 
 ---
 
+## Voice: present tense, never narrate change
+
+Reference docs (README, `SKILL.md`, reference files, module headers) describe **what the skill is and how to use it, in plain present tense — as if it had always been this way**. They must **not** describe the skill by what it is *not* or how it *changed*.
+
+- **Banned framing:** "no longer", "instead of", "reframed", "previously", "used to", "X derives from Y / downstream … not its source", "it is **not** a router/wrapper/…". This is the *curse of knowledge* as **negative / apophatic documentation** — it only parses for a reader who knew a prior design.
+- **Before the first release there is no audience for change.** Nobody ran a prior public version, so any before/after framing is noise and actively misleads (readers hunt for a "router" that never existed). The same holds for unreleased, in-between edits: the diff *is* the commit; the README must not know a change happened.
+- **History lives only in `CHANGELOG` / `UPGRADING` / release notes / ADRs / the commit log** — those have a reader (someone upgrading from a version they used) who needs the contrast. The README and `SKILL.md` never do.
+- A deprecation notice ("X is deprecated, use Y") is the one legitimate non-history contrast and belongs in the changelog/upgrade doc, not the "what this is" sections.
+
+---
+
 ## Cross-checks (machine-friendly)
 
 | Check | PASS criterion |
@@ -44,6 +55,7 @@ Use **exact** level-2 headings so agents can grep them:
 | `Example prompts` | ≥3 prompts. |
 | `Related skills` | ≥1 link/slug **or** justified none. |
 | `Installation` | Mentions marketplace **or** documents exclusive alternate with owner approval in README. |
+| Present-tense voice | `grep -niE 'no longer\|reframed\|previously\|used to\|derives? from\|downstream\|not its source\|is not a (router\|wrapper)'` over README/`SKILL.md` returns nothing — change-narration belongs in `CHANGELOG`/`UPGRADING`. |
 
 ---
 


### PR DESCRIPTION
## Why

A brand-new skill's docs were written by contrast against a prior design no reader ever saw ("this skill **is** the source of truth — it is **not** a router to somewhere else", "downstream artifacts **derive from** this, not its source"). On a repo with no release there is no "before" in any reader's head, so that framing is noise and misleads. This is the **curse of knowledge** as **negative/apophatic documentation**.

## What

Adds a **Voice: present tense, never narrate change** rule to `references/readme-template.md` + a machine-friendly grep cross-check:

- README / SKILL.md / reference docs describe what the skill **is**, in present tense, as if it had always been this way.
- Banned: `no longer`, `instead of`, `reframed`, `previously`, `derives from / downstream … not its source`, `it is not a router/wrapper`.
- **Pre-release / between releases → write zero change-docs.** History lives only in `CHANGELOG`/`UPGRADING`/release notes/ADRs/the commit log.
- Deprecation notices are the one legitimate non-history contrast.

`plugin.json` + `SKILL.md` bumped to 1.24.0 (parity); markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)