### PR TITLE
feat(skill-repo): scaffold validate.yml so new skill repos get CI validation

### DIFF
--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -142,6 +142,7 @@ For `new-skill` destination, use the templates in `skills/skill-repo/templates/`
 - `LICENSE-MIT.template`, `LICENSE-CC-BY-SA-4.0.template`
 - `README.md.template`
 - `release.yml.template` (GitHub Actions release workflow)
+- `validate.yml.template` (CI caller for the reusable skill-validation workflow — without it the SKILL.md word cap, plugin.json schema, and markdown/yaml/action lints run only in local pre-commit, never in CI)
 - `pr-quality.yml.template` (PR validation)
 - `auto-merge-deps.yml.template` (Dependabot/Renovate auto-merge)
 - `pre-commit.template`
@@ -159,6 +160,7 @@ Required files in the new repo:
 - One initial entry in `skills/<name>/evals/evals.json` covering the friction (TDD)
 - Optionally `skills/<name>/checkpoints.yaml` (start with structural checkpoints)
 - `.github/workflows/release.yml` (from template)
+- `.github/workflows/validate.yml` (from template — required so skill validation runs in CI, not just pre-commit)
 
 Run `bash skills/skill-repo/scripts/validate-skill.sh <new-repo-path>` to confirm the scaffold passes structural validation.
 

--- a/skills/skill-repo/templates/.github/workflows/validate.yml.template
+++ b/skills/skill-repo/templates/.github/workflows/validate.yml.template
@@ -1,0 +1,20 @@
+name: Lint
+
+# Skill validation (SKILL.md word cap, plugin.json schema, markdown lint, …)
+# via the skill-repo-skill reusable. The reusable declares `permissions:
+# contents: read` at top level; the calling job mirrors it explicitly so the
+# grant is visible at the call site and independent of the repo default.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  validate:
+    name: Skill Validation
+    uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## What & why

The new-skill scaffold ships workflow templates for `release`, `pr-quality`, `auto-merge-deps`, and `npm-pack-smoke` — but **none for the skill-validation caller**, even though `SKILL.md` documents `.github/workflows/validate.yml` as required and states skill repos MUST delegate CI to the reusable `validate.yml`.

A repo scaffolded from these templates therefore has **no CI running `validate-skill`/markdownlint/etc.** — the SKILL.md word cap, plugin.json schema, and lints are enforced only by local pre-commit (and only if a contributor installed the hooks). `check-template-drift` can't catch it: it only diffs files that exist as templates.

This bit **peer-qa-review-skill** — its `SKILL.md` drifted to 1117 words (cap 500) with no CI to flag it (fixed separately in that repo).

## Changes

- **`templates/.github/workflows/validate.yml.template`** — thin caller of the reusable `validate.yml@main`, mirroring this repo's own `lint.yml`.
- **`references/materialization-contract.md`** (Rule 9) — list the new template and require `.github/workflows/validate.yml` in scaffolded repos.

Docs + template only; no behavioral change to existing reusables.
