### PR TITLE
fix(run-ab-evals): read assertion 'value' field, not only 'pattern'

### DIFF
--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -268,7 +268,7 @@ import json
 raw = json.load(open('$EVALS_FILE'))
 evals = raw['evals'] if isinstance(raw, dict) and 'evals' in raw else raw
 for a in evals[$i].get('assertions', []):
-    print(a.get('pattern', ''))
+    print(a.get('value') or a.get('pattern') or '')
 ")"
 
         delta=$((pass_s - pass_w))


### PR DESCRIPTION
`run-ab-evals.sh` extracted each regex assertion via `a.get('pattern')`, but the eval schema (docker-development-skill, typo3-ckeditor5-skill, and every A6 backfill) stores the regex under `value`. Result: every assertion resolved to an empty pattern and was skipped, so the without/with pass delta was always 0 — the delta-discrimination gate that A6 relies on could never discriminate.

Fix: prefer `value`, fall back to `pattern` for any legacy file.

Verified: extraction now returns all three assertions for a `value`-schema + legacy-`pattern` fixture (was 2 of 3 dropped); shellcheck -S error clean.

Follow-up to the A6 eval-backfill (#148).