### PR TITLE
feat(eval-validate): add require_evals input for breadth-threshold enforcement

### DIFF
--- a/.github/workflows/eval-validate.yml
+++ b/.github/workflows/eval-validate.yml
@@ -2,6 +2,16 @@ name: Validate Evals
 
 on:
   workflow_call:
+    inputs:
+      require_evals:
+        description: >-
+          Fail when a skill exceeds the breadth threshold (SKILL.md body
+          >300 words or >3 reference files) and has no evals.json. Small
+          pointer-skills stay exempt. Default false: a missing evals.json
+          only emits a warning, unchanged.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -50,3 +60,7 @@ jobs:
       - name: Validate evals structure
         if: steps.find-evals.outputs.found == 'true'
         run: bash .skill-repo-tools/skills/skill-repo/scripts/validate-evals.sh "${{ steps.find-evals.outputs.path }}"
+
+      - name: Enforce required evals for broad skills
+        if: steps.find-evals.outputs.found == 'false' && inputs.require_evals == true
+        run: bash .skill-repo-tools/skills/skill-repo/scripts/validate-evals.sh --require-evals

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -33,8 +33,8 @@ warn() { WARN=$((WARN + 1)); echo "  WARN: $1"; }
 # that it should have had one. Small pointer-skills are exempt. Exits 1 with
 # a ::error:: annotation per offending skill; otherwise returns 0.
 check_required_evals() {
-  local skill_md skill_dir skill_name body_words ref_count close_line
-  local -a skill_files=() broad_skills=()
+  local skill_md skill_dir skill_name body_words ref_count
+  local -a skill_files=() broad_skills=() ref_files=()
 
   [[ -f "SKILL.md" ]] && skill_files+=("SKILL.md")
   for skill_md in skills/*/SKILL.md; do
@@ -52,20 +52,23 @@ check_required_evals() {
     [[ "$skill_dir" == "." ]] && skill_name=$(basename "$(pwd)")
 
     # Body word count: SKILL.md content after the frontmatter closing '---'.
-    if head -1 "$skill_md" | grep -q '^---$'; then
-      close_line=$(awk 'NR>1 && /^---$/{print NR; exit}' "$skill_md")
-      if [[ -n "$close_line" ]]; then
-        body_words=$(tail -n +"$((close_line + 1))" "$skill_md" | wc -w | tr -d ' ')
-      else
-        body_words=$(wc -w < "$skill_md" | tr -d ' ')
-      fi
-    else
-      body_words=$(wc -w < "$skill_md" | tr -d ' ')
-    fi
+    body_words=$(awk '
+      BEGIN { has_fm = 0; fm_closed = 0; total_words = 0; body_words = 0 }
+      NR == 1 { if (/^---$/) { has_fm = 1; next } }
+      /^---$/ && has_fm && !fm_closed { fm_closed = 1; next }
+      {
+        total_words += NF
+        if (fm_closed) { body_words += NF }
+      }
+      END { print (has_fm && fm_closed ? body_words : total_words) }
+    ' "$skill_md")
 
     ref_count=0
     if [[ -d "$skill_dir/references" ]]; then
-      ref_count=$(find "$skill_dir/references" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+      ref_files=("$skill_dir/references"/*.md)
+      if [[ -e "${ref_files[0]}" ]]; then
+        ref_count=${#ref_files[@]}
+      fi
     fi
 
     if [[ "$body_words" -gt 300 ]] || [[ "$ref_count" -gt 3 ]]; then

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -8,8 +8,14 @@
 #   Legacy A: {"skill_name": "...", "evals": [{id, eval_name, prompt, assertions: [...]}]}
 #   Legacy B: [{name, prompt, assertions: [{type, value/pattern, description?}]}]
 #
-# Usage: bash validate-evals.sh [path-to-evals.json]
+# Usage: bash validate-evals.sh [path-to-evals.json] [--require-evals]
 #   If no path given, searches skills/*/evals/evals.json then evals/evals.json
+#
+#   --require-evals: only takes effect when no evals.json is found. Instead of
+#     the plain "no evals.json found" error, checks whether any SKILL.md in
+#     the repo exceeds the breadth threshold (body >300 words or >3 files in
+#     references/). Small pointer-skills stay exempt. Broad skills without an
+#     evals.json fail with a ::error:: annotation naming the skill.
 
 set -euo pipefail
 
@@ -21,8 +27,76 @@ pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 warn() { WARN=$((WARN + 1)); echo "  WARN: $1"; }
 
+# --- Breadth check (--require-evals mode) ---
+# Only called when no evals.json was found anywhere in the repo. Determines
+# whether any skill is broad enough (body >300 words or >3 reference files)
+# that it should have had one. Small pointer-skills are exempt. Exits 1 with
+# a ::error:: annotation per offending skill; otherwise returns 0.
+check_required_evals() {
+  local skill_md skill_dir skill_name body_words ref_count close_line
+  local -a skill_files=() broad_skills=()
+
+  [[ -f "SKILL.md" ]] && skill_files+=("SKILL.md")
+  for skill_md in skills/*/SKILL.md; do
+    [[ -f "$skill_md" ]] && skill_files+=("$skill_md")
+  done
+
+  if [[ ${#skill_files[@]} -eq 0 ]]; then
+    echo "WARN: --require-evals set but no SKILL.md found, skipping breadth check"
+    return 0
+  fi
+
+  for skill_md in "${skill_files[@]}"; do
+    skill_dir=$(dirname "$skill_md")
+    skill_name=$(basename "$skill_dir")
+    [[ "$skill_dir" == "." ]] && skill_name=$(basename "$(pwd)")
+
+    # Body word count: SKILL.md content after the frontmatter closing '---'.
+    if head -1 "$skill_md" | grep -q '^---$'; then
+      close_line=$(awk 'NR>1 && /^---$/{print NR; exit}' "$skill_md")
+      if [[ -n "$close_line" ]]; then
+        body_words=$(tail -n +"$((close_line + 1))" "$skill_md" | wc -w | tr -d ' ')
+      else
+        body_words=$(wc -w < "$skill_md" | tr -d ' ')
+      fi
+    else
+      body_words=$(wc -w < "$skill_md" | tr -d ' ')
+    fi
+
+    ref_count=0
+    if [[ -d "$skill_dir/references" ]]; then
+      ref_count=$(find "$skill_dir/references" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')
+    fi
+
+    if [[ "$body_words" -gt 300 ]] || [[ "$ref_count" -gt 3 ]]; then
+      broad_skills+=("$skill_name (body: ${body_words} words, references: ${ref_count} files)")
+    fi
+  done
+
+  if [[ ${#broad_skills[@]} -eq 0 ]]; then
+    echo "PASS: no skill exceeds the breadth threshold (body >300 words or >3 reference files); evals.json not required"
+    return 0
+  fi
+
+  local entry
+  for entry in "${broad_skills[@]}"; do
+    echo "::error::require_evals: $entry exceeds the breadth threshold but has no evals.json — add skills/<name>/evals/evals.json (or evals/evals.json) with structural evals, or keep require_evals: false for this repo"
+  done
+  echo ""
+  echo "Results: 0 passed, ${#broad_skills[@]} failed, 0 warnings"
+  exit 1
+}
+
 # --- Locate evals.json ---
-EVALS_FILE="${1:-}"
+REQUIRE_EVALS=0
+EVALS_FILE=""
+for arg in "$@"; do
+  case "$arg" in
+    --require-evals) REQUIRE_EVALS=1 ;;
+    *) EVALS_FILE="$arg" ;;
+  esac
+done
+
 if [[ -z "$EVALS_FILE" ]]; then
   for candidate in skills/*/evals/evals.json evals/evals.json; do
     if [[ -f "$candidate" ]]; then
@@ -33,6 +107,10 @@ if [[ -z "$EVALS_FILE" ]]; then
 fi
 
 if [[ -z "$EVALS_FILE" ]] || [[ ! -f "$EVALS_FILE" ]]; then
+  if [[ "$REQUIRE_EVALS" -eq 1 ]]; then
+    check_required_evals
+    exit 0
+  fi
   echo "ERROR: No evals.json found"
   echo "Searched: skills/*/evals/evals.json, evals/evals.json"
   exit 1


### PR DESCRIPTION
Part of the skill value-gate program — epic https://github.com/netresearch/skill-repo-skill/issues/142.

Closes #147.

## What

Adds an opt-in `require_evals` input (default `false`) to the reusable `eval-validate.yml` (`workflow_call`). When a caller sets it to `true` and no `evals.json` is found, the run now checks whether any skill in the repo exceeds a breadth threshold (SKILL.md body >300 words, counted after the frontmatter closing `---`, or >3 `references/*.md` files). If so, the job fails with a `::error::` annotation naming the skill, word count, and reference count. Small pointer-skills (under both thresholds) stay exempt and pass.

Default (`false`, unchanged for every current caller): a missing `evals.json` still only emits the pre-existing `::warning::No evals.json found, skipping validation` and the job does not fail — verified by reading `eval-validate.yml` before this change; not touched.

`validate-evals.sh` gains a `--require-evals` flag carrying the breadth+require logic (`check_required_evals`); the workflow's new "Enforce required evals for broad skills" step passes it through only when `find-evals` reported nothing found. The existing structural-validation path (evals.json present) is untouched.

## Why body/reference counts, not a different metric

"Body" mirrors the terminology `scripts/audit-skills.sh` already uses for its own word-count tiers (content after frontmatter); `references/*.md` mirrors the P1/P2/P3 reachability patterns in `skills/skill-repo/references/skill-quality.md`. Both scripts are independent (no cross-invocation) because only `skills/skill-repo/scripts/` is sparse-checked-out to callers — `scripts/audit-skills.sh` at repo root is not.

## No flag flip in this PR

No caller repo is touched and no caller sets `require_evals: true`. This PR only adds the mechanism.

## Caller rollout (follow-up, not in this PR)

`gh api search/code -f q='eval-validate.yml org:netresearch'` (2026-07-12) finds **26** repos currently calling this reusable workflow — more than the "15+" the issue estimated:

agent-rules-skill, cli-tools-skill, context7-skill, data-tools-skill, docker-development-skill, enterprise-readiness-skill, file-search-skill, german-technical-writing-skill, git-workflow-skill, github-project-skill, github-release-skill, go-development-skill, jira-skill, matrix-skill, netresearch-branding-skill, orocommerce-skill, php-modernization-skill, security-audit-skill, typo3-ckeditor5-skill, typo3-conformance-skill, typo3-ddev-skill, typo3-docs-skill, typo3-extension-upgrade-skill, typo3-project-upgrade-skill, typo3-testing-skill, typo3-typoscript-ref-skill

Flipping `require_evals: true` per repo is gated on the eval backfill in #148 (A6) landing for that repo (several of the 26 have zero evals today — flipping the flag on them immediately would fail broad skills that simply haven't been backfilled yet). Tracked there, not here.

## Verification

- `actionlint .github/workflows/eval-validate.yml` — clean
- `yamllint -c .yamllint.yml .github/workflows/eval-validate.yml` — clean
- `shellcheck -x -S error skills/skill-repo/scripts/validate-evals.sh` (same invocation as `validate.yml`'s ShellCheck step) — clean
- `bash -n` on the script — clean
- No trailing blank line on either file (`tail -c2 | xxd -p` != `0a0a`)
- No new `uses:` action added, so nothing needed SHA-pinning; the pre-existing `harden-runner`/`checkout` pins are untouched (this branch already carries `main`'s harden-runner v2.20.0 bump)
- Local fixture simulation (fixtures created under scratch, not committed):
  - Broad skill (310-word body, 0 refs), no evals.json, `--require-evals` → `::error::` naming `broad-skill (body: 310 words, references: 0 files)`, exit 1
  - Skill with 4 reference files and a 4-word body, no evals.json, `--require-evals` → `::error::` naming `refs-skill (body: 4 words, references: 4 files)`, exit 1
  - Small skill (well under both thresholds), no evals.json, `--require-evals` → `PASS: no skill exceeds the breadth threshold …`, exit 0 (exempt)
  - Broad skill, no evals.json, **no** `--require-evals` flag → unchanged `ERROR: No evals.json found` / exit 1 (pre-existing standalone-script behavior, untouched)
  - Regression: `validate-evals.sh` against this repo's own `skills/skill-repo/evals/evals.json` → 43 passed, 0 failed (unchanged from before this PR)
- Pre-commit hooks ran clean on commit (yamllint, actionlint, shellcheck; `validate-evals`/`validate-skill` hooks correctly skipped — no `evals.json`/`SKILL.md`/`checkpoints.yaml` touched by this diff)
