### PR TITLE
chore(release): v1.26.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.25.2"
+  version: "1.26.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Changes since v1.25.2:

- feat(evals): scheduled A/B eval runs with provenance and dashboard refresh
- feat(eval-validate): `require_evals` input for breadth-threshold enforcement
- feat(validate): model-delta README heading + `STRICT_README` strict mode
- feat(validate-skill): warn on missing checkpoints.yaml
- feat(audit): advisory generic-share and workflow-verification passes
- feat(checkpoints): SR-37 version-parity checkpoint (+ release keywords in trigger), SR-38 skill-value LLM review checkpoint
- fix(run-ab-evals): read assertion `value` field, not only `pattern`
- fix(evals): reject malformed dashboard data file; guard `s.results` before model-alias access; contain CLI paths, gate PR-body lines on merge success, pin CLI
- fix(audit): get_description double-print inflated DESCRIPTION char count; strip fenced code before workflow-verification greps; flush paragraph buffer before skipping table rows
- fix(validate-skill): correct relative-path and marker regex in checkpoints warning
- fix(validate): accept true/yes for `STRICT_README`, case-insensitive; POSIX word boundaries in workflow-verification grep
- fix(checkpoints): SR-37 pattern as plain YAML scalar; make SR-37 executable and able to fail
- docs(skill-repo): canonical failure-pattern schema; require it in retro PR template
- docs(quality): content value rubric, scripts-first and fact-ownership rules
- docs(materialization): require a delta-discriminating eval assertion; align run-ab-evals terminology
- refactor(evals): pass provenance values as argv into the result heredoc