### PR TITLE
fix(ci): silence setup-uv cache glob warning for callers without dependency files

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -54,6 +54,19 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          # Default glob plus workflow files: callers without Python dependency
+          # files (standalone scripts, uv run --with) otherwise get a
+          # "No file matched" warning annotation on every run.
+          cache-dependency-glob: |
+            **/*requirements*.txt
+            **/*requirements*.in
+            **/*constraints*.txt
+            **/*constraints*.in
+            **/pyproject.toml
+            **/uv.lock
+            **/*.py.lock
+            .github/workflows/*.yml
+            .github/workflows/*.yaml
 
       - name: Run Bandit
         env:
@@ -85,6 +98,19 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
+          # Default glob plus workflow files: callers without Python dependency
+          # files (standalone scripts, uv run --with) otherwise get a
+          # "No file matched" warning annotation on every run.
+          cache-dependency-glob: |
+            **/*requirements*.txt
+            **/*requirements*.in
+            **/*constraints*.txt
+            **/*constraints*.in
+            **/pyproject.toml
+            **/uv.lock
+            **/*.py.lock
+            .github/workflows/*.yml
+            .github/workflows/*.yaml
 
       - name: Run tests
         env:


### PR DESCRIPTION
## What

Extends `cache-dependency-glob` on both `astral-sh/setup-uv` steps in the reusable `ci-python.yml` with `.github/workflows/*.yml`/`*.yaml` in addition to the action's default patterns.

## Why

Downstream callers without Python dependency files (security-audit-skill, automated-assessment-skill run standalone scripts via `uv run`) get a warning annotation on every `ci / Test (Python 3.x)` job: "No file matched to [**/*requirements*.txt, …, pyproject.toml, uv.lock]. The cache will never get invalidated." Example: https://github.com/netresearch/security-audit-skill/actions/runs/29280793634

A caller repo always has workflow files, and they hold the `uv run --with` / test-command dependency declarations, so the cache now invalidates on workflow changes. Callers with real dependency files keep the default patterns.

## Not changed

The Node.js-20 deprecation annotation on the "build" check of the v1.26.0 tagged commit comes from GitHub's managed `pages build and deployment` workflow (`dynamic/pages/pages-build-deployment`, run https://github.com/netresearch/skill-repo-skill/actions/runs/29280972331), which internally uses `actions/checkout@v4` and `actions/upload-artifact@v4`. Those action versions are controlled by GitHub, not by this repo — all workflows in this repo already pin `actions/checkout` v7.0.0 / `actions/upload-artifact` v7.0.1.