### PR TITLE
fix(ci): restore reusable release.yml (template adoption overwrote it)

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -20,3 +20,4 @@ template: skill
 intentional-drift:
   - .github/workflows/eval-validate.yml
   - .github/workflows/harness-verify.yml
+  - .github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,298 @@
-name: Release
+name: Release Skill
 
-# Skill release pipeline (composer/npm package publish + Sigstore cosign +
-# SHA256SUMS attestation) via the skill-repo-skill reusable. The reusable's
-# release job declares contents/id-token/attestations: write; the calling job
-# grants exactly that union. id-token + attestations are required for the
-# OIDC-backed Sigstore signing and the GitHub native attestation API.
+# Reusable release workflow for skill repos.
+#
+# Trigger model: signed-tag-push only.
+#
+# To release a skill:
+#   1. Bump versions locally (plugin.json + each skill's SKILL.md frontmatter)
+#   2. Commit, open a release PR, get it merged to main
+#   3. Tag locally with a signed annotated tag, then push:
+#         git tag -s -m "vX.Y.Z" vX.Y.Z
+#         git push origin vX.Y.Z
+#   4. This workflow verifies the tag is signed, then builds and publishes
+#      the GitHub Release with archives + SHA256SUMS.
+#
+# Why no auto-bump path: the previous version of this workflow had a
+# `workflow_dispatch` `bump` input that asked the workflow to bump versions,
+# create a release PR, --admin-merge it, and create a tag via the GitHub
+# API. The tag-via-API path produces an UNSIGNED tag (tagger
+# `github-actions[bot]`), violating the signed-tag policy and burning a
+# v-tag in the wild. Removing the bump job makes that class of bug
+# impossible.
+#
+# Supply-chain attestation: every release ships with provenance-attested
+# archives and a Cosign-signed checksum file that binds the archives by their
+# SHA-256 digest. Only `SHA256SUMS.txt` is Cosign-signed; the `.zip`/`.tar.gz`
+# files themselves are integrity-protected via that signed checksum (verifying
+# the signature on `SHA256SUMS.txt` and then `sha256sum --check` against it
+# proves any individual archive was produced by this workflow). All of this
+# happens in the SAME job that publishes the GitHub Release, BEFORE the assets
+# are made public — no race window where unattested artefacts are downloadable.
+# The flow is, in order:
+#   1. Build the archives (zip + tar.gz).
+#   2. Generate SHA256SUMS.txt over them.
+#   3. Cosign sign-blob (keyless / Sigstore) the SHA256SUMS.txt
+#      → SHA256SUMS.txt.sigstore.json (Sigstore bundle format: cert + sig +
+#      Rekor inclusion proof in a single self-contained JSON; cosign v3+
+#      default). The `.sigstore.json` extension is chosen so OSSF Scorecard's
+#      signed-releases probe recognises it — content is identical to cosign's
+#      `--bundle` default output; only the file name differs.
+#   4. SLSA build-provenance attest the archives + SHA256SUMS.txt via
+#      actions/attest-build-provenance → published to GitHub's attestation API.
+#   5. softprops/action-gh-release creates the Release with all assets at once.
+# Callers must grant `id-token: write` and `attestations: write` on the calling
+# job (in addition to `contents: write`). All netresearch skill-repo callers do;
+# fork this workflow only after granting those scopes.
+# Verify a downloaded archive:
+#   gh attestation verify <archive>.zip --repo <org>/<repo-name>
+#   sha256sum --check SHA256SUMS.txt   # after verifying the signature below
+# Verify the checksums signature with cosign. The cert SAN reflects the SIGNER
+# (this reusable workflow), NOT the caller; pin the regex to skill-repo-skill,
+# not the consuming repo:
+#   cosign verify-blob \
+#     --bundle SHA256SUMS.txt.sigstore.json \
+#     --certificate-identity-regexp "^https://github\.com/netresearch/skill-repo-skill/\.github/workflows/release\.yml@" \
+#     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+#     SHA256SUMS.txt
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      # DEPRECATED — kept declared so existing callers' `with: bump: …` does
+      # not error syntactically. The bump job has been removed; passing this
+      # input now has no effect. Callers should drop it; releases happen
+      # exclusively via signed-tag push.
+      bump:
+        description: 'DEPRECATED — ignored. Releases happen via signed tag-push only.'
+        type: string
+        required: false
+      # DEPRECATED — kept declared so existing callers' `with: attest: …`
+      # doesn't error syntactically. SLSA build provenance is now always
+      # generated for release archives; every caller's job grants the required
+      # `id-token: write` and `attestations: write` since the org-wide rollout
+      # of those permissions completed. Callers should drop `with: attest: …`.
+      attest:
+        description: 'DEPRECATED — ignored. SLSA build provenance is always generated.'
+        type: boolean
+        required: false
+        default: true
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   release:
-    uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main
+    name: Create Release
+    runs-on: ubuntu-latest
     permissions:
