### PR TITLE
#119: validate-skill.sh: accept all valid YAML scalar styles for description

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,4 +38,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - name: Set up uv
+        # Provides `uv run --with pyyaml` so the validator smoke test can cover
+        # the PyYAML-authoritative path in addition to the stdlib fallback.
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          cache-dependency-glob: ""
       - run: bash skills/skill-repo/scripts/validate-skill.sh .
+      - name: Validator smoke tests
+        run: bash tests/validate-skill.sh

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -85,8 +85,73 @@ if [[ -n "$SKILL_FILE" ]]; then
 
         # Check description field and prefix
         if echo "$FRONTMATTER" | grep -q "^description:"; then
-            DESC=$(echo "$FRONTMATTER" | grep "^description:" | head -1 | sed 's/description: *//' | sed 's/^"//' | sed 's/"$//')
-            if [[ "$DESC" == Use\ when* ]]; then
+            # Parse the *YAML value* of description so every valid scalar style
+            # (plain, single/double-quoted, block) is accepted as long as the
+            # parsed value starts with "Use when". Uses PyYAML when available,
+            # otherwise a stdlib-only fallback covering the common scalar styles,
+            # so the script keeps running with just python3 (no yq/PyYAML needed).
+            # When PyYAML is present it is authoritative: invalid YAML is
+            # reported (sentinel __PARSE_ERROR__), not silently re-parsed by the
+            # fallback. The stdlib-only fallback runs solely when PyYAML is
+            # absent, so the script still works with just python3.
+            DESC=$(FRONTMATTER="$FRONTMATTER" python3 <<'PYEOF' 2>/dev/null || echo "__PARSE_ERROR__"
+import os, re, sys
+
+fm = os.environ["FRONTMATTER"]
+
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+if yaml is not None:
+    # PyYAML available: trust it fully so semantics match CI exactly.
+    try:
+        data = yaml.safe_load(fm)
+    except Exception:
+        print("__PARSE_ERROR__")
+        sys.exit(0)
+    desc = data.get("description") if isinstance(data, dict) else None
+    print(desc if desc is not None else "")
+    sys.exit(0)
+
+# Fallback without PyYAML: best-effort for the common scalar styles
+# (plain, single/double-quoted, block). description: is a column-0 key.
+desc = None
+lines = fm.splitlines()
+for i, line in enumerate(lines):
+    m = re.match(r"description:[ \t]*(.*)$", line)
+    if not m:
+        continue
+    val = m.group(1).strip()
+    if val[:1] in ("|", ">"):
+        # Block scalar: first non-blank line that is indented into the block.
+        # A column-0 (non-indented) line is the next sibling key -> empty body.
+        for nxt in lines[i + 1:]:
+            if not nxt.strip():
+                continue
+            if not nxt[:1].isspace():
+                break
+            desc = nxt.strip()
+            break
+    else:
+        dq = re.match(r'"((?:[^"\\]|\\.)*)"[ \t]*(?:#.*)?$', val)
+        sq = re.match(r"'((?:[^']|'')*)'[ \t]*(?:#.*)?$", val)
+        if dq:
+            desc = dq.group(1)
+        elif sq:
+            desc = sq.group(1).replace("''", "'")
+        else:
+            # Plain scalar: strip a trailing ' #' comment (YAML needs the space).
+            desc = re.sub(r"[ \t]+#.*$", "", val)
+    break
+
+print(desc if desc is not None else "")
+PYEOF
+)
+            if [[ "$DESC" == "__PARSE_ERROR__" ]]; then
+                error "SKILL.md frontmatter is not valid YAML (could not parse 'description')"
+            elif [[ "$DESC" == Use\ when* ]]; then
                 success "Description starts with 'Use when'"
             else
                 error "Description must start with 'Use when': ${DESC:0:60}..."

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -41,19 +41,24 @@ ACCEPT_LINE="Description starts with 'Use when'"
 
 # fixture <name> <raw-content> -> echoes the created dir path
 fixture() {
-    local dir="$TMP/fx_$1"
+    local name="$1" content="$2" dir
+    dir="$TMP/fx_$name"
     rm -rf "$dir"
     mkdir -p "$dir"
-    printf '%b' "$2" > "$dir/SKILL.md"
+    printf '%b' "$content" > "$dir/SKILL.md"
     printf '%s' "$dir"
+    return 0
 }
 
 # run_validator <fallback|yaml> <dir>
 run_validator() {
-    case "$1" in
-        fallback) PYTHONPATH="$SHIM" bash "$VALIDATOR" "$2" 2>&1 ;;
-        yaml)     "${YAML_RUNNER[@]}" bash "$VALIDATOR" "$2" 2>&1 ;;
+    local path="$1" dir="$2"
+    case "$path" in
+        fallback) PYTHONPATH="$SHIM" bash "$VALIDATOR" "$dir" 2>&1 ;;
+        yaml)     "${YAML_RUNNER[@]}" bash "$VALIDATOR" "$dir" 2>&1 ;;
+        *)        echo "unknown path: $path" >&2; return 2 ;;
     esac
