### PR TITLE
docs: skill-authoring word-budget and CI portability gotchas

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -113,7 +113,7 @@ scripts/validate-skill.sh
 
 ## References (`references/`)
 
-**Distribution:** installation-methods, composer-setup, release-discipline, review-replies · **SKILL text:** skill-quality · **Repo/README:** repository-quality-rules, readme-template · **Discovery:** skill-discovery-metadata · **Done:** validation-checklist · **Sync:** marketplace-integration · **Retro:** materialization-contract · **Gotchas:** [authoring-ci-gotchas](references/authoring-ci-gotchas.md)
+**Distribution:** [installation-methods](references/installation-methods.md), [composer-setup](references/composer-setup.md), [release-discipline](references/release-discipline.md), [review-replies](references/review-replies.md) · **SKILL text:** [skill-quality](references/skill-quality.md) · **Repo/README:** [repository-quality-rules](references/repository-quality-rules.md), [readme-template](references/readme-template.md) · **Discovery:** [skill-discovery-metadata](references/skill-discovery-metadata.md) · **Done:** [validation-checklist](references/validation-checklist.md) · **Sync:** [marketplace-integration](references/marketplace-integration.md) · **Retro:** [materialization-contract](references/materialization-contract.md) · **Gotchas:** [authoring-ci-gotchas](references/authoring-ci-gotchas.md)
 
 ## See Also
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -113,7 +113,7 @@ scripts/validate-skill.sh
 
 ## References (`references/`)
 
-**Distribution:** installation-methods, composer-setup, release-discipline, review-replies · **SKILL text:** skill-quality · **Repo/README:** repository-quality-rules, readme-template · **Discovery:** skill-discovery-metadata · **Done:** validation-checklist · **Sync:** marketplace-integration · **Retro:** materialization-contract
+**Distribution:** installation-methods, composer-setup, release-discipline, review-replies · **SKILL text:** skill-quality · **Repo/README:** repository-quality-rules, readme-template · **Discovery:** skill-discovery-metadata · **Done:** validation-checklist · **Sync:** marketplace-integration · **Retro:** materialization-contract · **Gotchas:** [authoring-ci-gotchas](references/authoring-ci-gotchas.md)
 
 ## See Also
 

--- a/skills/skill-repo/references/authoring-ci-gotchas.md
+++ b/skills/skill-repo/references/authoring-ci-gotchas.md
@@ -1,0 +1,75 @@
+# Authoring & CI Gotchas
+
+Process learnings from a cross-session retrospective (2026-06-27). Companion to
+[`skill-quality.md`](skill-quality.md) (SKILL.md sizing) and the
+[`validation-checklist.md`](validation-checklist.md) (pre-completion checks).
+Each item is a habit that prevents a costly redo, not a structural rule.
+
+## 1. Word-budget-first authoring
+
+This repo enforces a **hard 500-word cap on `SKILL.md`** (`scripts/validate-skill.sh`
+fails above 500; this very SKILL.md sits at ~492). The body also persists in context
+for the whole session, so every word is paid on each invocation — see
+[`skill-quality.md`](skill-quality.md) for the full cost model.
+
+**Before editing an existing `SKILL.md`, `wc -w` it first.** If it is already near
+the ceiling, decide the **architecture before you type**:
+
+- new content that is a lookup/detail → a `references/*.md` file (lazy-loaded, free
+  until cited),
+- a genuinely separate capability → a new standalone skill,
+- only then, prose edits to the body itself.
+
+Do **not** open by iteratively trimming the maintainer's existing prose to free up
+room. In a real 2026-06-27 case that approach burned ~7 edit cycles shaving words off
+carefully-written copy before the obvious move — put the addition in a reference file
+and add one catalog line — was taken. Architecture decision first, word-shaving last
+(and rarely).
+
+## 2. macOS / BSD portability for shell **and** test scripts
+
+This repo's CI matrix runs on macOS, not just Linux: `validate-agents.yml` defaults its
+`os-matrix` to `["ubuntu-latest", "macos-latest"]`. Any `*.sh` (and any test script the
+workflows execute) therefore has to be **BSD/macOS-portable**, not just GNU-portable.
+
+The classic trap a reviewer flagged: **`sed -i` is GNU-only.** BSD `sed` (macOS) requires
+an explicit empty backup-suffix argument:
+
+```sh
+sed -i 's/a/b/' file      # GNU only — fails on macOS
+sed -i '' 's/a/b/' file   # BSD only — fails on GNU
+```
+
+Prefer a form that needs no in-place flag at all, e.g. write to a temp file and move it,
+or use `perl -i -pe`. This complements the portability notes already in `SKILL.md`
+(`grep -E` not `-P`; `bash` shebangs not `zsh`; `[[ ]]` conditionals). If the CI matrix
+ever drops macOS these become Linux-only conveniences again — verify the matrix before
+relying on a GNU-ism.
+
+## 3. Lint without dirtying the worktree
+
+Running the JS-based linters locally (e.g. `bunx markdownlint-cli2`) can make `bun`
+resolve and **write a lockfile**, emitting `Saved lockfile` and leaving the working tree
+dirty — exactly when you are about to commit or merge and want a clean status.
+
+Run a frozen/no-save install first so the lint step touches nothing:
+
+```sh
+bun install --frozen-lockfile   # then run the linter
+# or invoke the linter in a no-save mode
+```
+
+(CI itself runs markdownlint via the pinned `markdownlint-cli2-action`, so this is a
+**local-authoring** hygiene step — keep the pre-commit / pre-merge `git status` clean.)
+
+## 4. "Skill Validation" can run more than once — wait for all of it
+
+The skill-validation gate can surface as **more than one run/check context** for a single
+PR (this repo wires it through the reusable `validate.yml`, and `lint.yml` triggers on
+both `push` to `main` and `pull_request`; reusable-workflow nesting can add further
+contexts). A lagging second instance can keep a PR `BLOCKED` for a short while **after
+the first one has already gone green**.
+
+Before concluding the gate is stuck, confirm **every** validation run/check has reported
+— `gh pr checks <n>` — rather than acting on the first green. Re-running or "fixing" a gate
+that is merely still finishing wastes a round-trip.

