### PR TITLE
chore(release): v1.26.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "description": "Guide for structuring Netresearch skill repositories",
   "repository": "https://github.com/netresearch/skill-repo-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.4"
+  version: "1.26.5"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Version bump 1.26.4 → 1.26.5.

Changes since v1.26.4:

- docs(release): remote-first fleet survey and the wrong-branch pull hazard
- docs(release): releases/latest semantics and explicit main in the compare
- docs(gotchas): generated YAML needs exactly one trailing newline
- docs(gotchas): empty-lines comes from yamllint's default config, overridable per repo
- docs(agents): the six structure docs drift as a set — update together

Surfaces bumped: `.claude-plugin/plugin.json`, SKILL.md frontmatter version.