+    return 0
 }
 
 # assert <accept|reject> <path> <dir> <label>
@@ -67,7 +72,9 @@ assert() {
         reject)
             if grep -qF "$ACCEPT_LINE" <<<"$out"; then
                 echo "  FAIL [$path] $label: expected REJECT, was accepted"; ((FAIL++)); else ((PASS++)); fi ;;
+        *)  echo "  FAIL [$path] $label: unknown expectation '$want'"; ((FAIL++)) ;;
     esac
+    return 0
 }
 
 # Fixtures are keyed by name to avoid packing YAML (which contains '|', '>', ':')
@@ -75,7 +82,8 @@ assert() {
 # CASES lists "name want" pairs with the expected verdict (same on both paths).
 hdr='---\nname: t\n'
 content_for() {
-    case "$1" in
+    local name="$1"
+    case "$name" in
         plain)          printf '%s' "${hdr}description: Use when doing X\n---\n# T\n" ;;
         dquote)         printf '%s' "${hdr}description: \"Use when doing X\"\n---\n# T\n" ;;
         squote)         printf '%s' "${hdr}description: 'Use when doing X'\n---\n# T\n" ;;
@@ -86,7 +94,9 @@ content_for() {
         empty_block)    printf '%s' "${hdr}description: |\nlicense: Use when fake\n---\n# T\n" ;;
         wrong_prefix)   printf '%s' "${hdr}description: 'Helps with X'\n---\n# T\n" ;;
         invalid_yaml)   printf '%s' "${hdr}description: \"Use when unterminated\n---\n# T\n" ;;
+        *)              echo "unknown fixture: $name" >&2; return 2 ;;
     esac