--- a/skills/skill-repo/references/authoring-ci-gotchas.md
+++ b/skills/skill-repo/references/authoring-ci-gotchas.md
@@ -8,7 +8,7 @@ Each item is a habit that prevents a costly redo, not a structural rule.
 ## 1. Word-budget-first authoring
 
 This repo enforces a **hard 500-word cap on `SKILL.md`** (`scripts/validate-skill.sh`
-fails above 500; this very SKILL.md sits at ~492). The body also persists in context
+fails above 500; this repo's SKILL.md sits at ~495). The body also persists in context
 for the whole session, so every word is paid on each invocation — see
 [`skill-quality.md`](skill-quality.md) for the full cost model.
 


### PR DESCRIPTION
## What

Adds a small bundle of skill-authoring / CI process learnings from a cross-session retrospective (2026-06-27), as a new reference file `skills/skill-repo/references/authoring-ci-gotchas.md`, linked from `SKILL.md`'s References catalog.

Four gotchas:

1. **Word-budget-first authoring** — `SKILL.md` has a hard 500-word cap (`validate-skill.sh`); this SKILL.md sits at ~492/495. `wc -w` before editing; if near the ceiling decide architecture (references file / new skill) first instead of iteratively trimming the maintainer's prose (a real case burned ~7 edit cycles).
2. **macOS/BSD portability** — CI runs on `macos-latest` too (`validate-agents.yml` `os-matrix` default `["ubuntu-latest", "macos-latest"]`), so shell *and* test scripts must be BSD-portable; `sed -i` is GNU-only (a reviewer flagged exactly this). Complements the existing `grep -E` / `bash` shebang notes.
3. **Lint without dirtying the worktree** — running JS linters locally via `bun` can write a lockfile (`Saved lockfile`); `bun install --frozen-lockfile` / no-save first so pre-merge `git status` stays clean. (CI uses the pinned `markdownlint-cli2-action`, so this is local hygiene.)
4. **Skill Validation can run more than once** — wait for every validation run/check (`gh pr checks`) before assuming a `BLOCKED` gate is stuck.

## Placement & house style

To honor gotcha (1), this is a references file + a single catalog line in `SKILL.md` — not body bloat. New file is Pattern-1 reachable (full-path cite), so no orphan. SKILL.md stays under the cap at **495/500** words.

## Verification (this repo's own tooling)

- 500-word cap: **verified** (`scripts/validate-skill.sh` errors above 500).
- macOS in CI: **verified** (`validate-agents.yml` matrix includes `macos-latest`).
- Double validation run: **phrased generally** — on PR #132 the `Skill Validation` check appeared once; this repo wires it via the reusable `validate.yml` with `lint.yml` triggering on both `push` and `pull_request`, which can surface overlapping contexts, so the advice is framed as "wait for all instances" rather than asserting a guaranteed double-run.
- `validate-skill.sh`: **0 errors, 0 warnings**; `markdownlint-cli2`: **0 errors**; orphan audit: new file reachable (P1).

## Version

No bump. CI checks SKILL.md ↔ plugin.json version **parity** (already in sync at 1.25.0), not that it changed; references-only docs changes are released later via the normal bump PR.

From a cross-session retrospective, 2026-06-27.