### PR TITLE
chore(release): v1.26.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.3"
+  version: "1.26.4"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Version bump for the v1.26.4 release: plugin.json and SKILL.md metadata.version 1.26.3 -> 1.26.4. Tag v1.26.4 follows after merge.