### PR TITLE
ci: add zizmor workflow scanner to security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,12 @@ jobs:
     secrets:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
   dependency-review:
     if: github.event_name == 'pull_request'
     uses: netresearch/.github/.github/workflows/dependency-review.yml@main


### PR DESCRIPTION
Rolls out the `zizmor` job added to the shared skill template in
netresearch/.github#327.

- **zizmor** — static analysis for GitHub Actions workflows

Report-only (results go to code scanning) and runs with minimal
permissions: `contents: read` + `security-events: write`.

The file was byte-identical to the previous template revision before this
change, so the diff is exactly the new job — no repo-specific drift was
touched.
