### PR TITLE
fix(audit): get_description double-print inflated DESCRIPTION char count ~2x

### DIFF
--- a/scripts/audit-skills.sh
+++ b/scripts/audit-skills.sh
@@ -132,7 +132,7 @@ get_description() {
     awk '
         BEGIN { collecting=0; val="" }
         /^[a-zA-Z_][a-zA-Z0-9_-]*:/ {
-            if (collecting) { print val; exit }
+            if (collecting) { print val; collecting=0; exit }
         }
         /^description:/ {
             sub(/^description:[[:space:]]*/, "", $0)

--- a/tests/audit-skills.sh
+++ b/tests/audit-skills.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Regression test for scripts/audit-skills.sh get_description().
+# Guards issue #160: exit-in-a-rule used to trigger the END block, printing
+# the description twice and inflating the reported char count ~2x.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/../scripts/audit-skills.sh"
+
+get_description() { :; }
+eval "$(sed -n '/^get_description()/,/^}/p' "$script")"
+
+fm=$'name: x\ndescription: "Use when doing a thing with a description of a known, specific length here."\nlicense: MIT'
+expected='Use when doing a thing with a description of a known, specific length here.'
+got="$(get_description "$fm")"
+
+fail=0
+[[ "$got" == "$expected" ]] || { echo "FAIL: get_description returned '$got', expected '$expected'"; fail=1; }
+lines="$(printf '%s' "$got" | grep -c '^' || true)"
+[[ "$lines" == "1" ]] || { echo "FAIL: expected 1 line, got $lines (double-print regression)"; fail=1; }
+[[ ${#got} -eq ${#expected} ]] || { echo "FAIL: char count ${#got} != real ${#expected}"; fail=1; }
+
+if [[ "$fail" == "0" ]]; then echo "PASS: get_description single-prints, char count matches real length"; fi
+exit "$fail"

--- a/tests/audit-skills.sh
+++ b/tests/audit-skills.sh
@@ -15,8 +15,7 @@ got="$(get_description "$fm")"
 
 fail=0
 [[ "$got" == "$expected" ]] || { echo "FAIL: get_description returned '$got', expected '$expected'"; fail=1; }
-lines="$(printf '%s' "$got" | grep -c '^' || true)"
-[[ "$lines" == "1" ]] || { echo "FAIL: expected 1 line, got $lines (double-print regression)"; fail=1; }
+[[ "$got" != *$'\n'* ]] || { echo "FAIL: output contains a newline (double-print regression)"; fail=1; }
 [[ ${#got} -eq ${#expected} ]] || { echo "FAIL: char count ${#got} != real ${#expected}"; fail=1; }
 
 if [[ "$fail" == "0" ]]; then echo "PASS: get_description single-prints, char count matches real length"; fi


### PR DESCRIPTION
Closes #160.

`get_description()` in scripts/audit-skills.sh printed the description twice: awk's `exit` inside the top-level-key rule jumps to the `END` block, which also printed `val`. Since `license:` always follows `description:`, the double-print always fired — the reported DESCRIPTION char count was ~2x the real length, tripping the length WARN/FAIL thresholds on skills whose descriptions are actually within budget.

**Fix:** `collecting=0` before the `exit` so the `END` guard (`if (collecting)`) does not re-print. One-token change.

**Verified:**
- Direct fixture: buggy = 2 lines / 162 chars (80×2), fixed = 1 line / 81 chars.
- Real data: skill-repo's own description now reports **297 chars** (its true length via `len(desc)`), was ~594 before.
- Added `tests/audit-skills.sh` — asserts a known-length fixture single-prints and the char count matches; shellcheck-clean.

Impact: every prior audit-skills.sh run overstated description length; the value-gate advisories keyed on it were off.