### PR TITLE
docs(gotchas): generated YAML needs exactly one trailing newline

### DIFF
--- a/skills/skill-repo/references/authoring-ci-gotchas.md
+++ b/skills/skill-repo/references/authoring-ci-gotchas.md
@@ -93,9 +93,11 @@ the CLI's own vetted installer, explicitly.
 
 ## 6. Generated YAML: exactly one trailing newline
 
-The reusable `validate.yml` runs yamllint with the `empty-lines` rule, which
-rejects trailing blank lines — and batch-generated YAML (heredoc, `echo`,
-templating) routinely picks one up. One deploy of `auto-merge-deps.yml` across
+The reusable `validate.yml` runs yamllint, whose **default config** (`extends:
+default`, `empty-lines: max-end: 0`) rejects trailing blank lines; the workflow
+writes that default only when the repo ships no `.yamllint*` of its own, so a
+repo config can override it — most skill repos don't. Batch-generated YAML
+(heredoc, `echo`, templating) routinely picks up a trailing blank line. One deploy of `auto-merge-deps.yml` across
 22 repos failed CI in every one of them on exactly this.
 
 When writing YAML programmatically, emit the content with a single trailing

--- a/skills/skill-repo/references/authoring-ci-gotchas.md
+++ b/skills/skill-repo/references/authoring-ci-gotchas.md
@@ -90,3 +90,18 @@ claude --version   # proves the binary is in place
 
 This blocks lifecycle scripts of the whole dependency tree while running only
 the CLI's own vetted installer, explicitly.
+
+## 6. Generated YAML: exactly one trailing newline
+
+The reusable `validate.yml` runs yamllint with the `empty-lines` rule, which
+rejects trailing blank lines — and batch-generated YAML (heredoc, `echo`,
+templating) routinely picks one up. One deploy of `auto-merge-deps.yml` across
+22 repos failed CI in every one of them on exactly this.
+
+When writing YAML programmatically, emit the content with a single trailing
+newline and verify before committing:
+
+```bash
+printf '%s\n' "$CONTENT" > file.yml     # not: echo "$CONTENT" > file.yml
+tail -c 2 file.yml | xxd -p             # must NOT be 0a0a
+```


### PR DESCRIPTION
## What

Adds gotcha #6 to `authoring-ci-gotchas.md`: batch-generated YAML (heredoc, `echo`, templating) routinely ends with a trailing blank line, and the reusable `validate.yml`'s yamllint `empty-lines` rule rejects it — a 22-repo `auto-merge-deps.yml` deploy failed CI in every repo on exactly this. The recipe: `printf '%s\n'` instead of `echo`, verified with `tail -c 2 file.yml | xxd -p` (must not be `0a0a`).

Promoted from session memory (`/retro promote`); the source note is tombstoned once this PR exists.

Came from /retro: yes
