### PR TITLE
ci(evals): convert ab-evals to a hosted reusable + pure caller

### DIFF
--- a/.github/workflows/ab-evals-caller.yml
+++ b/.github/workflows/ab-evals-caller.yml
@@ -1,0 +1,60 @@
+name: A/B Evals Schedule
+
+# Scheduled entry point for the A/B eval sweep (issue #146). This is a PURE
+# CALLER: the run logic and every pinned action live in the hosted reusable
+# ab-evals-schedule.yml — the same caller + reusable split this repo already
+# uses for eval-validate and npm-pack-smoke.
+#
+# Why the reusable kept the "-schedule" filename: converting that file in
+# place (rather than renaming it) keeps `git blame` on the run logic and
+# keeps its untouched lines out of the "new code" window — SonarCloud does
+# not follow renames and would otherwise re-report pre-existing findings in
+# the moved body. Renaming it is a cosmetic follow-up, not worth re-opening
+# that window here.
+#
+# Cost bound: a scheduled run processes BATCH_SIZE skills, selected
+# deterministically by ISO week number modulo the number of catalog groups
+# (ceil(catalog / BATCH_SIZE), currently ceil(42/5) = 9 groups), so the full
+# catalog rotates through in ~9 weekly runs. The full catalog runs only via
+# workflow_dispatch with full=true (takes several hours).
+#
+# Prerequisite (human setup step): the ANTHROPIC_API_KEY repository secret
+# must exist — run-ab-evals.sh drives the claude CLI with it. The run fails
+# early with a clear error if the secret is missing.
+#
+# The refresh PR is created with GITHUB_TOKEN, so PR CI does not start
+# automatically (GitHub limitation) — close/reopen the PR to trigger checks.
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"  # Mondays 03:17 UTC
+  workflow_dispatch:
+    inputs:
+      skills:
+        description: "Comma/space-separated plugin names to run (empty = weekly rotation subset)"
+        type: string
+        default: ""
+      full:
+        description: "Run the full catalog instead of the rotation subset (several hours)"
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  group: ab-evals-schedule
+  cancel-in-progress: false
+
+jobs:
+  ab-evals:
+    uses: ./.github/workflows/ab-evals-schedule.yml
+    permissions:
+      contents: write  # push the refresh branch
+      pull-requests: write  # open the refresh PR
+    # On `schedule` the workflow_dispatch inputs are unset, so fall back to
+    # the rotation-subset defaults.
+    with:
+      skills: ${{ inputs.skills || '' }}
+      full: ${{ inputs.full || false }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ab-evals-schedule.yml
+++ b/.github/workflows/ab-evals-schedule.yml
@@ -1,42 +1,63 @@
-name: A/B Evals Schedule
+name: A/B Evals (reusable)
 
-# Scheduled A/B eval runs (issue #146): runs scripts/run-ab-evals.sh for
-# marketplace catalog skills, merges the per-skill results (with a
-# provenance block) into docs/dashboard/data/results.json via
-# scripts/merge-ab-results.py, validates the dashboard, and opens a PR.
+# Hosted reusable that runs the A/B eval sweep (issue #146): runs
+# scripts/run-ab-evals.sh for marketplace catalog skills, merges the
+# per-skill results (with a provenance block) into
+# docs/dashboard/data/results.json via scripts/merge-ab-results.py,
+# validates the dashboard, and opens a PR.
 #
-# Cost bound: a scheduled run processes BATCH_SIZE skills, selected
-# deterministically by ISO week number modulo the number of catalog groups
+# The scheduled entry point lives in ab-evals-caller.yml, which is a PURE
+# CALLER with no step-level action uses — the same caller + reusable split
+# this repo already uses for eval-validate and npm-pack-smoke. Every pinned
+# action now lives here, in the shared workflow, instead of in the consumer.
+#
+# Cost bound: a run processes BATCH_SIZE skills, selected deterministically
+# by ISO week number modulo the number of catalog groups
 # (ceil(catalog / BATCH_SIZE), currently ceil(42/5) = 9 groups), so the full
-# catalog rotates through in ~9 weekly runs. The full catalog runs only via
-# workflow_dispatch with full=true (takes several hours).
+# catalog rotates through in ~9 weekly runs. The full catalog runs only when
+# the caller passes full=true (takes several hours).
 #
-# Prerequisite (human setup step): the ANTHROPIC_API_KEY repository secret
-# must exist — run-ab-evals.sh drives the claude CLI with it. The run fails
-# early with a clear error if the secret is missing.
+# Prerequisite (human setup step): the caller must pass the
+# ANTHROPIC_API_KEY secret — run-ab-evals.sh drives the claude CLI with it.
+# The run fails early with a clear error if it is missing.
 #
 # The refresh PR is created with GITHUB_TOKEN, so PR CI does not start
 # automatically (GitHub limitation) — close/reopen the PR to trigger checks.
 
 on:
-  schedule:
-    - cron: "17 3 * * 1"  # Mondays 03:17 UTC
-  workflow_dispatch:
+  workflow_call:
     inputs:
       skills:
         description: "Comma/space-separated plugin names to run (empty = weekly rotation subset)"
+        required: false
         type: string
         default: ""
       full:
         description: "Run the full catalog instead of the rotation subset (several hours)"
+        required: false
         type: boolean
         default: false
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: "Anthropic API key used by scripts/run-ab-evals.sh to drive the claude CLI."
+        required: true
 
+# CALLER REQUIREMENTS
+# ===================
+# The calling job MUST grant both scopes below, otherwise the run fails with
+# `startup_failure` before any job executes:
+#   contents: write       - push the refresh branch
+#   pull-requests: write  - open the refresh PR
+#
+#   jobs:
+#     ab-evals:
+#       uses: ./.github/workflows/ab-evals-schedule.yml
+#       permissions:
+#         contents: write
+#         pull-requests: write
+#       secrets:
+#         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 permissions: {}
-
-concurrency:
-  group: ab-evals-schedule
-  cancel-in-progress: false
 
 env:
   BATCH_SIZE: "5"


### PR DESCRIPTION
## What

- `ab-evals-schedule.yml` — converted **in place** into a hosted reusable (`on: workflow_call`, inputs `skills`/`full`, secret `ANTHROPIC_API_KEY`). Run logic untouched.
- New **`ab-evals-caller.yml`** — the scheduled pure caller.

Same caller + reusable split this repo already uses for `eval-validate` and `npm-pack-smoke`.

## Why

Audited every workflow here against "actions live only in shared workflows; no stray step-level action uses in consumers":

- **9 workflows are hosted reusables** (`ci-python`, `validate`, `validate-agents`, `release`, `eval-validate`, `harness-verify`, `npm-pack-smoke`, `dependency-audit`, `pr-quality`) — their actions are correct where they are; they *are* the shared workflows.
- **`ab-evals-schedule.yml` was the single genuine violation** — 3 step-level actions (`harden-runner`, `checkout`, `upload-artifact`).

After this, every consumer workflow in the repo is a pure caller (verified mechanically).

## Why converted in place instead of renamed

The run logic never changes file, so it keeps `git blame` and stays out of the PR's "new code" window.

This matters concretely. Earlier revisions of this PR moved the job body into a new `ab-evals.yml` (first as a new file, then as a proper `git mv` recorded at 84% similarity). **Both** failed the SonarCloud gate with `new_security_rating = 3` on `githubactions:S6505` at the `npm install -g @anthropic-ai/claude-code` line — SonarCloud does **not** follow renames, so it re-reported a pre-existing finding in the moved body.

That flag genuinely cannot be added. Verified locally:

```
$ npm install @anthropic-ai/claude-code@2.1.206 --ignore-scripts && ./node_modules/.bin/claude --version
Error: claude native binary not installed.
Either postinstall did not run (--ignore-scripts, some pnpm configs)
```

The package needs its postinstall to fetch the native binary — adding `--ignore-scripts` would silently break the weekly eval run. So the line is left untouched rather than broken or suppressed, and the conversion is structured so it is not re-reported as new code.

## Safety

- Run logic byte-identical; only the header (trigger + inputs/secrets) changed — the diff is header-only.
- `${{ inputs.skills }}` / `${{ inputs.full }}` unchanged — `workflow_call` inputs use the same `inputs` context as `workflow_dispatch`.
- On `schedule` the dispatch inputs are unset, so the caller passes `${{ inputs.skills || '' }}` / `${{ inputs.full || false }}` to keep rotation-subset defaults.
- `concurrency: ab-evals-schedule` moves to the caller; `BATCH_SIZE` / `MARKETPLACE_REPO` stay with the job.
- Caller grants `contents: write` + `pull-requests: write` (documented in CALLER REQUIREMENTS).
- Workflow display name stays `A/B Evals Schedule`.
- The reusable keeps the `-schedule` filename deliberately (see the comment in the caller); renaming it is a cosmetic follow-up.

## Validation
- `actionlint` clean on both files; repo pre-commit suite (yamllint, actionlint) passes
- Verified repo-wide: no consumer workflow has step-level `uses:` left
