### PR TITLE
feat(trigger+SR-37): add release keywords to trigger; add version-parity checkpoint

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-repo
-description: "Use when creating new skill repositories from scratch, standardizing or validating existing skill repo structure, setting up composer/release workflows for skills, configuring split licensing (MIT + CC-BY-SA-4.0), fixing plugin.json / SKILL.md validation errors, or releasing a new skill version (version bump, tagging, plugin.json / SKILL.md / composer.json version parity, git tag push)."
+description: "Use when creating skill repositories, standardizing or validating skill repo structure, setting up composer/release workflows, configuring split licensing (MIT + CC-BY-SA-4.0), fixing plugin.json / SKILL.md validation or version-parity errors, or releasing a skill version (version bump, tagging)."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-repo
-description: "Use when creating new skill repositories from scratch, standardizing or validating existing skill repo structure, setting up composer/release workflows for skills, configuring split licensing (MIT + CC-BY-SA-4.0), or fixing plugin.json / SKILL.md validation errors."
+description: "Use when creating new skill repositories from scratch, standardizing or validating existing skill repo structure, setting up composer/release workflows for skills, configuring split licensing (MIT + CC-BY-SA-4.0), fixing plugin.json / SKILL.md validation errors, or releasing a new skill version (version bump, tagging, plugin.json / SKILL.md / composer.json version parity, git tag push)."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -253,6 +253,20 @@ mechanical:
     severity: warning
     desc: "Release workflow should not declare workflow_dispatch or use --admin merges — the auto-bump path produced unsigned tags. Use signed tag-push only (see skill-repo-skill PR #15)."
 
+  - id: SR-37
+    type: command
+    # Run the shipped parity script. It checks: plugin.json has .version;
+    # composer.json does NOT have .version (Composer derives from tag);
+    # every SKILL.md that declares metadata.version matches plugin.json.
+    # The script exits 1 and prints [ERROR] lines on any mismatch.
+    # `|| true` is intentional: we want PASS/FAIL from the advisory output,
+    # not a hard CI abort (the validate:skill job already aborts). This
+    # checkpoint surfaces the mismatch as a reviewable finding.
+    pattern: "! (bash skills/skill-repo/scripts/check-version-parity.sh 2>&1 | grep -q '\\[ERROR\\]')"
+    severity: error
+    desc: "plugin.json version must match every SKILL.md metadata.version (run skills/skill-repo/scripts/check-version-parity.sh to verify before tagging)"
+    tags: [release, versioning, parity]
+
 llm_reviews:
   - id: SR-32
     domain: repo-health

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -255,14 +255,20 @@ mechanical:
 
   - id: SR-37
     type: command
-    # Run the shipped parity script. It checks: plugin.json has .version;
-    # composer.json does NOT have .version (Composer derives from tag);
-    # every SKILL.md that declares metadata.version matches plugin.json.
-    # The script exits 1 and prints [ERROR] lines on any mismatch.
-    # `|| true` is intentional: we want PASS/FAIL from the advisory output,
-    # not a hard CI abort (the validate:skill job already aborts). This
-    # checkpoint surfaces the mismatch as a reviewable finding.
-    pattern: "! (bash skills/skill-repo/scripts/check-version-parity.sh 2>&1 | grep -q '\\[ERROR\\]')"
+    # Mirrors scripts/check-version-parity.sh mechanically — the runner's
+    # command allowlist forbids invoking repo scripts (only vendor/bin/*),
+    # `bash` as base command, and `;`/`&&` anywhere in the pattern; hence
+    # a single-line awk with one statement per pattern-action block.
+    # Reads plugin.json .version, then compares every metadata.version
+    # declared in skills/*/SKILL.md FRONTMATTER against it (the fm gate
+    # keeps JSON examples in SKILL.md bodies from matching). Fails on any
+    # mismatch or when plugin.json declares no version.
+    # Not covered here (script-only): composer.json must-not-have-version,
+    # tag-argument parity. Run the script for exact diagnostics.
+    # The runner parses checkpoints line-by-line (no yq), so the pattern
+    # cannot be folded across lines — exempt it from the 200-char rule.
+    # yamllint disable-line rule:line-length
+    pattern: "awk 'FNR==1{fm=0} /^---$/{fm=1-fm} FILENAME~/json$/{if ($0 ~ /\"version\"/) gsub(/[\",]/,\"\")} FILENAME~/json$/{if ($1 == \"version:\") pv=$2} fm{if ($1 == \"version:\") sv=$2} fm{if ($1 == \"version:\") gsub(/[\"\\047]/,\"\",sv)} fm{if ($1 == \"version:\") if (sv != pv) bad=1} END{if (pv == \"\") bad=1} END{exit bad}' .claude-plugin/plugin.json skills/*/SKILL.md"
     severity: error
     desc: "plugin.json version must match every SKILL.md metadata.version (run skills/skill-repo/scripts/check-version-parity.sh to verify before tagging)"
     tags: [release, versioning, parity]


### PR DESCRIPTION
## Summary

During a skill release session the `skill-repo` skill never auto-triggered because \"release\", \"tag\", and \"version bump\" were absent from the trigger description. The result: `SKILL.md` and `composer.json` were bumped to `v1.1.0` but `.claude-plugin/plugin.json` was missed, causing CI to fail with:

```
SKILL.md metadata.version '1.1.0' != plugin.json version '1.0.0'
```

The knowledge to prevent this already existed (`check-version-parity.sh`, `release-discipline.md`) — the skill just didn't fire.

## Changes

**`SKILL.md` trigger** — appended release-time keywords so the skill fires when an agent starts a version bump or tag workflow:
> _…or releasing a new skill version (version bump, tagging, plugin.json / SKILL.md / composer.json version parity, git tag push)._

**`checkpoints.yaml` SR-37** — new mechanical checkpoint that runs `check-version-parity.sh` and fails if any `[ERROR]` line appears. Catches the mismatch as a reviewable finding before the tag is pushed, even if the skill was never explicitly invoked.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify SR-37 fires on a repo where `plugin.json` version ≠ `SKILL.md` version
- [ ] Verify SR-37 passes on a repo where versions are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

## Revisions while finishing (fb783b6)

- Rebased onto main (was BEHIND).
- `ddf429c` trims the trigger wording: the keyword addition pushed SKILL.md to 513 words, over the 500-word CI cap. All release keywords survive (releasing, version bump, tagging, version-parity); now 498 words.
- `fb783b6` replaces the SR-37 pattern. The original could never fire: the parity script prints `ERROR:`, never `[ERROR]`, so the negated grep always passed — and the assessment runner's command allowlist rejects `bash` as base command, so the runner would have reported "Command rejected" permanently. New pattern is a single-line awk (allowlist-compliant: no `;`, no `&&`) comparing plugin.json `.version` against every `metadata.version` in `skills/*/SKILL.md` frontmatter, with a frontmatter gate so JSON examples in SKILL.md bodies do not match. Verified: parity rc=0, either-file-bumped rc=1, gawk+mawk, `is_safe_eval_command` accepts it.
