### PR TITLE
feat(evals): scheduled A/B eval runs with provenance + dashboard refresh

### DIFF
--- a/.github/workflows/ab-evals-schedule.yml
+++ b/.github/workflows/ab-evals-schedule.yml
@@ -1,0 +1,233 @@
+name: A/B Evals Schedule
+
+# Scheduled A/B eval runs (issue #146): runs scripts/run-ab-evals.sh for
+# marketplace catalog skills, merges the per-skill results (with a
+# provenance block) into docs/dashboard/data/results.json via
+# scripts/merge-ab-results.py, validates the dashboard, and opens a PR.
+#
+# Cost bound: a scheduled run processes BATCH_SIZE skills, selected
+# deterministically by ISO week number modulo the number of catalog groups
+# (ceil(catalog / BATCH_SIZE), currently ceil(42/5) = 9 groups), so the full
+# catalog rotates through in ~9 weekly runs. The full catalog runs only via
+# workflow_dispatch with full=true (takes several hours).
+#
+# Prerequisite (human setup step): the ANTHROPIC_API_KEY repository secret
+# must exist — run-ab-evals.sh drives the claude CLI with it. The run fails
+# early with a clear error if the secret is missing.
+#
+# The refresh PR is created with GITHUB_TOKEN, so PR CI does not start
+# automatically (GitHub limitation) — close/reopen the PR to trigger checks.
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"  # Mondays 03:17 UTC
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: "Comma/space-separated plugin names to run (empty = weekly rotation subset)"
+        type: string
+        default: ""
+      full:
+        description: "Run the full catalog instead of the rotation subset (several hours)"
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: ab-evals-schedule
+  cancel-in-progress: false
+
+env:
+  BATCH_SIZE: "5"
+  MARKETPLACE_REPO: netresearch/claude-code-marketplace
+
+jobs:
+  ab-evals:
+    name: Run A/B evals and refresh dashboard data
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    permissions:
+      contents: write  # push the refresh branch
+      pull-requests: write  # open the refresh PR
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Require ANTHROPIC_API_KEY secret
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -z "$ANTHROPIC_API_KEY" ]]; then
+            echo "::error::Repository secret ANTHROPIC_API_KEY is not set (Settings > Secrets and variables > Actions). The eval runner cannot call the Anthropic API without it."
+            exit 1
+          fi
+          echo "ANTHROPIC_API_KEY is set."
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Select catalog subset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_SKILLS: ${{ inputs.skills }}
+          INPUT_FULL: ${{ inputs.full }}
+        run: |
+          gh api "repos/${MARKETPLACE_REPO}/contents/.claude-plugin/marketplace.json" --jq '.content' | base64 -d > /tmp/marketplace.json
+          python3 - <<'PYEOF'
+          import datetime
+          import json
+          import os
+
+          with open("/tmp/marketplace.json") as f:
+              catalog = json.load(f)
+          plugins = sorted(
+              (p["name"], p["source"]["repo"], p.get("category", ""))
+              for p in catalog["plugins"]
+              if isinstance(p.get("source"), dict) and p["source"].get("repo")
+          )
+          requested = [
+              s for s in os.environ.get("INPUT_SKILLS", "").replace(",", " ").split() if s
+          ]
+          batch = int(os.environ["BATCH_SIZE"])
+          if requested:
+              selected = [p for p in plugins if p[0] in requested]
+              mode = f"name filter ({len(selected)}/{len(plugins)})"
+          elif os.environ.get("INPUT_FULL") == "true":
+              selected = plugins
+              mode = f"full catalog ({len(plugins)})"
+          else:
+              week = datetime.date.today().isocalendar()[1]
+              groups = -(-len(plugins) // batch)  # ceil
+              group = week % groups
+              selected = plugins[group * batch : (group + 1) * batch]
+              mode = f"rotation week={week} group={group}/{groups}"
+          with open("/tmp/ab-catalog.tsv", "w") as f:
+              for name, repo, category in selected:
+                  f.write(f"{name}\t{repo}\t{category}\n")
+          print(f"Selection mode: {mode}")
+          for name, repo, _ in selected:
+              print(f"  {name} ({repo})")
+          PYEOF
+
+      - name: Run A/B evals per skill (fail-soft)
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          mkdir -p /tmp/ab-out
+          : > /tmp/ab-out/pr-lines.md
+          ok=0
+          failed=()
+          while IFS=$'\t' read -r -u3 name repo category; do
+            echo "::group::${name} (${repo})"
+            dir="/tmp/skill-checkouts/${name}"
+            if ! git clone --quiet --depth 1 "https://github.com/${repo}.git" "$dir"; then
+              echo "::warning::${name}: clone failed, skipping"
+              failed+=("$name"); echo "::endgroup::"; continue
+            fi
+            evals=""
+            for cand in "$dir"/skills/*/evals/evals.json "$dir/evals/evals.json"; do
+              if [[ -f "$cand" ]]; then evals="$cand"; break; fi
+            done
+            if [[ -z "$evals" ]]; then
+              echo "${name}: no evals.json, skipping"
+              echo "::endgroup::"; continue
+            fi
+            skilldir="$(dirname "$(dirname "$evals")")"
+            skill=""
+            for cand in "$skilldir/SKILL.md" "$dir"/skills/*/SKILL.md "$dir/SKILL.md"; do
+              if [[ -f "$cand" ]]; then skill="$cand"; break; fi
+            done
+            if [[ -z "$skill" ]]; then
+              echo "::warning::${name}: evals.json without SKILL.md, skipping"
+              failed+=("$name"); echo "::endgroup::"; continue
+            fi
+            rm -rf scripts/ab-results
+            if ! bash scripts/run-ab-evals.sh --evals="$evals" --skill="$skill" < /dev/null; then
+              echo "::warning::${name}: eval run failed, skipping"
+              failed+=("$name"); echo "::endgroup::"; continue
+            fi
+            if [[ ! -f scripts/ab-results/ab-results.json ]]; then
+              echo "::warning::${name}: run produced no ab-results.json, skipping"
+              failed+=("$name"); echo "::endgroup::"; continue
+            fi
+            cp scripts/ab-results/ab-results.json "/tmp/ab-out/${name}.json"
+            cp scripts/ab-results/summary.md "/tmp/ab-out/${name}-summary.md" 2>/dev/null || true
+            version=""
+            if [[ -f "$dir/.claude-plugin/plugin.json" ]]; then
+              version=$(python3 -c "import json, sys; print(json.load(open(sys.argv[1])).get('version', ''))" "$dir/.claude-plugin/plugin.json" || true)
+            fi
+            if python3 scripts/merge-ab-results.py \
+                --data-file docs/dashboard/data/results.json \
+                --name "$name" --repo "$repo" --category "$category" \
+                --version "$version" \
+                --skill-path "${skill#"$dir"/}" --evals-path "${evals#"$dir"/}" \
+                --ab-results "/tmp/ab-out/${name}.json" | tee -a /tmp/ab-out/pr-lines.md; then
+              ok=$((ok + 1))
+            else
+              echo "::warning::${name}: merge failed"
+              failed+=("$name")
+            fi
+            echo "::endgroup::"
+          done 3< /tmp/ab-catalog.tsv
+          echo "succeeded=${ok} failed=${#failed[@]} ${failed[*]:-}"
+          if [[ "$ok" -eq 0 ]]; then
+            echo "::error::No skill produced mergeable results"
+            exit 1
+          fi
+
+      - name: Validate dashboard against refreshed data
+        run: bash scripts/generate-dashboard.sh
+
+      - name: Upload raw eval results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ab-eval-results
+          path: /tmp/ab-out/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Open PR with refreshed dashboard data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet -- docs/dashboard/data/results.json; then
+            echo "No changes to dashboard data; skipping PR."
+            exit 0
+          fi
+          branch="chore/ab-evals-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add docs/dashboard/data/results.json
+          git commit -m "chore(evals): refresh dashboard data from scheduled A/B eval run"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push -u origin "$branch"
+          {
+            echo "Scheduled A/B eval run ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} refreshed \`docs/dashboard/data/results.json\`."
+            echo ""
+            echo "## Skills updated"
+            echo ""
+            sed 's/^/- /' /tmp/ab-out/pr-lines.md
+            echo ""
+            echo "Raw eval outputs: \`ab-eval-results\` artifact on the run linked above."
+            echo ""
+            echo "Note: created with GITHUB_TOKEN, so PR CI does not start automatically — close and reopen this PR to trigger checks."
+          } > /tmp/pr-body.md
+          gh pr create \
+            --title "chore(evals): dashboard data refresh from scheduled A/B run" \
+            --body-file /tmp/pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/ab-evals-schedule.yml
+++ b/.github/workflows/ab-evals-schedule.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: Install Claude Code CLI
         run: |
-          npm install -g @anthropic-ai/claude-code
+          # Pinned exact version (holds ANTHROPIC_API_KEY in env; latest
+          # verified 2026-07-10). Bump deliberately, not implicitly.
+          npm install -g @anthropic-ai/claude-code@2.1.206
           claude --version
 
       - name: Select catalog subset
@@ -173,9 +175,13 @@ jobs:
                 --name "$name" --repo "$repo" --category "$category" \
                 --version "$version" \
                 --skill-path "${skill#"$dir"/}" --evals-path "${evals#"$dir"/}" \
-                --ab-results "/tmp/ab-out/${name}.json" | tee -a /tmp/ab-out/pr-lines.md; then
+                --ab-results scripts/ab-results/ab-results.json \
+                > /tmp/ab-out/merge-line.txt 2>&1; then
+              cat /tmp/ab-out/merge-line.txt >> /tmp/ab-out/pr-lines.md
+              cat /tmp/ab-out/merge-line.txt
               ok=$((ok + 1))
             else
+              cat /tmp/ab-out/merge-line.txt || true
               echo "::warning::${name}: merge failed"
               failed+=("$name")
             fi

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -394,7 +394,7 @@ async function loadData() {
     // Result blocks are keyed by the model id recorded in provenance
     // (legacy entries: "opus"). Alias the single model key to `opus`
     // so the render code below has one canonical accessor.
-    DATA.skills.forEach(s => { if (!s.results.opus) s.results.opus = Object.values(s.results)[0]; });
+    DATA.skills.forEach(s => { if (s.results && !s.results.opus) s.results.opus = Object.values(s.results)[0]; });
   } catch (e) {
     document.body.innerHTML = '<p style="padding:2rem;color:red;">Failed to load data/results.json</p>';
     return;

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -391,6 +391,10 @@ async function loadData() {
   try {
     const resp = await fetch('data/results.json');
     DATA = await resp.json();
+    // Result blocks are keyed by the model id recorded in provenance
+    // (legacy entries: "opus"). Alias the single model key to `opus`
+    // so the render code below has one canonical accessor.
+    DATA.skills.forEach(s => { if (!s.results.opus) s.results.opus = Object.values(s.results)[0]; });
   } catch (e) {
     document.body.innerHTML = '<p style="padding:2rem;color:red;">Failed to load data/results.json</p>';
     return;

--- a/scripts/generate-dashboard.sh
+++ b/scripts/generate-dashboard.sh
@@ -37,15 +37,20 @@ import json, sys
 with open("$DATA_FILE") as f:
     data = json.load(f)
 
+def res(s):
+    # Result blocks are keyed by the model id recorded in provenance
+    # (legacy entries: "opus"). Each entry carries exactly one model key.
+    return next(iter(s["results"].values()))
+
 skills = data["skills"]
 total_skills = len(skills)
 total_evals = sum(s["eval_count"] for s in skills)
-avg_delta = sum(s["results"]["opus"]["delta"] for s in skills) / total_skills
-perfect = sum(1 for s in skills if s["results"]["opus"]["with_skill_pass_rate"] >= 1.0)
+avg_delta = sum(res(s)["delta"] for s in skills) / total_skills
+perfect = sum(1 for s in skills if res(s)["with_skill_pass_rate"] >= 1.0)
 categories = {}
 for s in skills:
     cat = s["category"]
-    categories.setdefault(cat, []).append(s["results"]["opus"]["delta"])
+    categories.setdefault(cat, []).append(res(s)["delta"])
 
 print(f"Generated:     {data['generated']}")
 print(f"Total skills:  {total_skills}")
@@ -58,11 +63,11 @@ for cat, deltas in sorted(categories.items(), key=lambda x: -sum(x[1])/len(x[1])
     avg = sum(deltas) / len(deltas)
     print(f"  {cat:15s} {len(deltas):2d} skills  avg +{avg*100:.0f}%")
 
-best = max(skills, key=lambda s: s["results"]["opus"]["delta"])
-worst = min(skills, key=lambda s: s["results"]["opus"]["delta"])
+best = max(skills, key=lambda s: res(s)["delta"])
+worst = min(skills, key=lambda s: res(s)["delta"])
 print()
-print(f"Highest delta: {best['name']} (+{best['results']['opus']['delta']*100:.0f}%)")
-print(f"Lowest delta:  {worst['name']} (+{worst['results']['opus']['delta']*100:.0f}%)")
+print(f"Highest delta: {best['name']} (+{res(best)['delta']*100:.0f}%)")
+print(f"Lowest delta:  {worst['name']} (+{res(worst)['delta']*100:.0f}%)")
 PYEOF
 )
 

--- a/scripts/merge-ab-results.py
+++ b/scripts/merge-ab-results.py
@@ -59,6 +59,12 @@ def main() -> int:
     with open(ab_results) as f:
         ab = json.load(f)
 
+    if not isinstance(data, dict) or not isinstance(data.get("skills"), list):
+        sys.exit(
+            f"{args.data_file}: malformed data file "
+            f"(expected an object with a 'skills' array)"
+        )
+
     provenance = ab["provenance"]
     combined = ab["totals"]["combined"]
     checks = combined["checks"]

--- a/scripts/merge-ab-results.py
+++ b/scripts/merge-ab-results.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Merge one run-ab-evals.sh ab-results.json into the dashboard data file.
+
+Updates (or inserts) the entry for a single skill in
+docs/dashboard/data/results.json, preserving all other entries. The result
+block is keyed by the model id recorded in the run's provenance block, and
+the provenance block itself is stored on the entry.
+
+Usage:
+    merge-ab-results.py --data-file docs/dashboard/data/results.json \
+        --name file-search --repo netresearch/file-search-skill \
+        --ab-results /tmp/ab-out/file-search.json \
+        [--category tooling] [--version 1.3.0] \
+        [--skill-path skills/file-search/SKILL.md] \
+        [--evals-path skills/file-search/evals/evals.json]
+"""
+
+import argparse
+import datetime
+import json
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-file", required=True)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--ab-results", required=True)
+    parser.add_argument("--category", default="")
+    parser.add_argument("--version", default="")
+    parser.add_argument("--skill-path", default="")
+    parser.add_argument("--evals-path", default="")
+    args = parser.parse_args()
+
+    with open(args.data_file) as f:
+        data = json.load(f)
+    with open(args.ab_results) as f:
+        ab = json.load(f)
+
+    provenance = ab["provenance"]
+    combined = ab["totals"]["combined"]
+    checks = combined["checks"]
+    if checks <= 0:
+        print(f"{args.name}: no graded checks in {args.ab_results}; not merging")
+        return 1
+
+    without_rate = round(combined["without"] / checks, 4)
+    with_rate = round(combined["with"] / checks, 4)
+
+    entry = next(
+        (
+            s
+            for s in data["skills"]
+            if s.get("repo") == args.repo or s.get("name") == args.name
+        ),
+        None,
+    )
+    if entry is None:
+        entry = {"top_finding": ""}
+        data["skills"].append(entry)
+
+    entry["name"] = args.name
+    entry["repo"] = args.repo
+    entry["eval_count"] = ab["eval_count"]
+    entry["results"] = {
+        provenance["model"]: {
+            "without_skill_pass_rate": without_rate,
+            "with_skill_pass_rate": with_rate,
+            "delta": round(with_rate - without_rate, 4),
+        }
+    }
+    entry["provenance"] = provenance
+    if args.category:
+        entry["category"] = args.category
+    entry.setdefault("category", "other")
+    if args.version:
+        entry["version"] = args.version
+    entry.setdefault("version", "unknown")
+    if args.skill_path:
+        entry["skill_path"] = args.skill_path
+    if args.evals_path:
+        entry["evals_path"] = args.evals_path
+
+    data["generated"] = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    with open(args.data_file, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+    print(
+        f"{args.name}: merged {checks} checks "
+        f"(without={without_rate} with={with_rate} "
+        f"delta={entry['results'][provenance['model']]['delta']}) "
+        f"model={provenance['model']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/merge-ab-results.py
+++ b/scripts/merge-ab-results.py
@@ -18,7 +18,26 @@ Usage:
 import argparse
 import datetime
 import json
+import pathlib
 import sys
+
+
+def contained_json_path(raw: str, must_exist: bool) -> pathlib.Path:
+    """Resolve a CLI-supplied path; refuse escapes from the working tree.
+
+    Both callers pass workspace-relative paths; anything resolving outside
+    the current working tree (or without a .json suffix) is rejected before
+    any file access.
+    """
+    root = pathlib.Path.cwd().resolve()
+    resolved = pathlib.Path(raw).resolve()
+    if not resolved.is_relative_to(root):
+        sys.exit(f"refusing path outside {root}: {raw}")
+    if resolved.suffix != ".json":
+        sys.exit(f"refusing non-.json path: {raw}")
+    if must_exist and not resolved.is_file():
+        sys.exit(f"not a file: {raw}")
+    return resolved
 
 
 def main() -> int:
@@ -33,9 +52,11 @@ def main() -> int:
     parser.add_argument("--evals-path", default="")
     args = parser.parse_args()
 
-    with open(args.data_file) as f:
+    data_file = contained_json_path(args.data_file, must_exist=True)
+    ab_results = contained_json_path(args.ab_results, must_exist=True)
+    with open(data_file) as f:
         data = json.load(f)
-    with open(args.ab_results) as f:
+    with open(ab_results) as f:
         ab = json.load(f)
 
     provenance = ab["provenance"]
@@ -86,7 +107,7 @@ def main() -> int:
         "%Y-%m-%dT%H:%M:%SZ"
     )
 
-    with open(args.data_file, "w") as f:
+    with open(data_file, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")
 

--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -28,6 +28,11 @@ EVALS_FILE="${EVALS_FILE:-$REPO_DIR/skills/skill-repo/evals/evals.json}"
 SKILL_FILE="${SKILL_FILE:-$REPO_DIR/skills/skill-repo/SKILL.md}"
 RESULTS_DIR="${REPO_DIR}/scripts/ab-results"
 
+# Models used for the A/B completions and the LLM judge; recorded in the
+# provenance block of ab-results.json so published numbers stay reproducible.
+EVAL_MODEL="sonnet"
+GRADER_MODEL="haiku"
+
 mkdir -p "$RESULTS_DIR"
 
 # Normalize: support both top-level array and {evals: [...]} wrapper
@@ -76,7 +81,7 @@ run_single() {
             --no-session-persistence \
             --disable-slash-commands \
             --tools "" \
-            --model sonnet \
+            --model "$EVAL_MODEL" \
             "$prompt" \
             > "$output_file" 2>/dev/null || true
     else
@@ -84,7 +89,7 @@ run_single() {
             --no-session-persistence \
             --disable-slash-commands \
             --tools "" \
-            --model sonnet \
+            --model "$EVAL_MODEL" \
             --append-system-prompt "$(cat "$SKILL_FILE")" \
             "$prompt" \
             > "$output_file" 2>/dev/null || true
@@ -158,7 +163,7 @@ Format: one line per expectation, e.g.:
         --no-session-persistence \
         --disable-slash-commands \
         --tools "" \
-        --model haiku \
+        --model "$GRADER_MODEL" \
         "$grading_prompt" \
         > "$grader_file" 2>/dev/null || true
 }
@@ -324,3 +329,34 @@ if [[ "$COMBINED_TOTAL" -gt 0 ]]; then
 fi
 
 cat "$SUMMARY_FILE"
+
+# Emit machine-readable totals with a provenance block
+# (consumed by scripts/merge-ab-results.py)
+SKILL_REPO_SHA=$(git -C "$(dirname "$SKILL_FILE")" rev-parse HEAD 2>/dev/null || echo "unknown")
+RUNNER_REPO_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
+RUNNER_SCRIPT_SHA=$(git hash-object "$0" 2>/dev/null || echo "unknown")
+RUN_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+python3 - "$RESULTS_DIR/ab-results.json" <<PYEOF
+import json, sys
+
+with open(sys.argv[1], "w") as f:
+    json.dump({
+        "provenance": {
+            "run_date": "$RUN_DATE",
+            "model": "$EVAL_MODEL",
+            "grader_model": "$GRADER_MODEL",
+            "skill_repo_commit": "$SKILL_REPO_SHA",
+            "runner_commit": "$RUNNER_REPO_SHA",
+            "runner_script_sha": "$RUNNER_SCRIPT_SHA",
+        },
+        "eval_count": $EVAL_COUNT,
+        "totals": {
+            "regex": {"without": $TOTAL_WITHOUT, "with": $TOTAL_WITH, "checks": $TOTAL_CHECKS},
+            "llm": {"without": $TOTAL_EXP_WITHOUT, "with": $TOTAL_EXP_WITH, "checks": $TOTAL_EXPECTATIONS},
+            "combined": {"without": $COMBINED_WITHOUT, "with": $COMBINED_WITH, "checks": $COMBINED_TOTAL},
+        },
+    }, f, indent=2)
+    f.write("\n")
+PYEOF
+echo ""
+echo "Results JSON: $RESULTS_DIR/ab-results.json"

--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -336,24 +336,34 @@ SKILL_REPO_SHA=$(git -C "$(dirname "$SKILL_FILE")" rev-parse HEAD 2>/dev/null ||
 RUNNER_REPO_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
 RUNNER_SCRIPT_SHA=$(git hash-object "$0" 2>/dev/null || echo "unknown")
 RUN_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-python3 - "$RESULTS_DIR/ab-results.json" <<PYEOF
+python3 - "$RESULTS_DIR/ab-results.json" \
+    "$RUN_DATE" \
+    "$EVAL_MODEL" \
+    "$GRADER_MODEL" \
+    "$SKILL_REPO_SHA" \
+    "$RUNNER_REPO_SHA" \
+    "$RUNNER_SCRIPT_SHA" \
+    "$EVAL_COUNT" \
+    "$TOTAL_WITHOUT" "$TOTAL_WITH" "$TOTAL_CHECKS" \
+    "$TOTAL_EXP_WITHOUT" "$TOTAL_EXP_WITH" "$TOTAL_EXPECTATIONS" \
+    "$COMBINED_WITHOUT" "$COMBINED_WITH" "$COMBINED_TOTAL" <<'PYEOF'
 import json, sys
 
 with open(sys.argv[1], "w") as f:
     json.dump({
         "provenance": {
-            "run_date": "$RUN_DATE",
-            "model": "$EVAL_MODEL",
-            "grader_model": "$GRADER_MODEL",
-            "skill_repo_commit": "$SKILL_REPO_SHA",
-            "runner_commit": "$RUNNER_REPO_SHA",
-            "runner_script_sha": "$RUNNER_SCRIPT_SHA",
+            "run_date": sys.argv[2],
+            "model": sys.argv[3],
+            "grader_model": sys.argv[4],
+            "skill_repo_commit": sys.argv[5],
+            "runner_commit": sys.argv[6],
+            "runner_script_sha": sys.argv[7],
         },
-        "eval_count": $EVAL_COUNT,
+        "eval_count": int(sys.argv[8]),
         "totals": {
-            "regex": {"without": $TOTAL_WITHOUT, "with": $TOTAL_WITH, "checks": $TOTAL_CHECKS},
-            "llm": {"without": $TOTAL_EXP_WITHOUT, "with": $TOTAL_EXP_WITH, "checks": $TOTAL_EXPECTATIONS},
-            "combined": {"without": $COMBINED_WITHOUT, "with": $COMBINED_WITH, "checks": $COMBINED_TOTAL},
+            "regex": {"without": int(sys.argv[9]), "with": int(sys.argv[10]), "checks": int(sys.argv[11])},
+            "llm": {"without": int(sys.argv[12]), "with": int(sys.argv[13]), "checks": int(sys.argv[14])},
+            "combined": {"without": int(sys.argv[15]), "with": int(sys.argv[16]), "checks": int(sys.argv[17])},
         },
     }, f, indent=2)
     f.write("\n")


### PR DESCRIPTION
Adds a scheduled A/B eval pipeline: `.github/workflows/ab-evals-schedule.yml` runs `scripts/run-ab-evals.sh` for marketplace catalog skills, merges per-skill results with a provenance block into `docs/dashboard/data/results.json`, and opens a refresh PR.

## Design

**Catalog + rotation.** The catalog is fetched at run time from `netresearch/claude-code-marketplace` `.claude-plugin/marketplace.json` (42 plugins today). Skills are sorted by name and chunked into groups of `BATCH_SIZE = 5`; a scheduled run processes group `ISO_week mod ceil(42/5) = ISO_week mod 9`, so the full catalog rotates through in ~9 weekly runs. `workflow_dispatch` accepts a `skills` name filter and a `full=true` boolean for a full-catalog run.

**Cost bound per scheduled run.** 5 skills, each: `eval_count x 2` completions (sonnet, 90 s timeout each) plus up to `2 x eval_count` haiku gradings. At the current catalog average (~21 evals/skill) that is ~210 sonnet + ~210 haiku short completions per weekly run. A full-catalog dispatch is ~9x that and takes several hours (job timeout 350 min).

**Per-skill flow (fail-soft).** Shallow-clone the repo, locate `skills/*/evals/evals.json` or `evals/evals.json` (the two locations `validate-evals.sh` accepts; repos without evals are skipped silently), locate the matching `SKILL.md`, run the existing runner, merge via the new `scripts/merge-ab-results.py`. Any failure warns and continues; the job only fails hard when no skill produced mergeable results. Raw outputs are uploaded as the `ab-eval-results` artifact.

**Provenance.** `run-ab-evals.sh` now writes `scripts/ab-results/ab-results.json` next to `summary.md`. Sample:

```json
{
  "provenance": {
    "run_date": "2026-07-10T14:09:12Z",
    "model": "sonnet",
    "grader_model": "haiku",
    "skill_repo_commit": "4a03099837fa59914cb8f8d1f5b7c9a5e272d91b",
    "runner_commit": "4a03099837fa59914cb8f8d1f5b7c9a5e272d91b",
    "runner_script_sha": "6e37cfbec5a7fb3eec61e0c476b3c157dacf036b"
  },
  "eval_count": 1,
  "totals": {
    "regex": {"without": 1, "with": 1, "checks": 2},
    "llm": {"without": 0, "with": 0, "checks": 0},
    "combined": {"without": 1, "with": 1, "checks": 2}
  }
}
```

The merge keys each entry's result block by the model id recorded in provenance (new runs: `sonnet`) instead of the previous hardcoded `opus`, which the runner never used — this closes the reproducibility gap named in the issue. `generate-dashboard.sh` and `docs/dashboard/index.html` read the result block by its recorded key; legacy `opus` entries keep working until their rotation slot replaces them.

## Secret prerequisite (human setup step)

The workflow requires the **`ANTHROPIC_API_KEY`** repository secret (no existing Anthropic secret name is in use in this org's workflows). It must be created manually under Settings > Secrets and variables > Actions before the first run; the job fails early with a clear error while it is missing.

## Limitations

- The refresh PR is created with `GITHUB_TOKEN`, so its CI does not start automatically; close/reopen the PR to trigger checks.
- One skill per repo: for multi-skill repos only the first `skills/*/evals/evals.json` match is evaluated (the runner is one-skill-per-invocation).
- `claude` CLI is installed unpinned (`npm install -g @anthropic-ai/claude-code`) at run time.

## Verification

- Offline end-to-end run of `run-ab-evals.sh` (stub `claude` on PATH, `--no-llm`): default invocation (20 evals / 61 checks) and `--evals/--skill` invocation both produce `summary.md` plus the new `ab-results.json` (sample above).
- `merge-ab-results.py` tested against a copy of `results.json`: updates an existing entry in place (preserving `top_finding`, other 24 entries byte-identical) and inserts a new entry; `generate-dashboard.sh` then exits 0 on the mixed opus/sonnet data.
- `yamllint -c .yamllint.yml` and `actionlint` on the new workflow: 0 findings. `shellcheck -x -S error`, `ruff check`, `ruff format --check`, `bash -n`, `validate-skill.sh`: pass.

Closes #146
