### PR TITLE
docs(skill-repo): define canonical failure-pattern schema

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/retro.md
+++ b/.github/PULL_REQUEST_TEMPLATE/retro.md
@@ -7,6 +7,13 @@
 <!-- If this PR comes from /retro, include: session date, finding signal ID, brief description -->
 <!-- Otherwise: link to issue, describe motivation -->
 
+<!-- State the finding using the failure-pattern schema (see references/materialization-contract.md): -->
+
+- **Symptom:**
+- **Cause:**
+- **Required behavior:**
+- **Verification:** <!-- eval id (evals/evals.json name) or checkpoint id (checkpoints.yaml key) -->
+
 ## Change
 
 <!-- What concretely changed: files, scope, behavior. Paths are relative to skills/<skill-name>/ in this repo's layout. -->

--- a/.github/PULL_REQUEST_TEMPLATE/retro.md
+++ b/.github/PULL_REQUEST_TEMPLATE/retro.md
@@ -7,7 +7,7 @@
 <!-- If this PR comes from /retro, include: session date, finding signal ID, brief description -->
 <!-- Otherwise: link to issue, describe motivation -->
 
-<!-- State the finding using the failure-pattern schema (see references/materialization-contract.md): -->
+<!-- State the finding using the failure-pattern schema (see skills/skill-repo/references/materialization-contract.md): -->
 
 - **Symptom:**
 - **Cause:**

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -11,6 +11,21 @@ This contract covers two destinations from [retro-skill](https://github.com/netr
 
 For the full destination taxonomy and routing heuristics, see [retro-skill/references/destination-taxonomy.md](https://github.com/netresearch/retro-skill/blob/main/references/destination-taxonomy.md).
 
+## Failure-pattern schema
+
+Every failure pattern encoded into a skill — a `skill-update`, a `new-skill`, a PR's "Came from" section, a coach `rule.md`/`antipattern.md` entry — is captured in **exactly** four fields, in this order:
+
+| Field | Content |
+|---|---|
+| **Symptom** | What was observed going wrong |
+| **Cause** | Why it happened (root cause, not the trigger) |
+| **Required behavior** | What the agent must do instead |
+| **Verification** | An eval id (`evals/evals.json` `name`) or checkpoint id (`checkpoints.yaml` key) that proves the required behavior — not free text |
+
+Verification is mandatory. It makes explicit the pipeline's existing TDD-eval-stub rule: a failure pattern without a named eval or checkpoint has no machine check.
+
+This is the single source of truth for the schema's four fields and their order. Consuming surfaces (`retro-skill`'s PR "Came from" section, `claude-coach-skill`'s `rule.md`/`antipattern.md` templates) require the schema; they do not redefine it.
+
 ## Rule 1: Patches target source repos, never local cache
 
 Local skill cache (`~/.claude/plugins/cache/`) is overwritten on plugin update. Edits there are lost. **Always** locate the source repository before patching.
@@ -85,7 +100,7 @@ gh pr create --template retro.md ...
 This invokes `.github/PULL_REQUEST_TEMPLATE/retro.md` (not the repo's default template, if any). The retro template has:
 
 - `## Summary`
-- `## Came from` (session date, finding signal ID)
+- `## Came from` (session date, finding signal ID, and the finding stated in the [failure-pattern schema](#failure-pattern-schema): Symptom → Cause → Required behavior → Verification)
 - `## Change` (concrete diff scope)
 - `## Target area` (`skills/<name>/SKILL.md` / `references/` / `scripts/` / `templates/` / `checkpoints.yaml` / `evals/evals.json`)
 - `## Learning source` (checkboxes: from /retro, reusable, scoped, eval included)

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -24,7 +24,7 @@ Every failure pattern encoded into a skill — a `skill-update`, a `new-skill`, 
 
 Verification is mandatory. It makes explicit the pipeline's existing TDD-eval-stub rule: a failure pattern without a named eval or checkpoint has no machine check.
 
-This is the single source of truth for the schema's four fields and their order. Consuming surfaces (`retro-skill`'s PR "Came from" section, `claude-coach-skill`'s `rule.md`/`antipattern.md` templates) require the schema; they do not redefine it.
+This is the single source of truth for the schema's four fields and their order. Consuming surfaces (`retro-skill`'s PR "Came from" section, `claude-coach-plugin`'s `rule.md`/`antipattern.md` templates) require the schema; they do not redefine it.
 
 ## Rule 1: Patches target source repos, never local cache
 


### PR DESCRIPTION
## Summary

Defines a canonical four-field failure-pattern schema — Symptom -> Cause -> Required behavior -> Verification — as the single source of truth in `materialization-contract.md`, and requires it in this repo's own `retro.md` PR template.

## Change

- `skills/skill-repo/references/materialization-contract.md`: adds a "Failure-pattern schema" section defining the four fields and their order; Verification names an eval id (`evals/evals.json` name) or checkpoint id (`checkpoints.yaml` key). Cross-references the schema from Rule 5's "Came from" bullet.
- `.github/PULL_REQUEST_TEMPLATE/retro.md`: adds the four fields to the "Came from" section.

Companion PRs propagate the format (not a new pipeline) to the two consuming surfaces:
- netresearch/retro-skill (branch `feat/failure-pattern-schema`)
- netresearch/claude-coach-plugin (branch `feat/failure-pattern-schema`)

## Test plan

- [x] `bash skills/skill-repo/scripts/validate-skill.sh .` — 0 errors, 0 warnings, SKILL.md unchanged at 498/500 words
- [x] `npx markdownlint-cli2` on both changed files — 0 errors
- [x] Pre-commit hooks pass

Closes #149