### PR TITLE
chore(release): v1.26.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.1"
+  version: "1.26.2"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Prepare release v1.26.2 (patch — docs+chore since v1.26.1). Version bump only: plugin.json + SKILL.md (2 files).