### PR TITLE
fix(checkpoints): SR-37 pattern as plain YAML scalar — runner does not decode escapes

### DIFF
--- a/skills/skill-repo/checkpoints.yaml
+++ b/skills/skill-repo/checkpoints.yaml
@@ -268,7 +268,7 @@ mechanical:
     # The runner parses checkpoints line-by-line (no yq), so the pattern
     # cannot be folded across lines — exempt it from the 200-char rule.
     # yamllint disable-line rule:line-length
-    pattern: "awk 'FNR==1{fm=0} /^---$/{fm=1-fm} FILENAME~/json$/{if ($0 ~ /\"version\"/) gsub(/[\",]/,\"\")} FILENAME~/json$/{if ($1 == \"version:\") pv=$2} fm{if ($1 == \"version:\") sv=$2} fm{if ($1 == \"version:\") gsub(/[\"\\047]/,\"\",sv)} fm{if ($1 == \"version:\") if (sv != pv) bad=1} END{if (pv == \"\") bad=1} END{exit bad}' .claude-plugin/plugin.json skills/*/SKILL.md"
+    pattern: awk 'FNR==1{fm=0} /^---$/{fm=1-fm} FILENAME~/json$/{if ($0 ~ /"version"/) gsub(/[",]/,"")} FILENAME~/json$/{if ($1 == "version:") pv=$2} fm{if ($1 == "version:") sv=$2} fm{if ($1 == "version:") gsub(/["\047]/,"",sv)} fm{if ($1 == "version:") if (sv != pv) bad=1} END{if (pv == "") bad=1} END{exit bad}' .claude-plugin/plugin.json skills/*/SKILL.md
     severity: error
     desc: "plugin.json version must match every SKILL.md metadata.version (run skills/skill-repo/scripts/check-version-parity.sh to verify before tagging)"
     tags: [release, versioning, parity]


### PR DESCRIPTION
Found during Wave-2 verification (open question in #155's implementation report), reproduced and fixed.

**Defect:** the assessment runner parses checkpoints.yaml line-by-line and executes the pattern RAW. SR-37's double-quoted YAML scalar keeps its \" escapes, awk rejects them, and the checkpoint reported **fail on every run** since #123 — the parity check it implements was intact. #123's verification ran the yq-decoded pattern, not the raw line (the runner's actual execution path).

**Fix:** plain (unquoted) YAML scalar — no escapes, raw == decoded. Decoded value byte-identical to main (diff-verified), so direct-execution behavior is unchanged.

**Evidence:** real-runner run before/after: `✗ [SR-37] … Command failed` → `✓ [SR-37]`; all other checkpoints unchanged; yamllint clean.

**Class follow-up:** the runner should decode (or reject) escaped double-quoted patterns — issue to follow on automated-assessment-skill.