### PR TITLE
feat(validate): warn when a command is missing from the README

### DIFF
--- a/skills/skill-repo/references/readme-template.md
+++ b/skills/skill-repo/references/readme-template.md
@@ -32,6 +32,15 @@ Use **exact** level-2 headings so agents can grep them:
 - `## Contributing`
 - `## License`
 
+**Optional (skills that ship a `commands/` dir):** `## Commands` — a table or
+list enumerating **every** slash-command **and each of its modes / sub-commands
+/ flags**. When you add or rename a command *or a mode*, update this list in the
+**same change** — the implementation, its reference docs, and the README/AGENTS
+menus drift apart otherwise (a mode added everywhere except the README menu is a
+common, user-visible miss). `validate-skill.sh` warns when a command's `/<name>`
+(from `commands/<name>.md`) is not mentioned in the README, but it cannot see
+mode-level drift — that part is on the author.
+
 **Optional:** `## German summary` — short paragraph if DACH/TYPO3/Oro/agency audience; technical detail may remain English. The scaffold [`../templates/README.md.template`](../templates/README.md.template) ships this as a **commented block** after `## License` — uncomment when needed.
 
 ---
@@ -56,6 +65,7 @@ Reference docs (README, `SKILL.md`, reference files, module headers) describe **
 | `Related skills` | ≥1 link/slug **or** justified none. |
 | `Installation` | Mentions marketplace **or** documents exclusive alternate with owner approval in README. |
 | Present-tense voice | `grep -rin -e 'no longer' -e 'reframed' -e 'previously' -e 'used to' -e 'derive' -e 'downstream' -e 'not its source' -e 'is not a router'` over README/`SKILL.md` returns nothing — change-narration belongs in `CHANGELOG`/`UPGRADING`. |
+| `Commands` (if `commands/` exists) | Every `commands/<name>.md`, and each mode/flag it documents, is enumerated in the README. |
 
 ---
 

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -349,6 +349,25 @@ if [[ -f "$REPO_DIR/README.md" ]]; then
             warning "README.md missing recommended section (exact line ## ${heading}) — see skill-repo-skill skills/skill-repo/references/readme-template.md"
         fi
     done
+
+    # Every documented slash-command should be enumerated in the README so the
+    # command (and mode) list does not silently drift when one is added. Warning
+    # only: the name match is heuristic and a skill may intentionally omit one.
+    if [[ -d "$REPO_DIR/commands" ]]; then
+        for cmd_file in "$REPO_DIR"/commands/*.md; do
+            [[ -e "$cmd_file" ]] || continue
+            cmd_name="$(basename "$cmd_file" .md)"
+            # -F: match the command name literally (a filename with regex
+            # metacharacters can't break or mis-match). -w: require word
+            # boundaries, so `/work-update` does not match inside
+            # `commands/work-update.md` or a URL like `netresearch/work-update`.
+            if grep -qFw -- "/${cmd_name}" "$REPO_DIR/README.md"; then
+                success "README.md references /${cmd_name}"
+            else
+                warning "README.md does not mention command /${cmd_name} (commands/${cmd_name}.md) — keep the README command/mode list in sync when adding commands or modes"
+            fi
+        done
+    fi
 fi
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

A skill-authoring failure mode: you add a command or mode to `commands/` and
update the implementation + its reference docs, but forget the README menu users
actually read — it drifts silently. Surfaced by retro-skill v0.4.0
(`/retro promote` shipped documented everywhere *except* the README modes table;
a human caught it post-release). This puts the lesson at the broadest useful
scope — `skill-repo-skill` — so it helps **every** skill repo via the reusable
`validate.yml`.

## Changes

- **`validate-skill.sh`** — for each `commands/<name>.md`, emit a **warning**
  (non-blocking) when `/<name>` is not mentioned in `README.md`. Skips repos
  with no `commands/` dir; word-boundary match so `/check` ≠ `/checkout`.
- **`references/readme-template.md`** — documents an optional `## Commands`
  section and requires enumerating every command **and its modes/flags**, kept
  in sync in the same change. The mechanical check can't see mode-level drift —
  the template makes that the author's explicit responsibility.

## Verification

- `shellcheck -x -S error` clean.
- Fleet scan across all ~50 `~/p/*-skill` repos: **no crashes** (exit codes in
  {0,1}); correct `OK` for repos that list their commands (github-release,
  retro); **legitimate warnings** for 5 repos with real gaps
  (enterprise-readiness `/audit` `/slsa`, matrix `/work-update`,
  typo3-conformance `/check`, typo3-extension-upgrade `/assess` `/rector`,
  typo3-update-issues `/create-update-issues`).

Warning-only, so it nudges without breaking any consumer's CI; the 5 gaps get
fixed as those repos are next touched.

Came from `/retro`.
