### PR TITLE
feat(validate): model-delta README heading + strict mode for heading checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,4 +146,4 @@ jobs:
 - No `composer.lock` committed
 - `composer.json`: type, license SPDX, name matches repo, skill plugin dependency, skill path exists
 - `plugin.json`: name matches SKILL.md, skills is array, paths exist, author URL correct
-- `README.md`: Netresearch reference; **warnings** (errors with `STRICT_README=1`) if required level-2 sections from `skills/skill-repo/references/readme-template.md` are missing (`What this skill solves`, `Why this is a skill (model delta)`, `Use when`, `Expected outputs`, `Context requirements`, `Example prompts`, `Related skills`, `Installation`, `Contributing`, `License`)
+- `README.md`: Netresearch reference; **warnings** (errors with `STRICT_README=1`, or `true`/`yes`) if required level-2 sections from `skills/skill-repo/references/readme-template.md` are missing (`What this skill solves`, `Why this is a skill (model delta)`, `Use when`, `Expected outputs`, `Context requirements`, `Example prompts`, `Related skills`, `Installation`, `Contributing`, `License`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,4 +146,4 @@ jobs:
 - No `composer.lock` committed
 - `composer.json`: type, license SPDX, name matches repo, skill plugin dependency, skill path exists
 - `plugin.json`: name matches SKILL.md, skills is array, paths exist, author URL correct
-- `README.md`: Netresearch reference; **warnings** if recommended level-2 sections from `skills/skill-repo/references/readme-template.md` are missing (`What this skill solves`, `Use when`, `Expected outputs`, `Context requirements`, `Example prompts`, `Related skills`, `Installation`, `Contributing`, `License`)
+- `README.md`: Netresearch reference; **warnings** (errors with `STRICT_README=1`) if required level-2 sections from `skills/skill-repo/references/readme-template.md` are missing (`What this skill solves`, `Why this is a skill (model delta)`, `Use when`, `Expected outputs`, `Context requirements`, `Example prompts`, `Related skills`, `Installation`, `Contributing`, `License`)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Netresearch maintains many agent skills; without a shared layout, packaging and 
 
 It extends Anthropic-style single-file skills with **repository-level** conventions (not a replacement for Anthropic’s skill-creator — see comparison below).
 
+## Why this is a skill (model delta)
+
+- **Value categories:** org/project-specific knowledge (Netresearch repo shape, split licensing, composer type `ai-agent-skill`) and executable scripts/validators (`validate-skill.sh`, `checkpoints.yaml`).
+- **Without the skill:** the model invents a plausible generic repo layout — single `LICENSE`, no `plugin.json`, `composer.json` without the `ai-agent-skill` type — that fails `validate-skill.sh` and org CI.
+- **Eval evidence:** `validate_skill_repo_structure` and `readme_requirements` in [`skills/skill-repo/evals/evals.json`](skills/skill-repo/evals/evals.json).
+
 ## Compatibility
 
 This is an **Agent Skill** following the [open standard](https://agentskills.io) originally developed by Anthropic and released for cross-platform use.

--- a/skills/skill-repo/references/readme-template.md
+++ b/skills/skill-repo/references/readme-template.md
@@ -23,6 +23,7 @@ Without long scrolling, the reader must see answers to:
 Use **exact** level-2 headings so agents can grep them:
 
 - `## What this skill solves`
+- `## Why this is a skill (model delta)` — the claimed value category/categories from the content value rubric ([`skill-quality.md`](skill-quality.md)), **one sentence** on what the model does wrong without the skill, and a pointer to eval evidence (`evals.json` id or dashboard delta) where it exists. Distinct from `## What this skill solves`: that section names the problem; this one justifies why a skill (not the base model) solves it.
 - `## Use when`
 - `## Expected outputs`
 - `## Context requirements`
@@ -60,6 +61,7 @@ Reference docs (README, `SKILL.md`, reference files, module headers) describe **
 
 | Check | PASS criterion |
 | --- | --- |
+| `Why this is a skill (model delta)` | Names ≥1 rubric value category, states one model-without-skill failure, links eval evidence where it exists. |
 | `Use when` | Section exists and contains trigger phrases (ticket prefixes, stacks, commands). |
 | `Example prompts` | ≥3 prompts. |
 | `Related skills` | ≥1 link/slug **or** justified none. |

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -4,7 +4,7 @@
 #
 # Checks: SKILL.md frontmatter, word count, composer.json, plugin.json,
 #          cross-file consistency, required files
-# Env:    STRICT_README=1 promotes README heading misses from warnings to errors
+# Env:    STRICT_README=1 (also true/yes, case-insensitive) promotes README heading misses from warnings to errors
 # Exit: 0 = valid, 1 = errors found
 
 set -euo pipefail
@@ -391,7 +391,7 @@ fi
 # The default must stay warnings-only: consumer repos run this script from
 # main via the reusable validate.yml, so flipping the default would break
 # their CI. Opt in per repo (or org-wide, later) by exporting STRICT_README=1.
-readme_heading_miss() { if [[ "${STRICT_README:-0}" == "1" ]]; then error "$1"; else warning "$1"; fi; }
+readme_heading_miss() { case "${STRICT_README:-0}" in 1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]) error "$1" ;; *) warning "$1" ;; esac; }
 
 # Required level-2 headings (whole-line match) per skills/skill-repo/references/readme-template.md
 README_REQUIRED_HEADINGS=(

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -4,6 +4,7 @@
 #
 # Checks: SKILL.md frontmatter, word count, composer.json, plugin.json,
 #          cross-file consistency, required files
+# Env:    STRICT_README=1 promotes README heading misses from warnings to errors
 # Exit: 0 = valid, 1 = errors found
 
 set -euo pipefail
@@ -385,10 +386,17 @@ else
     error ".claude-plugin/plugin.json not found"
 fi
 
-# --- README.md quality checks (warnings only) ---
-# Recommended level-2 headings (whole-line match) per skills/skill-repo/references/readme-template.md
+# --- README.md quality checks (warnings by default) ---
+# Heading misses are warnings unless STRICT_README=1 promotes them to errors.
+# The default must stay warnings-only: consumer repos run this script from
+# main via the reusable validate.yml, so flipping the default would break
+# their CI. Opt in per repo (or org-wide, later) by exporting STRICT_README=1.
+readme_heading_miss() { if [[ "${STRICT_README:-0}" == "1" ]]; then error "$1"; else warning "$1"; fi; }
+
+# Required level-2 headings (whole-line match) per skills/skill-repo/references/readme-template.md
 README_REQUIRED_HEADINGS=(
     "What this skill solves"
+    "Why this is a skill (model delta)"
     "Use when"
     "Expected outputs"
     "Context requirements"
@@ -411,7 +419,7 @@ if [[ -f "$REPO_DIR/README.md" ]]; then
         if grep -Fxq "## ${heading}" "$REPO_DIR/README.md"; then
             success "README.md has ## ${heading}"
         else
-            warning "README.md missing recommended section (exact line ## ${heading}) — see skill-repo-skill skills/skill-repo/references/readme-template.md"
+            readme_heading_miss "README.md missing section (exact line ## ${heading}) — see skill-repo-skill skills/skill-repo/references/readme-template.md"
         fi
     done
 

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -8,6 +8,12 @@
 - {Capability or outcome 2}
 - {Capability or outcome 3}
 
+## Why this is a skill (model delta)
+
+- **Value categories:** {Category/categories from the content value rubric in skill-quality.md — e.g. org-specific knowledge, retro-born failure patterns}
+- **Without the skill:** {One sentence: what the model does wrong without this skill.}
+- **Eval evidence:** {evals.json id or dashboard delta — or “none yet”}
+
 ## Use when
 
 - {Trigger phrase, stack, ticket prefix, or user intent 1}


### PR DESCRIPTION
## What

- **`skills/skill-repo/references/readme-template.md`**: adds `## Why this is a skill (model delta)` to the required level-2 headings — the claimed value category/categories from the content value rubric (`skill-quality.md`), one sentence on what the model does wrong without the skill, and a pointer to eval evidence (`evals.json` id or dashboard delta) where it exists. New row in the machine-friendly cross-checks table.
- **`skills/skill-repo/templates/README.md.template`**: ships the section as a placeholder block after `## What this skill solves`.
- **`skills/skill-repo/scripts/validate-skill.sh`**: the new heading joins `README_REQUIRED_HEADINGS`; a miss is a **warning** by default. New `STRICT_README=1` env toggle promotes README heading misses to errors via a `readme_heading_miss()` helper. The default stays warnings-only because consumer repos run this script from `main` via the reusable `validate.yml` — flipping the default would break their CI. Promotion of the heading set to error tier can follow after a release cycle by exporting `STRICT_README=1` in the reusable workflow.
- **`README.md`**: this repo dogfoods the section (rubric categories, model-without-skill failure, eval pointers).
- **`AGENTS.md`**: validation docs heading list synced.

## Template-drift scope check

The `Template Drift` job compares only `.github/` files against `netresearch/.github/templates/skill/.github/`. None of the files changed here are governed by it; `validate-skill.sh`, the README template, and the reference doc are canonical in this repo.

## Verification

- `bash skills/skill-repo/scripts/validate-skill.sh .` — 0 errors, 0 warnings (own README carries the new heading)
- Default run against a fixture repo without the heading — WARNING, exit 0
- `STRICT_README=1` against the same fixture — ERROR, exit 1
- `STRICT_README=1` against this repo — 0 errors, exit 0
- `shellcheck -x -S error` on the script, `tests/validate-skill.sh` (21/21), markdownlint on the changed Markdown files

Closes #145