### PR TITLE
docs(skill-repo): add skill retirement reference and eval

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -51,7 +51,7 @@ description: "Use when <trigger conditions>"
 ---
 ```
 
-Body ≤500 words; description ≤1,536 chars (target 100–300, trigger first). Every `references/*.md` must be reachable from SKILL.md (catalog conventions — no orphans). Audit: `scripts/audit-skills.sh`. See [`references/skill-quality.md`](references/skill-quality.md). Put discovery/catalog fields in README or optional YAML, not frontmatter — [`references/skill-discovery-metadata.md`](references/skill-discovery-metadata.md).
+Body ≤500 words; description ≤1,536 chars (target 100–300, trigger first). Every `references/*.md` must be reachable from SKILL.md (no orphans). Audit: `scripts/audit-skills.sh`. See [`references/skill-quality.md`](references/skill-quality.md). Put discovery/catalog fields in README or optional YAML, not frontmatter — [`references/skill-discovery-metadata.md`](references/skill-discovery-metadata.md).
 
 ## plugin.json (`.claude-plugin/plugin.json`)
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -113,7 +113,7 @@ scripts/validate-skill.sh
 
 ## References (`references/`)
 
-**Distribution:** [installation-methods](references/installation-methods.md), [composer-setup](references/composer-setup.md), [release-discipline](references/release-discipline.md), [review-replies](references/review-replies.md) · **SKILL text:** [skill-quality](references/skill-quality.md) · **Repo/README:** [repository-quality-rules](references/repository-quality-rules.md), [readme-template](references/readme-template.md) · **Discovery:** [skill-discovery-metadata](references/skill-discovery-metadata.md) · **Done:** [validation-checklist](references/validation-checklist.md) · **Sync:** [marketplace-integration](references/marketplace-integration.md) · **Retro:** [materialization-contract](references/materialization-contract.md) · **Gotchas:** [authoring-ci-gotchas](references/authoring-ci-gotchas.md)
+**Distribution:** [installation-methods](references/installation-methods.md), [composer-setup](references/composer-setup.md), [release-discipline](references/release-discipline.md), [review-replies](references/review-replies.md) · **SKILL text:** [skill-quality](references/skill-quality.md) · **Repo/README:** [repository-quality-rules](references/repository-quality-rules.md), [readme-template](references/readme-template.md) · **Discovery:** [skill-discovery-metadata](references/skill-discovery-metadata.md) · **Done:** [validation-checklist](references/validation-checklist.md) · **Sync:** [marketplace-integration](references/marketplace-integration.md) · **Retro:** [materialization-contract](references/materialization-contract.md) · **Gotchas:** [authoring-ci-gotchas](references/authoring-ci-gotchas.md) · **Retirement:** [skill-retirement](references/skill-retirement.md)
 
 ## See Also
 

--- a/skills/skill-repo/evals/evals.json
+++ b/skills/skill-repo/evals/evals.json
@@ -179,5 +179,15 @@
       { "type": "content", "pattern": "netresearch/skill-repo-skill" },
       { "type": "content", "pattern": "(dependabot|renovate|pull_request)" }
     ]
+  },
+  {
+    "name": "retire_superseded_skill",
+    "prompt": "The 'example-legacy' skill is superseded by automation and must be decommissioned. Walk through the retirement.",
+    "assertions": [
+      { "type": "content", "pattern": "marketplace\\.json" },
+      { "type": "content", "pattern": "[Dd]eprecat" },
+      { "type": "content", "pattern": "archive" },
+      { "type": "content", "pattern": "plugin uninstall" }
+    ]
   }
 ]

--- a/skills/skill-repo/references/skill-retirement.md
+++ b/skills/skill-repo/references/skill-retirement.md
@@ -1,0 +1,53 @@
+# Skill Retirement
+
+How to decommission a skill that is superseded (e.g. by automation) or obsolete.
+Order matters — each step keeps the trail auditable and every action reversible.
+
+## Workflow
+
+1. **Verify the successor.** Confirm the replacing process or tooling is live
+   (ticket closed, automation running) before removing anything.
+
+2. **Remove the marketplace entry.** MR/PR against the marketplace repo:
+   delete the plugin entry from `marketplace.json` **and** the README skill
+   table. Run the marketplace's own validator before committing
+   (`make validate` in the Netresearch internal marketplace).
+
+3. **Add a deprecation notice** at the top of the skill repo's README — name
+   the successor and the tracking ticket. Push this **before** archiving:
+   archived repos are read-only.
+
+   ```markdown
+   > **⚠️ DEPRECATED / ARCHIVED (<month year>)**
+   >
+   > Superseded by <successor> (<ticket>). This repository is archived.
+   ```
+
+4. **Archive the repository — never delete.** Archiving is reversible and
+   preserves history, tags, and MRs.
+
+   ```bash
+   glab repo archive https://git.netresearch.de/GROUP/PROJECT   # GitLab
+   gh repo archive OWNER/REPO                                   # GitHub
+   ```
+
+5. **Uninstall locally and verify propagation.**
+
+   ```bash
+   claude plugin uninstall <name>@<marketplace>
+   claude plugin marketplace update <marketplace>   # refresh cache
+   grep -c "<name>" <marketplace-cache>/.claude-plugin/marketplace.json  # expect 0
+   ```
+
+6. **Document in the tracking ticket.** What was removed, MR links, archive
+   status — so the ticket history is self-contained.
+
+## Gotchas
+
+- **Installed plugins outlive the marketplace entry.** Removing the entry does
+  not uninstall existing local installations — they keep working from the
+  plugin cache. Announce the retirement (team channel) so users uninstall.
+- **README edits after archiving require unarchiving first.** Get the wording
+  right before step 4.
+- **Do not delete the repo or its tags.** Released versions may still be
+  referenced by lockfiles, Satis indexes, or npm/composer installs.


### PR DESCRIPTION
## Summary

Adds `references/skill-retirement.md` — a 6-step decommission workflow for superseded skills — plus a SKILL.md index entry and an eval stub.

## Came from

`/retro` session on 2026-07-13: `d6badec1-682c-4079-86b4-b2bb669a0f49`
Finding: B16 (hard-won technique) — a full skill decommission (typo3-update-issues, superseded by Renovate automation) had to be derived from scratch.

- **Symptom:** no guidance existed for retiring a skill; the session assembled the workflow step by step (marketplace entry removal MR, README deprecation notice, repo archive, local uninstall, ticket documentation).
- **Cause:** skill-repo owns the skill lifecycle (creation, structure, release) but stops at release — retirement was undocumented.
- **Required behavior:** follow the ordered retirement workflow; in particular archive (never delete) and push the README deprecation notice **before** archiving makes the repo read-only.
- **Verification:** eval `retire_superseded_skill` in `evals/evals.json` (asserts marketplace.json removal, deprecation notice, archive, plugin uninstall).

## Change

- New `skills/skill-repo/references/skill-retirement.md` (workflow + gotchas)
- SKILL.md references index: added **Retirement** entry (body stays ~500 words, audit INFO threshold)
- `evals/evals.json`: added `retire_superseded_skill` eval stub

## Test plan

- [ ] `skill-retirement.md` reachable from SKILL.md index (no orphan reference)
- [ ] `evals.json` parses (validated locally)
- [ ] Commands in the reference verified in the 2026-07-13 session (`glab repo archive` documented in netresearch-gitlab skill; `claude plugin uninstall`/`marketplace update` executed successfully)