### PR TITLE
feat(validate-skill): warn on missing checkpoints.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,3 +147,4 @@ jobs:
 - `composer.json`: type, license SPDX, name matches repo, skill plugin dependency, skill path exists
 - `plugin.json`: name matches SKILL.md, skills is array, paths exist, author URL correct
 - `README.md`: Netresearch reference; **warnings** (errors with `STRICT_README=1`, or `true`/`yes`) if required level-2 sections from `skills/skill-repo/references/readme-template.md` are missing (`What this skill solves`, `Why this is a skill (model delta)`, `Use when`, `Expected outputs`, `Context requirements`, `Example prompts`, `Related skills`, `Installation`, `Contributing`, `License`)
+- `checkpoints.yaml` presence in the skill directory — **warning** only, never fails; suppress by adding a line `Checkpoints: none (justified — <reason>)` to `SKILL.md` or `README.md` for skills that are not suitable per the add-checkpoints skill's suitability criteria (e.g. purely conceptual skills)

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -179,6 +179,25 @@ PYEOF
         COUNT=$(echo "$RELATIVE_PATHS" | wc -l)
         warning "SKILL.md has $COUNT script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
     fi
+
+    # checkpoints.yaml presence (warning only — many skills legitimately lack
+    # one; a documented justification marker suppresses the warning per
+    # add-checkpoints' suitability criteria, e.g. purely conceptual skills)
+    SKILL_DIR="$(dirname "$SKILL_FILE")"
+    CHECKPOINTS_JUSTIFIED=0
+    for f in "$SKILL_FILE" "$REPO_DIR/README.md"; do
+        if [[ -f "$f" ]] && grep -qE "^Checkpoints: none \(justified" "$f"; then
+            CHECKPOINTS_JUSTIFIED=1
+            break
+        fi
+    done
+    if [[ -f "$SKILL_DIR/checkpoints.yaml" ]]; then
+        success "checkpoints.yaml exists"
+    elif [[ $CHECKPOINTS_JUSTIFIED -eq 1 ]]; then
+        success "checkpoints.yaml absence is justified"
+    else
+        warning "checkpoints.yaml not found in ${SKILL_DIR#"$REPO_DIR"/} — add checkpoints (see add-checkpoints skill) or document opt-out with 'Checkpoints: none (justified — <reason>)' in SKILL.md or README.md"
+    fi
 else
     error "SKILL.md not found (checked root and skills/*/)"
 fi

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -184,9 +184,12 @@ PYEOF
     # one; a documented justification marker suppresses the warning per
     # add-checkpoints' suitability criteria, e.g. purely conceptual skills)
     SKILL_DIR="$(dirname "$SKILL_FILE")"
+    SKILL_DIR_REL="${SKILL_DIR#"$REPO_DIR"}"
+    SKILL_DIR_REL="${SKILL_DIR_REL#/}"
+    SKILL_DIR_REL="${SKILL_DIR_REL:-.}"
     CHECKPOINTS_JUSTIFIED=0
     for f in "$SKILL_FILE" "$REPO_DIR/README.md"; do
-        if [[ -f "$f" ]] && grep -qE "^Checkpoints: none \(justified" "$f"; then
+        if [[ -f "$f" ]] && grep -qiE "^[[:space:]]*([*-][[:space:]]+)?checkpoints:[[:space:]]*none[[:space:]]*\(justified" "$f"; then
             CHECKPOINTS_JUSTIFIED=1
             break
         fi
@@ -196,7 +199,7 @@ PYEOF
     elif [[ $CHECKPOINTS_JUSTIFIED -eq 1 ]]; then
         success "checkpoints.yaml absence is justified"
     else
-        warning "checkpoints.yaml not found in ${SKILL_DIR#"$REPO_DIR"/} — add checkpoints (see add-checkpoints skill) or document opt-out with 'Checkpoints: none (justified — <reason>)' in SKILL.md or README.md"
+        warning "checkpoints.yaml not found in ${SKILL_DIR_REL} — add checkpoints (see add-checkpoints skill) or document opt-out with 'Checkpoints: none (justified — <reason>)' in SKILL.md or README.md"
     fi
 else
     error "SKILL.md not found (checked root and skills/*/)"


### PR DESCRIPTION
## What

`skills/skill-repo/scripts/validate-skill.sh` now warns (never fails) when a skill directory lacks `checkpoints.yaml`. The warning is suppressible with a `Checkpoints: none (justified — <reason>)` marker line in `SKILL.md` or `README.md`, for skills that are not suitable for checkpoints per the add-checkpoints skill's suitability criteria (e.g. purely conceptual skills).

Warnings-only by default: 15+ repos sparse-checkout this script via the reusable `validate.yml` workflow, so a FAIL-by-default check would break them immediately. Catalog state at audit time: only ~20 of ~50 repos ship `checkpoints.yaml`.

`AGENTS.md`'s "Validation Script Details" section is updated to document the new check.

## Deferred

Per the issue's DEFERRAL note, this PR does **not** add a scheduled org-wide `/assess --check-coverage` workflow. That run exercises `llm_reviews` checkpoints (LLM in the pipeline), which the team has deferred separately. Only the `validate-skill.sh` presence WARN from item 1 is in scope here.

## Verification

- `bash skills/skill-repo/scripts/validate-skill.sh .` on this repo (has `checkpoints.yaml`) — 0 errors, 0 warnings, `OK: checkpoints.yaml exists`.
- Copied this repo to a sibling dir in `/tmp` and removed `skills/skill-repo/checkpoints.yaml` — `WARNING: checkpoints.yaml not found in skills/skill-repo …` fires as expected.
- Added `Checkpoints: none (justified — purely conceptual skill)` to that copy's `README.md` — warning is suppressed, `OK: checkpoints.yaml absence is justified`, 0 warnings. Confirmed the same marker also suppresses when placed in `SKILL.md`.
- `shellcheck -x -S error skills/skill-repo/scripts/validate-skill.sh` — clean.
- `bash tests/validate-skill.sh` (existing description-parsing smoke tests) — 21/21 passed.
- `pre-commit run` on changed files — all hooks passed.

Closes https://github.com/netresearch/skill-repo-skill/issues/150