+    return 0
 }
 declare -a CASES=(
     "plain accept"

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# tests/validate-skill.sh — smoke tests for the description-scalar parsing in
+# skills/skill-repo/scripts/validate-skill.sh (regression cover for issue #119:
+# single-quoted and block scalars were wrongly rejected).
+#
+# Runs each fixture through BOTH code paths of the validator:
+#   - fallback : stdlib-only path, forced by shimming `import yaml` to fail
+#   - yaml     : PyYAML-authoritative path (uses uv --with pyyaml if the system
+#                python3 cannot import yaml; skipped with a notice if neither
+#                a yaml-capable python3 nor uv is available)
+#
+# Asserts on the validator's description verdict line, not its overall exit code
+# (the minimal fixtures intentionally lack composer.json/README so the validator
+# always exits non-zero on unrelated checks).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+VALIDATOR="$REPO_ROOT/skills/skill-repo/scripts/validate-skill.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# yaml-disabling shim: placed first on PYTHONPATH so `import yaml` raises even
+# when PyYAML is installed, deterministically exercising the stdlib fallback.
+SHIM="$TMP/_noyaml"
+mkdir -p "$SHIM"
+printf 'raise ImportError("yaml disabled for fallback test")\n' > "$SHIM/yaml.py"
+
+# Determine a yaml-capable runner for the authoritative path.
+YAML_RUNNER=()
+if python3 -c 'import yaml' >/dev/null 2>&1; then
+    YAML_RUNNER=(env)
+elif command -v uv >/dev/null 2>&1 && uv run --with pyyaml python3 -c 'import yaml' >/dev/null 2>&1; then
+    YAML_RUNNER=(uv run --with pyyaml)
+fi
+
+PASS=0
+FAIL=0
+ACCEPT_LINE="Description starts with 'Use when'"
+
+# fixture <name> <raw-content> -> echoes the created dir path
+fixture() {
+    local dir="$TMP/fx_$1"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    printf '%b' "$2" > "$dir/SKILL.md"
+    printf '%s' "$dir"
+}
+
+# run_validator <fallback|yaml> <dir>
+run_validator() {
+    case "$1" in
+        fallback) PYTHONPATH="$SHIM" bash "$VALIDATOR" "$2" 2>&1 ;;
+        yaml)     "${YAML_RUNNER[@]}" bash "$VALIDATOR" "$2" 2>&1 ;;
+    esac
+}
+
+# assert <accept|reject> <path> <dir> <label>
+assert() {
+    local want="$1" path="$2" dir="$3" label="$4" out
+    out="$(run_validator "$path" "$dir")"
+    case "$want" in
+        accept)
+            if grep -qF "$ACCEPT_LINE" <<<"$out"; then ((PASS++)); else
+                echo "  FAIL [$path] $label: expected ACCEPT, was rejected"; ((FAIL++)); fi ;;
+        reject)
+            if grep -qF "$ACCEPT_LINE" <<<"$out"; then
+                echo "  FAIL [$path] $label: expected REJECT, was accepted"; ((FAIL++)); else ((PASS++)); fi ;;
+    esac
+}
+
+# Fixtures are keyed by name to avoid packing YAML (which contains '|', '>', ':')
+# into a delimited string. content_for echoes the raw SKILL.md body for a name;
+# CASES lists "name want" pairs with the expected verdict (same on both paths).
+hdr='---\nname: t\n'
+content_for() {
+    case "$1" in
+        plain)          printf '%s' "${hdr}description: Use when doing X\n---\n# T\n" ;;
+        dquote)         printf '%s' "${hdr}description: \"Use when doing X\"\n---\n# T\n" ;;
+        squote)         printf '%s' "${hdr}description: 'Use when doing X'\n---\n# T\n" ;;
+        block_fold)     printf '%s' "${hdr}description: >-\n  Use when doing X\n  across lines\n---\n# T\n" ;;
+        block_literal)  printf '%s' "${hdr}description: |\n  Use when doing X\n---\n# T\n" ;;
+        dquote_comment) printf '%s' "${hdr}description: \"Use when doing X\"   # a comment\n---\n# T\n" ;;
+        plain_comment)  printf '%s' "${hdr}description: Use when doing X  # c\n---\n# T\n" ;;
+        empty_block)    printf '%s' "${hdr}description: |\nlicense: Use when fake\n---\n# T\n" ;;
+        wrong_prefix)   printf '%s' "${hdr}description: 'Helps with X'\n---\n# T\n" ;;
+        invalid_yaml)   printf '%s' "${hdr}description: \"Use when unterminated\n---\n# T\n" ;;
+    esac
+}
+declare -a CASES=(
+    "plain accept"
+    "dquote accept"
+    "squote accept"
+    "block_fold accept"
+    "block_literal accept"
+    "dquote_comment accept"
+    "plain_comment accept"
+    "empty_block reject"
+    "wrong_prefix reject"
+    "invalid_yaml reject"
+)
+
+echo "== Fallback path (stdlib only, yaml shimmed out) =="
+for c in "${CASES[@]}"; do
+    read -r name want <<<"$c"
+    assert "$want" fallback "$(fixture "$name" "$(content_for "$name")")" "$name"
+done
+
+if [[ ${#YAML_RUNNER[@]} -gt 0 ]]; then
+    echo "== PyYAML-authoritative path (${YAML_RUNNER[*]}) =="
+    for c in "${CASES[@]}"; do
+        read -r name want <<<"$c"
+        assert "$want" yaml "$(fixture "$name" "$(content_for "$name")")" "$name"
+    done
+
+    # #2: invalid YAML must be reported as such, not as a content error.
+    out="$(run_validator yaml "$(fixture invalid_yaml2 "$(content_for invalid_yaml)")")"
+    if grep -qF "frontmatter is not valid YAML" <<<"$out"; then ((PASS++)); else
+        echo "  FAIL [yaml] invalid_yaml: expected 'not valid YAML' diagnostic"; ((FAIL++)); fi
+else
+    echo "== PyYAML-authoritative path: SKIPPED (no yaml-capable python3 or uv) =="
+fi
+
+echo "----------------------------------------"
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }
+echo "All validator smoke tests passed"


### PR DESCRIPTION
Fixes #119.

## Problem

The `description` check in `scripts/validate-skill.sh` stripped only **double** quotes from the raw `description:` line, so descriptions that are valid YAML and whose *parsed* value starts with "Use when" were wrongly rejected:

- single-quoted: `description: 'Use when …'`
- block scalars: `description: >-` / `description: |`

This pushed authors toward multi-line **plain** scalars, which are invalid YAML — Claude Code then loads the skill with empty frontmatter and auto-activation silently breaks (the `ecom-orocommerce-docker` ≤1.0.4 incident).

## Fix

Parse the YAML *value* of `description` via `python3`:

- **PyYAML is authoritative when importable** — invalid YAML is reported (`ERROR: frontmatter is not valid YAML`), not silently re-parsed.
- **stdlib-only fallback** when PyYAML is absent, covering plain, single/double-quoted and block scalars — so the script keeps running with just `python3` (no new `yq`/PyYAML dependency, preserving its standalone contract).

The issue suggested `yq`, but this script deliberately depends on `python3` stdlib only so it runs standalone; a hard `yq`/PyYAML requirement would break that.

Beyond the core fix, an adversarial review surfaced three issues, all addressed here:
- block-scalar dead-code branch that could swallow the next key (empty block body),
- parse failures masked as a misleading "must start with Use when" content error,
- `description: "Use when x"  # comment` wrongly rejected.

## Tests

New `tests/validate-skill.sh` — dependency-free bash smoke test, 21 assertions across **both** code paths (stdlib fallback via a yaml-import shim, and the PyYAML-authoritative path via `uv run --with pyyaml`). Mutation-checked: against the pre-fix validator it produces 9 failures on exactly the #119 cases plus the invalid-YAML diagnostic. Wired into the `lint` workflow (added `setup-uv` for PyYAML-path coverage).

Local: smoke test 21/21, real repo validates (exit 0), shellcheck clean at `warning` severity.