### PR TITLE
feat(gate): SR-38 skill-value checkpoint + advisory generic-share audit

### DIFF
--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -8,6 +8,13 @@
 #   - CODE FENCE longest block (PASS/INFO at >25 lines)
 #   - REFERENCES reachability (P1 direct cite, P2 catalog convention,
 #                              P3 list-and-pick, ORPHAN otherwise)
+#   - GENERIC SHARE (PASS/INFO >30% of prose paragraphs carry generic-bloat
+#                    markers; paragraphs with failure-pattern, never-guess,
+#                    version-number, or org markers are protected and never
+#                    counted — see the "Content value rubric" in
+#                    skills/skill-repo/references/skill-quality.md)
+#   - WORKFLOW verification (PASS/INFO when the body has multi-step workflow
+#                            language but no verify/evidence/output rule)
 # Exit: 0 if no FAILs, 1 otherwise.
 #
 # shellcheck disable=SC2155 # local var with command substitution is intentional
@@ -43,6 +50,14 @@ Quality rules:
                Thresholds set by per-invocation token cost (~1.4x word count).
   CODE FENCES  INFO when longest fenced block exceeds 25 lines.
   REFERENCES   ORPHAN when references/*.md has no reachability pattern.
+  GENERIC      INFO when >30% of prose paragraphs in the body carry
+               generic-bloat markers ("best practice", "clean code", ...).
+               Paragraphs matching failure-pattern vocabulary, never-guess
+               rules, version numbers, or org names are protected and never
+               counted (content value rubric categories 3/5). Advisory only
+               while thresholds calibrate.
+  WORKFLOW     INFO when the body has numbered steps plus run/then language
+               but never mentions verify/evidence/output.
 
 Exit code: 0 if no FAILs across all skills, 1 otherwise.
 EOF
@@ -173,6 +188,55 @@ fence_stats() {
     ' <<<"$1"
 }
 
+# generic_share_stats <body_text (stdin)>: prints "<total> <generic> <protected>"
+#
+# Keyword heuristic for the generic-bloat share defined by the "Content value
+# rubric" in skills/skill-repo/references/skill-quality.md. A paragraph is a
+# blank-line-separated block of prose outside fenced code (fenced code is
+# rubric category 4 — executable — and never counted; headings and table
+# rows are structure/navigation, not prose).
+#
+# Protection comes FIRST and always wins: a paragraph matching failure-pattern
+# vocabulary (symptom/cause/verify), never-guess rules ("never guess",
+# "always read/run/check/fetch", "do not assume"), a version number, or an
+# org name is NEVER counted as generic, even when a generic marker also
+# matches. Rubric categories 3 (retro-born failure patterns) and 5
+# (inference suppression) are first-class value although they read as prose
+# advice.
+#
+# Deliberately conservative: high-precision generic markers only, so protected
+# content is not misflagged. Consumers emit INFO above 30%; a WARN tier
+# (>60% per netresearch/skill-repo-skill issue #144) stays disabled until the
+# thresholds are calibrated against the skill corpus.
+generic_share_stats() {
+    awk '
+        function flush(    lb) {
+            if (buf !~ /[^[:space:]]/) { buf = ""; return }
+            total++
+            lb = tolower(buf)
+            if (lb ~ protectre || buf ~ versionre) {
+                protected++
+            } else if (lb ~ genericre) {
+                generic++
+            }
+            buf = ""
+        }
+        BEGIN {
+            in_fence = 0; total = 0; generic = 0; protected = 0; buf = ""
+            protectre = "symptom|root cause|caused by|verif|evidence|never guess|never assume|do(n.t| not) (guess|assume)|always (read|run|check|fetch)|netresearch"
+            versionre = "[0-9]+\\.[0-9]+"
+            genericre = "write tests? first|clean code|best practices?|follow the principles?|keep it simple|single responsibility|separation of concerns|do(n.t| not) repeat yourself|meaningful names|self.documenting code|in this tutorial|this guide (will|shows)|step.by.step guide|as a general rule|it is important to|industry standard"
+        }
+        /^[[:space:]]*```/ { flush(); in_fence = 1 - in_fence; next }
+        in_fence { next }
+        /^[[:space:]]*$/ { flush(); next }
+        /^#/ { flush(); next }
+        /^[[:space:]]*\|/ { next }
+        { buf = buf " " $0 }
+        END { flush(); print total, generic, protected }
+    '
+}
+
 # audit_one <skill_md_path>
 audit_one() {
     local skill_md="$1"
@@ -195,14 +259,16 @@ audit_one() {
     local fm desc desc_status="PASS" desc_len=0 desc_warn_msg=""
     if ! fm=$(extract_frontmatter "$skill_md"); then
         # Broken frontmatter - WARN, skip rest of frontmatter checks.
-        # Pass all 17 args expected by emit_skill, with valid status strings
-        # for body/fence so $16/$17 are never unset under set -u.
+        # Pass all 25 args expected by emit_skill, with valid status strings
+        # for body/fence/generic/workflow so none are unset under set -u.
         TOTAL_WARN=$((TOTAL_WARN + 1))
         emit_skill "$skill_name" "$display_path" \
             "WARN" "0" "broken or missing frontmatter" \
             "PASS" "0" "0" \
             "PASS" "0" "0" \
-            "0" "0" "0" "0" "0" ""
+            "0" "0" "0" "0" "0" "" \
+            "PASS" "0" "0" "0" "0" \
+            "PASS" "0" "0"
         return
     fi
 
@@ -250,6 +316,42 @@ audit_one() {
     local fence_status="PASS"
     if (( fence_longest > 25 )); then
         fence_status="INFO"
+        TOTAL_INFO=$((TOTAL_INFO + 1))
+    fi
+
+    # --- Generic-bloat share (advisory; INFO only until thresholds are
+    #     calibrated — see issue #144 and the SR-38 checkpoint) ---
+    local gs_stats gs_total gs_generic gs_protected gs_pct=0 gs_status="PASS"
+    gs_stats=$(generic_share_stats <<<"$body")
+    gs_total=$(awk '{print $1}' <<<"$gs_stats")
+    gs_generic=$(awk '{print $2}' <<<"$gs_stats")
+    gs_protected=$(awk '{print $3}' <<<"$gs_stats")
+    [[ -z "$gs_total" ]] && gs_total=0
+    [[ -z "$gs_generic" ]] && gs_generic=0
+    [[ -z "$gs_protected" ]] && gs_protected=0
+    if (( gs_total > 0 )); then
+        gs_pct=$(( gs_generic * 100 / gs_total ))
+    fi
+    if (( gs_pct > 30 )); then
+        gs_status="INFO"
+        TOTAL_INFO=$((TOTAL_INFO + 1))
+    fi
+
+    # --- Workflow-without-verification (advisory; part of
+    #     netresearch/automated-assessment-skill#48) ---
+    # INFO when the body reads as an imperative multi-step workflow
+    # (numbered steps plus run/then sequencing) but never states a
+    # verification/evidence rule (no verify/evidence/output mention).
+    local wf_has_steps=0 wf_has_verify=0 wf_status="PASS"
+    if grep -qE '^[[:space:]]*[0-9]+[.)][[:space:]]' <<<"$body" \
+        && grep -qiE '\b(run|then)\b' <<<"$body"; then
+        wf_has_steps=1
+    fi
+    if grep -qiE '\b(verif[a-z]*|evidence|outputs?)\b' <<<"$body"; then
+        wf_has_verify=1
+    fi
+    if (( wf_has_steps == 1 && wf_has_verify == 0 )); then
+        wf_status="INFO"
         TOTAL_INFO=$((TOTAL_INFO + 1))
     fi
 
@@ -371,7 +473,9 @@ audit_one() {
         "$body_status" "$body_words" "$body_lines" \
         "$fence_status" "$fence_count" "$fence_longest" \
         "$ref_total" "$ref_p1" "$ref_p2" "$ref_p3" \
-        "$ref_orphan" "$orphan_list"
+        "$ref_orphan" "$orphan_list" \
+        "$gs_status" "$gs_pct" "$gs_generic" "$gs_protected" "$gs_total" \
+        "$wf_status" "$wf_has_steps" "$wf_has_verify"
 }
 
 # emit_skill: prints results in either text or JSON form.
@@ -379,12 +483,16 @@ audit_one() {
 #       body_status body_words body_lines
 #       fence_status fence_count fence_longest
 #       ref_total ref_p1 ref_p2 ref_p3 ref_orphan orphan_list
+#       gs_status gs_pct gs_generic gs_protected gs_total
+#       wf_status wf_has_steps wf_has_verify
 emit_skill() {
     local name="$1" path="$2"
     local ds="$3" dl="$4" dm="$5"
     local bs="$6" bw="$7" bln="$8"
     local fs="$9" fc="${10}" fl="${11}"
     local rt="${12}" rp1="${13}" rp2="${14}" rp3="${15}" rorph="${16}" olist="${17}"
+    local gss="${18}" gsp="${19}" gsg="${20}" gspr="${21}" gst="${22}"
+    local wfs="${23}" wfw="${24}" wfv="${25}"
 
     if [[ $JSON_OUTPUT -eq 1 ]]; then
         # Build orphan JSON array
@@ -404,12 +512,14 @@ emit_skill() {
             done
             orphans_json="[$items]"
         fi
-        printf '{"name":"%s","path":"%s","description":{"status":"%s","chars":%s,"message":"%s"},"body":{"status":"%s","words":%s,"lines":%s},"code_fences":{"status":"%s","count":%s,"longest_lines":%s},"references":{"total":%s,"p1_direct":%s,"p2_catalog":%s,"p3_listpick":%s,"reachable":%s,"orphans":%s,"orphan_files":%s}}\n' \
+        printf '{"name":"%s","path":"%s","description":{"status":"%s","chars":%s,"message":"%s"},"body":{"status":"%s","words":%s,"lines":%s},"code_fences":{"status":"%s","count":%s,"longest_lines":%s},"references":{"total":%s,"p1_direct":%s,"p2_catalog":%s,"p3_listpick":%s,"reachable":%s,"orphans":%s,"orphan_files":%s},"generic_share":{"status":"%s","percent":%s,"generic_paragraphs":%s,"protected_paragraphs":%s,"total_paragraphs":%s},"workflow_verification":{"status":"%s","has_workflow_steps":%s,"has_verification_rule":%s}}\n' \
             "$(json_escape "$name")" "$(json_escape "$path")" \
             "$ds" "$dl" "$(json_escape "$dm")" \
             "$bs" "$bw" "$bln" \
             "$fs" "$fc" "$fl" \
-            "$rt" "$rp1" "$rp2" "$rp3" "$((rp1 + rp2 + rp3))" "$rorph" "$orphans_json"
+            "$rt" "$rp1" "$rp2" "$rp3" "$((rp1 + rp2 + rp3))" "$rorph" "$orphans_json" \
+            "$gss" "$gsp" "$gsg" "$gspr" "$gst" \
+            "$wfs" "$wfw" "$wfv"
         return
     fi
 
@@ -430,6 +540,16 @@ emit_skill() {
     echo "BODY: $bw words, $bln lines [${bs_color}${bs}${NC}]"
     local fs_color="$GRN"; [[ "$fs" == "INFO" ]] && fs_color="$BLU"
     echo "CODE FENCES: $fc fenced blocks, longest $fl lines [${fs_color}${fs}${NC}]"
+    local gs_color="$GRN"; [[ "$gss" == "INFO" ]] && gs_color="$BLU"
+    echo "GENERIC SHARE: ${gsp}% (${gsg}/${gst} paragraphs generic, ${gspr} protected) [${gs_color}${gss}${NC}]"
+    local wf_color="$GRN"; [[ "$wfs" == "INFO" ]] && wf_color="$BLU"
+    if (( wfw == 0 )); then
+        echo "WORKFLOW: no multi-step workflow language [${wf_color}${wfs}${NC}]"
+    elif (( wfv == 1 )); then
+        echo "WORKFLOW: multi-step workflow with verification rule [${wf_color}${wfs}${NC}]"
+    else
+        echo "WORKFLOW: multi-step workflow, no verify/evidence/output rule [${wf_color}${wfs}${NC}]"
+    fi
     local reachable=$((rp1 + rp2 + rp3))
     if (( rt > 0 )); then
         echo "REFERENCES: $rt total -> ${rp1}/P1 + ${rp2}/P2 + ${rp3}/P3 = ${reachable} reachable, ${rorph} ORPHAN"

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -323,9 +323,7 @@ audit_one() {
     #     calibrated — see issue #144 and the SR-38 checkpoint) ---
     local gs_stats gs_total gs_generic gs_protected gs_pct=0 gs_status="PASS"
     gs_stats=$(generic_share_stats <<<"$body")
-    gs_total=$(awk '{print $1}' <<<"$gs_stats")
-    gs_generic=$(awk '{print $2}' <<<"$gs_stats")
-    gs_protected=$(awk '{print $3}' <<<"$gs_stats")
+    read -r gs_total gs_generic gs_protected <<<"$gs_stats"
     [[ -z "$gs_total" ]] && gs_total=0
     [[ -z "$gs_generic" ]] && gs_generic=0
     [[ -z "$gs_protected" ]] && gs_protected=0

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -346,10 +346,10 @@ audit_one() {
     local wf_prose wf_has_steps=0 wf_has_verify=0 wf_status="PASS"
     wf_prose=$(awk '/^[[:space:]]*```/{f=1-f;next} !f' <<<"$body")
     if grep -qE '^[[:space:]]*[0-9]+[.)][[:space:]]' <<<"$wf_prose" \
-        && grep -qiE '\b(run|then)\b' <<<"$wf_prose"; then
+        && grep -qiE '(^|[^a-zA-Z0-9_])(run|then)([^a-zA-Z0-9_]|$)' <<<"$wf_prose"; then
         wf_has_steps=1
     fi
-    if grep -qiE '\b(verif[a-z]*|evidence|outputs?)\b' <<<"$wf_prose"; then
+    if grep -qiE '(^|[^a-zA-Z0-9_])(verif[a-z]*|evidence|outputs?)([^a-zA-Z0-9_]|$)' <<<"$wf_prose"; then
         wf_has_verify=1
     fi
     if (( wf_has_steps == 1 && wf_has_verify == 0 )); then

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -231,7 +231,7 @@ generic_share_stats() {
         in_fence { next }
         /^[[:space:]]*$/ { flush(); next }
         /^#/ { flush(); next }
-        /^[[:space:]]*\|/ { next }
+        /^[[:space:]]*\|/ { flush(); next }
         { buf = buf " " $0 }
         END { flush(); print total, generic, protected }
     '

--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -342,12 +342,16 @@ audit_one() {
     # INFO when the body reads as an imperative multi-step workflow
     # (numbered steps plus run/then sequencing) but never states a
     # verification/evidence rule (no verify/evidence/output mention).
-    local wf_has_steps=0 wf_has_verify=0 wf_status="PASS"
-    if grep -qE '^[[:space:]]*[0-9]+[.)][[:space:]]' <<<"$body" \
-        && grep -qiE '\b(run|then)\b' <<<"$body"; then
+    # Strip fenced code blocks first — numbered steps inside a ```bash
+    # example are not workflow instructions (same fence toggle as
+    # generic_share_stats).
+    local wf_prose wf_has_steps=0 wf_has_verify=0 wf_status="PASS"
+    wf_prose=$(awk '/^[[:space:]]*```/{f=1-f;next} !f' <<<"$body")
+    if grep -qE '^[[:space:]]*[0-9]+[.)][[:space:]]' <<<"$wf_prose" \
+        && grep -qiE '\b(run|then)\b' <<<"$wf_prose"; then
         wf_has_steps=1
     fi
-    if grep -qiE '\b(verif[a-z]*|evidence|outputs?)\b' <<<"$body"; then
+    if grep -qiE '\b(verif[a-z]*|evidence|outputs?)\b' <<<"$wf_prose"; then
         wf_has_verify=1
     fi
     if (( wf_has_steps == 1 && wf_has_verify == 0 )); then

--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -357,3 +357,42 @@ llm_reviews:
       2. Get latest git tag (strip 'v' prefix)
       3. If plugin.json version is BEHIND the latest tag, flag as warning (version drift)
       4. If AHEAD, flag as info (pending release)
+
+  # === SKILL CONTENT VALUE ===
+  # Advisory (severity: warning) for two release cycles while thresholds
+  # calibrate against the corpus; promotion to error is planned for NEW
+  # skills only (netresearch/skill-repo-skill issue #144).
+  - id: SR-38
+    domain: skill-value
+    severity: warning
+    desc: "SKILL.md and reference content must earn its token cost under the six-category content value rubric (advisory during calibration)"
+    prompt: |
+      Classify the content value of the SKILL.md body and every
+      references/*.md file in this skill repo:
+      1. Read the canonical rubric — do NOT rely on a summary embedded
+         in this prompt (an embedded copy would drift from the owning
+         doc). Fetch
+         https://raw.githubusercontent.com/netresearch/skill-repo-skill/main/skills/skill-repo/references/skill-quality.md
+         and read the "Content value rubric" section. It defines six
+         value categories: (1) org/project-specific knowledge,
+         (2) version/ecosystem facts models get wrong, (3) retro-born
+         failure patterns, (4) executable scripts/validators,
+         (5) inference suppression, (6) anti-rationalization guards.
+      2. Classify each section (heading-delimited block) of each file
+         against the six categories. A section earns its place when it
+         provides at least one category.
+      3. A section that provides none is generic bloat. Apply the
+         rubric's generate-it-with-a-prompt test: if a one-line prompt
+         would regenerate the passage, the skill does not need to
+         carry it.
+      4. PROTECTED — never classify as generic: category 3 (failure
+         patterns: symptom, cause, required behavior, verification,
+         encoded from a real incident) and category 5 (inference
+         suppression: "read file X, never guess Y" rules). Per the
+         rubric these are first-class value even when they read as
+         generic prose advice. Do not flag them.
+      5. Report per file: the share of sections classified as generic
+         bloat, quoting each flagged section so a human can verify the
+         classification.
+      This checkpoint is advisory while thresholds calibrate — report
+      findings, do not fail the repo on them.


### PR DESCRIPTION
Implements the two layers of the skill-value gate from issue #144 (Wave 2, A2). The checkpoint lands as **SR-38** — SR-37 was taken by the version-parity checkpoint in https://github.com/netresearch/skill-repo-skill/pull/123.

## Layer 1 — SR-38 LLM checkpoint (`skills/skill-repo/checkpoints.yaml`)

New `llm_reviews` entry, domain `skill-value`, severity `warning`. The prompt instructs the reviewer to classify each SKILL.md body and `references/*.md` file section-by-section against the six categories of the content value rubric, fetching the canonical rubric from `skills/skill-repo/references/skill-quality.md` (raw URL) instead of embedding a copy that would drift. It reports the generic-bloat share per file with flagged sections quoted, applies the generate-it-with-a-prompt test, and explicitly protects categories 3 (retro-born failure patterns) and 5 (inference suppression) from being classified as generic.

## Layer 2 — advisory passes in `scripts/audit-skills.sh`

Pure-bash additions in the script's existing tier style, both INFO-only:

- **GENERIC SHARE**: counts prose paragraphs carrying generic markers ("best practice", "clean code", "write tests first", tutorial phrasings) as a share of total paragraphs; INFO above 30%. Protection wins over a generic match: paragraphs with failure-pattern vocabulary (symptom/cause/verify), never-guess rules ("never guess", "always read/run/check/fetch", "do not assume"), version numbers, or org names are never counted. Fenced code, headings, and table rows are excluded as non-prose. No WARN tier yet — the >60% WARN from the issue stays disabled until thresholds are calibrated.
- **WORKFLOW**: INFO when a body has numbered steps plus run/then sequencing but never mentions verify/evidence/output. Part of netresearch/automated-assessment-skill#48 (cross-repo part).

Both are surfaced in text and `--json` output; exit code is unchanged (no new FAIL paths).

## Rollout plan

1. **Now**: advisory only — SR-38 at severity `warning`, script passes at INFO.
2. **After two release cycles**: calibrate and enable the WARN tier (>60% per the issue) in `audit-skills.sh`.
3. **Later**: promote to FAIL for NEW skills only; existing skills stay advisory until the A23 sweep lands.

## Calibration evidence

Run against 10 local skill repos (12 SKILL.md files, `main/` worktrees):

| skill | body words | generic share | generic/total paragraphs | protected | generic status | workflow status |
|---|---|---|---|---|---|---|
| go-development | 427 | 0% | 0/11 | 2 | PASS | PASS |
| git-workflow | 406 | 0% | 0/11 | 2 | PASS | PASS |
| security-audit | 426 | 0% | 0/13 | 4 | PASS | PASS |
| typo3-testing | 437 | 0% | 0/15 | 4 | PASS | PASS |
| docker-development | 428 | 0% | 0/8 | 2 | PASS | PASS |
| docker-via-wsl | 370 | 0% | 0/8 | 1 | PASS | PASS |
| jujutsu-workflow | 363 | 0% | 0/12 | 3 | PASS | PASS |
| typo3-ddev | 445 | 0% | 0/12 | 4 | PASS | PASS |
| retro | 397 | 0% | 0/8 | 3 | PASS | PASS |
| github-project | 430 | 12% | 1/8 | 2 | PASS | PASS |
| jira-communication | 411 | 0% | 0/10 | 0 | PASS | PASS |
| jira-syntax | 420 | 0% | 0/10 | 0 | PASS | INFO |

Wider corpus (all 334 installed skills, `~/.claude/skills` + plugin cache): mean 0.42%, p95 2%, max 16%, **zero** skills above the 30% INFO threshold.

Sanity checks:

- retro and typo3-ddev (failure-pattern / inference-suppression heavy) score 0% — protected content is not counted.
- The single github-project flag is the intro tagline "GitHub repository configuration, troubleshooting, and collaboration workflow best practices." — contentless filler, and at 12% still PASS.
- The jira-syntax WORKFLOW INFO is genuine: 4 numbered-step lines, no verify/evidence/output mention.
- A synthetic all-generic fixture scores 71% INFO; a synthetic unverified-workflow fixture triggers the WORKFLOW INFO.
- Misfire found and fixed during calibration: an earlier draft flagged typo3-typoscript-ref at 42% because "ALWAYS run `lookup.sh`" rules (category 5) and reference-table rows matched "best practice(s)". The protection list gained `always run/check/fetch` and table rows are excluded as structure; the file now scores 16% with only the tagline flagged.

## Verification

- `yamllint -c .yamllint.yml skills/skill-repo/checkpoints.yaml` clean; checkpoint schema validation (validate.yml logic): 33 mechanical + 6 LLM review checkpoints, no duplicate IDs.
- automated-assessment `run-checkpoints.sh` parses the updated file; SR-38 is skipped by the mechanical runner as an `llm_reviews` entry. (SR-37 reports `fail` identically on `origin/main`'s file — pre-existing, unrelated.)
- `shellcheck -x scripts/audit-skills.sh` clean; `bash skills/skill-repo/scripts/validate-skill.sh .` passes (0 errors, 0 warnings).

Closes #144
