### PR TITLE
docs(quality): content value rubric, scripts-first and fact-ownership rules

### DIFF
--- a/skills/skill-repo/references/repository-quality-rules.md
+++ b/skills/skill-repo/references/repository-quality-rules.md
@@ -1,6 +1,6 @@
 # Repository Quality Rules (skill repositories)
 
-Prüfbare Regeln für **einzelne Skill-Repositories** (`netresearch/*-skill`).  
+Prüfbare Regeln für **einzelne Skill-Repositories** (`netresearch/*-skill`).
 **Nicht** für das Marketplace-Repository — Discovery-Katalog- und SEO-Governance für den Hub liegen in **`netresearch/claude-code-marketplace`** (`AGENTS.md` dort).
 
 ---
@@ -26,6 +26,17 @@ Jedes Repo **muss** die folgenden Elemente enthalten **oder** eine **explizite B
 | Skill-Verzeichnis mit `SKILL.md` | Pfad entspricht `.claude-plugin/plugin.json` → `skills`. |
 | `agents/openai.yaml` | Datei existiert **oder** Begründung + Alternative (z. B. „Agent Stack nicht OpenAI“) im README. |
 | `references/`, `scripts/`, `assets/` | **PASS**, wenn SKILL.md alle Referenzen erreichbar macht **oder** README erklärt bewusst schlankes Repo („no references: …“). |
+
+---
+
+## Scripts-first (mechanisch prüfbare Regeln)
+
+Generalisiert die Routing-Regel der retro-skill `destination-taxonomy` („mechanisch erkennbare Regel → `checkpoints.yaml`“) auf die Autorenseite: Was sich mechanisch prüfen lässt, wird nicht als Prosa ausgeliefert.
+
+- **PASS**, wenn jede mechanisch prüfbare Anforderung (Regex, Datei-Existenz, Kommando mit Exit-Code) als Eintrag in `checkpoints.yaml` **oder** als Script in `scripts/` vorliegt und der Fließtext nur mit **einer** Zeile darauf verweist.
+- **FAIL**, wenn eine mechanisch prüfbare Anforderung ausschließlich als Prosa-Anweisung existiert — der Agent muss sie dann bei jeder Anwendung neu interpretieren, und Abweichungen bleiben unentdeckt.
+- **Hinweis:** Checkpoint-Patterns unterliegen der Runner-Allowlist (`is_safe_eval_command`, automated-assessment `run-checkpoints.sh`): einzeilig, kein `bash` als Basiskommando, kein `;`/`&&`/`$()`; Repo-Scripts sind dort nicht aufrufbar — komplexe Prüfungen gehören nach `scripts/` und werden im Checkpoint gespiegelt (Beispiel: SR-37 / `check-version-parity.sh`).
+- Inhaltliche Bewertung, was überhaupt in einen Skill gehört: siehe Content value rubric in [`skill-quality.md`](skill-quality.md).
 
 ---
 
