### PR TITLE
docs(materialization): require a delta-discriminating eval assertion

### DIFF
--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -147,7 +147,7 @@ Other skill repos may use different eval conventions; consult each target's `eva
 ### Quality rule: every eval needs a delta-discriminating assertion
 
 Every eval needs at least one assertion a no-skill baseline answer FAILS; verify with
-`run-ab-evals.sh` (the `without_skill` pass rate on that assertion must be <1.0). A
+`repo-root run-ab-evals.sh` (the `without` pass rate on that assertion must be <1.0). A
 keyword assertion that any generic answer would already contain (`"alpine"`, `"USER"`,
 a bare `"Plugin"`) rewards boilerplate and never tests the retro-born gotcha that is
 the skill's actual value — write the assertion against the specific fact, number, flag,
@@ -156,7 +156,8 @@ path, an exact risk multiplier, a non-obvious CLI invocation, a "do X not Y" cor
 of the model's default instinct).
 
 This verification is a **LOCAL/manual step, not CI** — `run-ab-evals.sh` calls out to
-`claude -p` per eval and is not wired into any workflow.
+`claude -p` per eval. It is referenced only by `.github/workflows/ab-evals-schedule.yml`,
+which is disabled by team decision, so it is not part of any active CI gate.
 
 ## Rule 8: Per-private-repo confirmation
 

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -144,6 +144,20 @@ When a `skill-update` PR changes behavior expectations, **append a new eval obje
 
 Other skill repos may use different eval conventions; consult each target's `evals/` directory before submitting.
 
+### Quality rule: every eval needs a delta-discriminating assertion
+
+Every eval needs at least one assertion a no-skill baseline answer FAILS; verify with
+`run-ab-evals.sh` (the `without_skill` pass rate on that assertion must be <1.0). A
+keyword assertion that any generic answer would already contain (`"alpine"`, `"USER"`,
+a bare `"Plugin"`) rewards boilerplate and never tests the retro-born gotcha that is
+the skill's actual value — write the assertion against the specific fact, number, flag,
+or command shape a model can only produce by having read the skill (an internal script
+path, an exact risk multiplier, a non-obvious CLI invocation, a "do X not Y" correction
+of the model's default instinct).
+
+This verification is a **LOCAL/manual step, not CI** — `run-ab-evals.sh` calls out to
+`claude -p` per eval and is not wired into any workflow.
+
 ## Rule 8: Per-private-repo confirmation
 
 Before pushing to a private host (`git.netresearch.de`, `gitlab.com/<private-org>`, etc.), prompt the user. Decision is remembered per `(session, repo-url)` for the duration of the active retro-skill session; not persisted across sessions.


### PR DESCRIPTION
Part of https://github.com/netresearch/skill-repo-skill/issues/148 (A6: eval backfill + quality rule).

## Summary

Adds a quality rule to `references/materialization-contract.md` Rule 7 (Eval format): every eval needs at least one assertion a no-skill baseline answer FAILS, verified locally with `run-ab-evals.sh` (the `without_skill` pass rate on that assertion must be <1.0). Keyword assertions any generic answer already satisfies (`"alpine"`, `"USER"`, a bare `"Plugin"`) reward boilerplate and never test the retro-born gotcha that is a skill's actual value.

The rule explicitly notes this verification is a **local/manual step, not CI** — `run-ab-evals.sh` shells out to `claude -p` per eval and is intentionally not wired into any workflow.

## Companion PRs (backfilled per this rule)

- https://github.com/netresearch/jujutsu-workflow-skill/pull/10
- https://github.com/netresearch/markdown-to-pdf-skill/pull/7
- https://github.com/netresearch/typo3-upgrade-effort-model-skill/pull/14
- https://github.com/netresearch/typo3-site-conformance-skill/pull/9
- https://github.com/netresearch/docker-development-skill/pull/41

## Validation

```
$ npx markdownlint-cli2 skills/skill-repo/references/materialization-contract.md
Summary: 0 error(s)
```

Pre-commit hooks (trim-trailing-whitespace, end-of-file-fixer, markdownlint-cli2) passed on commit.