### PR TITLE
chore(release): v1.24.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.24.0"
+  version: "1.24.1"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Patch release bumping `plugin.json` and `skills/skill-repo/SKILL.md` to **1.24.1**.

## Unreleased changes since v1.24.0
- #120 / #119: `validate-skill.sh` now accepts all valid YAML scalar styles for `description` (bugfix), plus smoke tests on both YAML parse paths and SonarCloud shell-smell cleanup.

No functional skill/content changes — bugfix-only, hence a patch bump. Version parity verified against `v1.24.1`.