@@ -72,7 +83,7 @@ Bei Änderungen an Discovery-Inhalten: siehe [`marketplace-integration.md`](mark
 - **PASS:** Name candidates validated against GitHub search results — `gh search repos "<candidate phrase>"` — preferring an uncontested, descriptive phrase over a crowded generic one.
 - **PASS:** Short aliases or command names (e.g. `jj`) are kept in the **description and topics** rather than spent on the slug, so command-searchers still match.
 
-**Good:** repo `jujutsu-workflow-skill`, skill `jujutsu-workflow` (rankable noun + function; `jj` lives in description/topics).  
+**Good:** repo `jujutsu-workflow-skill`, skill `jujutsu-workflow` (rankable noun + function; `jj` lives in description/topics).
 **Bad:** `jj-agent-workflow-skill` (`jj` is generic/crowded; `agent` is redundant for a skill).
 
 ### Repository Description
@@ -82,7 +93,7 @@ Bei Änderungen an Discovery-Inhalten: siehe [`marketplace-integration.md`](mark
 - **FAIL:** Generic phrases such as “Useful AI skill for developers”, “ultimate automation assistant”.
 - **PASS:** Understandable **without** opening `README.md`.
 
-**Good:** `Agent skill for TYPO3 Vite setup, SCSS architecture and frontend asset integration.`  
+**Good:** `Agent skill for TYPO3 Vite setup, SCSS architecture and frontend asset integration.`
 **Bad:** `Useful AI skill for developers.`
 
 ### GitHub Topics

--- a/skills/skill-repo/references/repository-quality-rules.md
+++ b/skills/skill-repo/references/repository-quality-rules.md
@@ -35,7 +35,7 @@ Generalisiert die Routing-Regel der retro-skill `destination-taxonomy` („mecha
 
 - **PASS**, wenn jede mechanisch prüfbare Anforderung (Regex, Datei-Existenz, Kommando mit Exit-Code) als Eintrag in `checkpoints.yaml` **oder** als Script in `scripts/` vorliegt und der Fließtext nur mit **einer** Zeile darauf verweist.
 - **FAIL**, wenn eine mechanisch prüfbare Anforderung ausschließlich als Prosa-Anweisung existiert — der Agent muss sie dann bei jeder Anwendung neu interpretieren, und Abweichungen bleiben unentdeckt.
-- **Hinweis:** Checkpoint-Patterns unterliegen der Runner-Allowlist (`is_safe_eval_command`, automated-assessment `run-checkpoints.sh`): einzeilig, kein `bash` als Basiskommando, kein `;`/`&&`/`$()`; Repo-Scripts sind dort nicht aufrufbar — komplexe Prüfungen gehören nach `scripts/` und werden im Checkpoint gespiegelt (Beispiel: SR-37 / `check-version-parity.sh`).
+- **Hinweis:** Checkpoint-Patterns unterliegen der Runner-Allowlist (`is_safe_eval_command`, automated-assessment `run-checkpoints.sh`): einzeilig, kein `bash` als Basiskommando, kein `;`/`&&`/`$()`; Repo-Scripts sind dort nicht aufrufbar — komplexe Prüfungen gehören nach `scripts/` und werden im Checkpoint als allowlist-konformes Pattern **gespiegelt, nicht aufgerufen** (Beispiel: Checkpoint SR-37 spiegelt `skills/skill-repo/scripts/check-version-parity.sh`).
 - Inhaltliche Bewertung, was überhaupt in einen Skill gehört: siehe Content value rubric in [`skill-quality.md`](skill-quality.md).
 
 ---
@@ -83,8 +83,8 @@ Bei Änderungen an Discovery-Inhalten: siehe [`marketplace-integration.md`](mark
 - **PASS:** Name candidates validated against GitHub search results — `gh search repos "<candidate phrase>"` — preferring an uncontested, descriptive phrase over a crowded generic one.
 - **PASS:** Short aliases or command names (e.g. `jj`) are kept in the **description and topics** rather than spent on the slug, so command-searchers still match.
 
-**Good:** repo `jujutsu-workflow-skill`, skill `jujutsu-workflow` (rankable noun + function; `jj` lives in description/topics).
-**Bad:** `jj-agent-workflow-skill` (`jj` is generic/crowded; `agent` is redundant for a skill).
+- **Good:** repo `jujutsu-workflow-skill`, skill `jujutsu-workflow` (rankable noun + function; `jj` lives in description/topics).
+- **Bad:** `jj-agent-workflow-skill` (`jj` is generic/crowded; `agent` is redundant for a skill).
 
 ### Repository Description
 
@@ -93,8 +93,8 @@ Bei Änderungen an Discovery-Inhalten: siehe [`marketplace-integration.md`](mark
 - **FAIL:** Generic phrases such as “Useful AI skill for developers”, “ultimate automation assistant”.
 - **PASS:** Understandable **without** opening `README.md`.
 
-**Good:** `Agent skill for TYPO3 Vite setup, SCSS architecture and frontend asset integration.`
-**Bad:** `Useful AI skill for developers.`
+- **Good:** `Agent skill for TYPO3 Vite setup, SCSS architecture and frontend asset integration.`
+- **Bad:** `Useful AI skill for developers.`
 
 ### GitHub Topics
 

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -27,7 +27,7 @@ Size rules bound how MUCH a skill costs; this rubric bounds WHAT KIND of content
 Two protections when applying the rubric:
 
 - Categories 3 and 5 are **first-class even when they read as prose**. Reducing wrong or unnecessary inference counts as value although the model "knows" the underlying facts — a skill that surfaces the right rule at the right moment saves the retry tokens the guess would have cost. Do not cut a failure pattern or a never-guess rule because it "looks like advice".
-- A claimed activation/recall benefit ("the model knows this but forgets") is an eval claim: back it with an A/B delta (`scripts/run-ab-evals.sh`) rather than asserting it.
+- A claimed activation/recall benefit ("the model knows this but forgets") is an eval claim: back it with an A/B delta (repo-root `scripts/run-ab-evals.sh`) rather than asserting it.
 
 ### Fact and trigger ownership
 

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -11,6 +11,28 @@ Claude Code skills have two distinct context costs:
 
 Description bytes are the always-on tax; body bytes are the on-demand tax. References are free unless the model knows they exist and decides to read them.
 
+## Content value rubric
+
+Size rules bound how MUCH a skill costs; this rubric bounds WHAT KIND of content earns that cost. Every passage in a SKILL.md body or reference file must provide at least one of six value categories:
+
+1. **Org/project-specific knowledge** — Netresearch conventions, internal tooling, URLs, field IDs, policy decisions. (`jira` custom-field IDs; the split-licensing model.)
+2. **Version/ecosystem facts models get wrong** — post-training-cutoff changes, version-specific breaking changes, niche tool flags. (TYPO3 v14 `#108055` asset-concat removal; golangci-lint v2 config.)
+3. **Retro-born failure patterns** — symptom → cause → required behavior → verification, encoded from a real incident. (`github-project`: the auto-approve/Copilot race.)
+4. **Executable scripts/validators** — deterministic work shipped in `scripts/` or `checkpoints.yaml` instead of prose the model re-derives.
+5. **Inference suppression** — "read file X, never guess Y" rules that shut down a known guessing pattern and its retry cost. (`typo3-ddev`: never guess backend URLs — read `.ddev/config.yaml`.)
+6. **Anti-rationalization guards** — rules that stop the model from skipping steps or over-claiming. ("No 'tested' claim without pasted command output.")
+
+**Generic bloat** is content that provides none of these: restated public best practice a one-line prompt regenerates ("write tests first", "use parameterized SQL", tutorials paraphrased from public docs). The test, from Den Odell's essay (see Sources): *if you can generate the passage with a prompt, the skill doesn't need to carry it.*
+
+Two protections when applying the rubric:
+
+- Categories 3 and 5 are **first-class even when they read as prose**. Reducing wrong or unnecessary inference counts as value although the model "knows" the underlying facts — a skill that surfaces the right rule at the right moment saves the retry tokens the guess would have cost. Do not cut a failure pattern or a never-guess rule because it "looks like advice".
+- A claimed activation/recall benefit ("the model knows this but forgets") is an eval claim: back it with an A/B delta (`scripts/run-ab-evals.sh`) rather than asserting it.
+
+### Fact and trigger ownership
+
+Each fact and each trigger phrase has ONE canonical owning skill in the catalog; every other skill cross-references instead of restating. Duplicated facts drift apart at the next release, and duplicated trigger phrases compete for the model's skill selection. (Example: TYPO3 v14 breaking-change facts are owned by `typo3-conformance`; upgrade-execution phrasing by `typo3-extension-upgrade`; siblings link, they do not repeat.) This is the content-level twin of the discovery-level Mirroring rule in [`repository-quality-rules.md`](repository-quality-rules.md) — one canonical surface per fact, links from everywhere else.
+
 ## Description rules
 
 ### Caps
@@ -158,3 +180,4 @@ Pattern 2 detection is heuristic: a reference file counts as P2 when its stem ma
 - Anthropic Claude Code docs on skills: <https://code.claude.com/docs/en/skills>
 - Anthropic published skills: <https://github.com/anthropics/skills>
 - Settings schema: `skillListingBudgetFraction`, `skillListingMaxDescChars` (Claude Code settings.json)
+- Den Odell, "The Great Agent Skills Land Grab": <https://denodell.com/blog/the-great-agent-skills-land-grab> — the generate-it-with-a-prompt test and the eval-evidence bar for activation/recall claims


### PR DESCRIPTION
Implements A1 of the skill value-gate program (closes #143, part of the epic #142).

## What

- **skill-quality.md — Content value rubric**: six categories a passage must serve (org knowledge, version facts, retro-born failure patterns, executable scripts, inference suppression, anti-rationalization guards); generic bloat defined via the generate-it-with-a-prompt test (Den Odell, source added). Categories 3 and 5 are explicitly protected — they read as prose but reduce wrong/unnecessary inference. Activation/recall claims require an A/B eval delta, not assertion.
- **skill-quality.md — Fact and trigger ownership**: one canonical owning skill per fact and trigger phrase; cross-references elsewhere. Content-level twin of the existing discovery-level Mirroring rule.
- **repository-quality-rules.md — Scripts-first** (PASS/FAIL, German register like the rest of the file): mechanically checkable requirements ship as checkpoints.yaml entries or scripts/, never prose-only. Notes the runner-allowlist constraints (single line, no `bash` base, no `;`/`&&`) that #123 surfaced.

## Why now

This is the citable rule the enforcement gates (#144, SR-38) and every content-cut PR (A8–A12, A22, A23) reference — without it each deletion gets relitigated per file.

The trailing-whitespace hook normalized pre-existing hard-break spaces in repository-quality-rules.md; those hunks are mechanical.