-      contents: write          # release upload
+      contents: write
       id-token: write          # OIDC for sigstore (cosign + attest)
       attestations: write      # GitHub native attestation API
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Verify tag is annotated and signed
+        env:
+          TAG_REF: ${{ github.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG_REF" != refs/tags/v* ]]; then
+            echo "::error::This workflow must be triggered by a tag push (refs/tags/v*). Got: $TAG_REF"
+            exit 1
+          fi
+          TAG_NAME="${TAG_REF#refs/tags/}"
+
+          REF_INFO=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG_NAME}")
+          TAG_TYPE=$(echo "$REF_INFO" | jq -r '.object.type')
+          if [[ "$TAG_TYPE" != "tag" ]]; then
+            echo "::error::Tag ${TAG_NAME} is lightweight (object.type=${TAG_TYPE}). Releases require annotated, signed tags."
+            echo "::error::Recreate locally:  git tag -s -m \"${TAG_NAME}\" ${TAG_NAME} && git push origin ${TAG_NAME}"
+            exit 1
+          fi
+
+          TAG_OBJ_SHA=$(echo "$REF_INFO" | jq -r '.object.sha')
+          VERIFY=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TAG_OBJ_SHA}" --jq '.verification')
+          VERIFIED=$(echo "$VERIFY" | jq -r '.verified')
+          REASON=$(echo "$VERIFY" | jq -r '.reason')
+          if [[ "$VERIFIED" != "true" ]]; then
+            echo "::error::Tag ${TAG_NAME} is not signed (reason: ${REASON}). Releases require locally-signed tags."
+            echo "::error::Recreate locally:  git tag -s -m \"${TAG_NAME}\" ${TAG_NAME} && git push origin ${TAG_NAME}"
+            exit 1
+          fi
+          echo "Tag ${TAG_NAME} verified as signed (reason: ${REASON})."
+
+      - name: Determine tag version
+        id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout at tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
+      - name: Validate version and build packages
+        env:
+          TAG_VERSION: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PLUGIN_FILE=".claude-plugin/plugin.json"
+
+          # --- Validate version ---
+          PLUGIN_VERSION=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE'))['version'])")
+          PLUGIN_NAME=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE'))['name'])")
+          TAG_BARE="${TAG_VERSION#v}"
+          if [[ "$TAG_BARE" != "$PLUGIN_VERSION" ]]; then
+            echo "::error file=$PLUGIN_FILE::Tag $TAG_VERSION does not match plugin.json version $PLUGIN_VERSION"
+            exit 1
+          fi
+          echo "Version validated: $TAG_VERSION"
+
+          # --- Discover skills from plugin.json ---
+          SKILL_PATHS=$(python3 -c "
+          import json
+          data = json.load(open('$PLUGIN_FILE'))
+          skills = data.get('skills', [])
+          if isinstance(skills, str):
+              skills = [skills]
+          for s in skills:
+              print(s.strip('/').rstrip('/'))
+          ")
+
+          mkdir -p dist/releases
+
+          # --- Helper: copy skill contents ---
+          copy_skill() {
+            local src="$1" dst="$2"
+            for item in SKILL.md references scripts assets templates examples; do
+              if [[ -e "$src/$item" ]]; then
+                cp -r "$src/$item" "$dst/"
+              fi
+            done
+            [[ -f "$src/checkpoints.yaml" ]] && cp "$src/checkpoints.yaml" "$dst/"
+            cp LICENSE-MIT LICENSE-CC-BY-SA-4.0 "$dst/" 2>/dev/null || true
+          }
+
+          # --- Package each skill standalone ---
+          while IFS= read -r skill_path; do
+            [[ -z "$skill_path" ]] && continue
+            skill_path="${skill_path#./}"
+
+            if [[ "$skill_path" == "." ]]; then
+              SKILL_NAME="$PLUGIN_NAME"
+              SKILL_SRC="."
+            else
+              SKILL_NAME=$(basename "$skill_path")
+              SKILL_SRC="$skill_path"
+            fi
+
+            echo "=== Packaging standalone skill: $SKILL_NAME ==="
+            SKILL_DIST="dist/skill-$SKILL_NAME"
+            mkdir -p "$SKILL_DIST"
+            copy_skill "$SKILL_SRC" "$SKILL_DIST"
+
+            (cd "$SKILL_DIST" && zip -qr "../releases/${SKILL_NAME}-skill-${TAG_VERSION}.zip" .)
+            (cd "$SKILL_DIST" && tar -czf "../releases/${SKILL_NAME}-skill-${TAG_VERSION}.tar.gz" .)
+            echo "Created ${SKILL_NAME}-skill-${TAG_VERSION}.zip/.tar.gz"
+          done <<< "$SKILL_PATHS"
+
+          # --- Package full plugin ---
+          echo "=== Packaging plugin: $PLUGIN_NAME ==="
+          PLUGIN_DIST="dist/plugin"
+          mkdir -p "$PLUGIN_DIST"
+
+          while IFS= read -r skill_path; do
+            [[ -z "$skill_path" ]] && continue
+            skill_path="${skill_path#./}"
+
+            if [[ "$skill_path" == "." ]]; then
+              copy_skill "." "$PLUGIN_DIST"
+            else
+              mkdir -p "$PLUGIN_DIST/$skill_path"
+              copy_skill "$skill_path" "$PLUGIN_DIST/$skill_path"
+            fi
+          done <<< "$SKILL_PATHS"
+
+          cp LICENSE-MIT LICENSE-CC-BY-SA-4.0 "$PLUGIN_DIST/" 2>/dev/null || true
+          [[ -d ".claude-plugin" ]] && cp -r .claude-plugin "$PLUGIN_DIST/"
+          [[ -d "hooks" ]] && cp -r hooks "$PLUGIN_DIST/"
+          if [[ -d "scripts" ]]; then
+            cp -r scripts "$PLUGIN_DIST/"
+            find "$PLUGIN_DIST/scripts" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+          fi
+
+          (cd "$PLUGIN_DIST" && zip -qr "../releases/${PLUGIN_NAME}-plugin-${TAG_VERSION}.zip" .)
+          (cd "$PLUGIN_DIST" && tar -czf "../releases/${PLUGIN_NAME}-plugin-${TAG_VERSION}.tar.gz" .)
+          echo "Created ${PLUGIN_NAME}-plugin-${TAG_VERSION}.zip/.tar.gz"
+
+          # --- Checksums ---
+          (cd dist/releases && sha256sum ./*.zip ./*.tar.gz > SHA256SUMS.txt)
+          echo ""
+          echo "=== Release packages ==="
+          ls -lh dist/releases/
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign SHA256SUMS with Cosign (keyless)
+        working-directory: dist/releases
+        run: |
+          set -euo pipefail
+          # Cosign v3+ emits a single self-contained Sigstore bundle (cert +
+          # signature + Rekor inclusion proof) via --bundle. The legacy two-file
+          # output (--output-certificate / --output-signature) is deprecated and
+          # silently ignored when --new-bundle-format is the default.
+          cosign sign-blob --yes \
+            --bundle SHA256SUMS.txt.sigstore.json \
+            SHA256SUMS.txt
+
+      - name: Verify Cosign signature
+        working-directory: dist/releases
+        env:
+          # The cosign keyless cert's Subject Alternative Name is the path of
+          # the workflow that ran `cosign sign-blob` — that's THIS reusable
+          # workflow, not the caller. For a reusable workflow invoked via
+          # `uses: …@main`, the SAN looks like
+          #   https://github.com/netresearch/skill-repo-skill/.github/workflows/release.yml@refs/heads/main
+          # (the ref reflects how the reusable was referenced, NOT the tag that
+          # triggered the caller). Pin against the reusable's own path,
+          # NOT ${{ github.repository }} (which is the caller's repo).
+          SIGNER_REPO: netresearch/skill-repo-skill
+        run: |
+          set -euo pipefail
+          # Anchored regex: must START with the reusable's full URL plus an `@`.
+          # `\.` escapes the dot so it matches a literal period instead of any
+          # character. We don't pin a specific ref because the reusable may be
+          # referenced via `@main`, a SHA, or a future tag of skill-repo-skill.
+          cosign verify-blob \
+            --bundle SHA256SUMS.txt.sigstore.json \
+            --certificate-identity-regexp "^https://github\.com/${SIGNER_REPO}/\.github/workflows/release\.yml@" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            SHA256SUMS.txt
+
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/releases/*.zip
+            dist/releases/*.tar.gz
+            dist/releases/SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          files: dist/releases/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix(ci): restore reusable release.yml (template adoption overwrote it)

The 2026-06-16 "adopt netresearch/.github skill template" sweep (d26c07a2)
overwrote this repo's OWN reusable release workflow with the consumer CALLER
template. The result was a self-referential workflow — release.yml triggering
on tag push and then `uses: netresearch/skill-repo-skill/.github/workflows/release.yml@main`,
i.e. calling itself — which GitHub rejects at startup ("workflow file issue",
0 jobs).

Because every skill repo pins this file via `@main`, ALL skill releases
across the org failed at the publish step (verified: a tagged release on a
consumer repo produced a 0-job startup failure; no Release object was created,
so no tag was burned).

The same template-adoption regression already hit eval-validate.yml and
harness-verify.yml and was fixed by restoring the reusable + recording
intentional drift; release.yml was missed. This applies the identical fix:

- Restore .github/workflows/release.yml to the dual-trigger reusable
  (on: push.tags + workflow_call) with the full Create-Release job
  (signed-tag verification, multi-skill packaging, Cosign sign-blob,
  SLSA attestation, gh-release). Bytes restored from 970de94aa, the last
  commit before the overwrite.
- Add .github/workflows/release.yml to intentional-drift[] in
  .github/template.yaml so future template syncs stop managing it and the
  drift check treats it as an intended exception (matching eval-validate.yml
  and harness-verify.yml).
