### PR TITLE
feat(manifest): adopt Agent Plugins 1.0.0 portable manifest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,32 +18,3 @@ jobs:
     uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
     permissions:
       contents: read
-
-  # The reusable above runs the validator from main, so a PR that changes the
-  # validator does not gate itself. This job runs the scripts and their tests
-  # from the PR's own tree.
-  self-test:
-    name: Script self-test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Validator smoke tests
-        run: bash tests/validate-skill.sh
-
-      - name: Portable manifest tests
-        run: bash tests/portable-manifest.sh
-
-      - name: Validate this repo with the PR's validator
-        run: bash skills/skill-repo/scripts/validate-skill.sh .
-
-      - name: Version parity
-        run: bash skills/skill-repo/scripts/check-version-parity.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,3 +18,32 @@ jobs:
     uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
     permissions:
       contents: read
+
+  # The reusable above runs the validator from main, so a PR that changes the
+  # validator does not gate itself. This job runs the scripts and their tests
+  # from the PR's own tree.
+  self-test:
+    name: Script self-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validator smoke tests
+        run: bash tests/validate-skill.sh
+
+      - name: Portable manifest tests
+        run: bash tests/portable-manifest.sh
+
+      - name: Validate this repo with the PR's validator
+        run: bash skills/skill-repo/scripts/validate-skill.sh .
+
+      - name: Version parity
+        run: bash skills/skill-repo/scripts/check-version-parity.sh

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,43 @@
+name: Self-test
+
+# lint.yml calls the reusable validate.yml from `main`, so a PR that changes
+# the validator does not gate itself. This workflow runs the scripts and their
+# tests from the PR's own tree. It is repo-local on purpose: consumer repos
+# ship no tests/ directory.
+#
+# Not part of netresearch/.github/templates/skill — an extra workflow file is
+# not template drift.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+jobs:
+  self-test:
+    name: Script self-test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validator smoke tests
+        run: bash tests/validate-skill.sh
+
+      - name: Portable manifest tests
+        run: bash tests/portable-manifest.sh
+
+      - name: Validate this repo with the PR's validator
+        run: bash skills/skill-repo/scripts/validate-skill.sh .
+
+      - name: Version parity
+        run: bash skills/skill-repo/scripts/check-version-parity.sh

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Validator smoke tests
         run: bash tests/validate-skill.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Run skill validation
         run: bash .skill-repo-tools/skills/skill-repo/scripts/validate-skill.sh .
 
+      # Root plugin.json (Agent Plugins 1.0.0) is the source of truth for the
+      # shared metadata. No-op in repos that have not adopted it yet.
+      - name: Check Claude manifest is in sync with plugin.json
+        run: bash .skill-repo-tools/skills/skill-repo/scripts/sync-plugin-manifest.sh --check
+
       - name: Markdown lint defaults
         run: |
           # Provide sensible defaults if repo has no markdownlint config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,13 @@ This repository (`netresearch/skill-repo-skill`) defines the standard structure 
 | `skills/skill-repo/references/readme-template.md` | Required README headings and first-screen contract |
 | `skills/skill-repo/references/skill-discovery-metadata.md` | Discovery YAML, action/risk classification |
 | `skills/skill-repo/references/validation-checklist.md` | Pre-completion checklist for agents |
-| `.claude-plugin/plugin.json` | Plugin metadata (name, version, skills array) |
+| `plugin.json` | Agent Plugins 1.0.0 manifest — source of truth for name, version, description, author, license |
+| `.claude-plugin/plugin.json` | Claude Code manifest, generated from `plugin.json` by `sync-plugin-manifest.sh`; holds the Claude-only keys (skills array, …) |
 | `composer.json` | PHP/Composer distribution as `ai-agent-skill` type |
 | `.github/workflows/` | Reusable workflows consumed by other skill repos plus this repo's own CI. Canonical inventory in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md#reusable-ci-workflows). Auto-merge for Dependabot/Renovate is delegated to `netresearch/.github` via a thin local caller — NOT hosted here. |
 | `skills/skill-repo/scripts/validate-skill.sh` | Validates skill repo structure, licensing, metadata consistency |
 | `skills/skill-repo/scripts/migrate-licensing.sh` | Migrates repos from single LICENSE to split licensing |
+| `skills/skill-repo/scripts/sync-plugin-manifest.sh` | Projects `plugin.json` into `.claude-plugin/plugin.json` (`--check` in CI) |
 | `skills/skill-repo/templates/` | Templates for new skill repos (README, licenses, workflows, composer.json) |
 | `Build/hooks/` | Git hooks (pre-commit, pre-push) |
 | `Build/Scripts/check-plugin-version.sh` | Version validation script |
@@ -63,7 +65,7 @@ Copyright entity: `Netresearch DTT GmbH`
 
 ### Versioning and Releases
 
-1. Bump version in `.claude-plugin/plugin.json`
+1. Bump version in `plugin.json`, then `bash skills/skill-repo/scripts/sync-plugin-manifest.sh` to carry it into `.claude-plugin/plugin.json`
 2. Commit: `chore: release vX.Y.Z`
 3. Create signed tag: `git tag -s vX.Y.Z -m "vX.Y.Z"`
 4. Push: `git push origin main vX.Y.Z`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It extends Anthropic-style single-file skills with **repository-level** conventi
 
 ## Compatibility
 
-This is an **Agent Skill** following the [open standard](https://agentskills.io) originally developed by Anthropic and released for cross-platform use.
+This is an **Agent Skill** following the [open standard](https://agentskills.io) originally developed by Anthropic and released for cross-platform use. The repository is also packaged as an [Agent Plugins 1.0.0](https://agent-plugins.org) plugin: the root `plugin.json` plus `skills/` layout is what any conformant client loads.
 
 **Supported platforms:**
 
@@ -30,7 +30,7 @@ This is an **Agent Skill** following the [open standard](https://agentskills.io)
 ## Use when
 
 - Creating or bootstrapping a **Netresearch-style skill repository**
-- Standardizing layout, `composer.json`, `.claude-plugin/plugin.json`, or release workflows
+- Standardizing layout, `composer.json`, `plugin.json` / `.claude-plugin/plugin.json`, or release workflows
 - Wiring **reusable CI** from `netresearch/skill-repo-skill`
 - Fixing **validation errors** from `validate-skill.sh` or marketplace packaging
 - Migrating to **split licensing** (`LICENSE-MIT` + `LICENSE-CC-BY-SA-4.0`)
@@ -177,7 +177,8 @@ skill-repo-skill/
 ├── composer.json
 ├── package.json
 ├── renovate.json
-├── .claude-plugin/plugin.json
+├── plugin.json                    # Agent Plugins 1.0.0 manifest (source of truth)
+├── .claude-plugin/plugin.json     # Claude Code manifest (generated)
 ├── .github/workflows/             # validate, release, pr-quality,
 │                                  # harness-verify, eval-validate,
 │                                  # validate-agents, dependency-audit,

--- a/plugin.json
+++ b/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "skill-repo",
   "version": "1.27.0",
   "description": "Guide for structuring Netresearch skill repositories",
@@ -7,8 +8,5 @@
     "url": "https://www.netresearch.de"
   },
   "repository": "https://github.com/netresearch/skill-repo-skill",
-  "license": "(MIT AND CC-BY-SA-4.0)",
-  "skills": [
-    "./skills/skill-repo"
-  ]
+  "license": "(MIT AND CC-BY-SA-4.0)"
 }

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.26.5"
+  version: "1.27.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---
@@ -18,7 +18,8 @@ Standards for Netresearch skill repository layout and distribution.
 
 ```
 {repo-name}/
-├── .claude-plugin/plugin.json   # Plugin metadata (required)
+├── plugin.json                  # portable manifest (required)
+├── .claude-plugin/plugin.json   # generated
 ├── skills/{name}/SKILL.md       # AI instructions (required)
 ├── README.md                    # Human docs (required)
 ├── LICENSE-MIT                  # Code license (required)
@@ -51,15 +52,17 @@ description: "Use when <trigger conditions>"
 ---
 ```
 
-Body ≤500 words; description ≤1,536 chars (target 100–300, trigger first). Every `references/*.md` must be reachable from SKILL.md (no orphans). Audit: `scripts/audit-skills.sh`. See [`references/skill-quality.md`](references/skill-quality.md). Put discovery/catalog fields in README or optional YAML, not frontmatter — [`references/skill-discovery-metadata.md`](references/skill-discovery-metadata.md).
+Body ≤500 words; description ≤1,536 chars (target 100–300, trigger first). Every `references/*.md` must be reachable from SKILL.md (no orphans). Audit: `scripts/audit-skills.sh`. Put discovery/catalog fields in README or optional YAML, not frontmatter.
 
-## plugin.json (`.claude-plugin/plugin.json`)
+## Manifests
+
+Root `plugin.json` ([Agent Plugins 1.0.0](https://agent-plugins.org), closed field set) is the source of truth; `sync-plugin-manifest.sh` generates `.claude-plugin/plugin.json` plus Claude-only keys — [agent-plugins-compat](references/agent-plugins-compat.md).
 
 ```json
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "skill-name",
   "version": "1.0.0",
-  "skills": ["./skills/skill-name"],
   "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {"name": "Netresearch DTT GmbH", "url": "https://www.netresearch.de"}
 }
@@ -92,28 +95,22 @@ Callers: `validate.yml`, `release.yml` (here); `auto-merge-deps.yml` (`netresear
 
 ## Releasing
 
-Bump PR → merge → pull main → verify parity → signed tag → push → monitor Release. **Tag only after bump PR merges.** Never edit installed paths (`~/.claude/skills/**`, `~/.claude/plugins/**`); always the worktree. Multi-repo (>3) needs dry-run + approval. See `references/release-discipline.md`.
+Bump root `plugin.json` → sync → PR → merge → pull main → verify parity → signed tag → push → monitor Release. **Tag only after bump PR merges.** Multi-repo (>3) needs dry-run + approval. Never edit installed paths — [release-discipline](references/release-discipline.md).
 
 ## Installation
 
 1. **Marketplace**: `/plugin marketplace add netresearch/claude-code-marketplace`
 2. **Release**: Download to `~/.claude/skills/{name}/`
 3. **Composer**: `composer require netresearch/{repo-name}`
-4. **npm**: `npm i -D @netresearch/agent-skill-coordinator github:netresearch/{repo-name}`. Use `templates/package.json.template` (minimal `files` default; see `references/installation-methods.md`).
+4. **npm**: `npm i -D @netresearch/agent-skill-coordinator github:netresearch/{repo-name}`. Use `templates/package.json.template` (minimal `files` default).
 
 ## Validation
 
-```bash
-scripts/validate-skill.sh
-```
-
-## Cross-platform Compatibility
-
-`grep -E` (not `-P`); `bash` shebangs (zsh on macOS); `[[ ]]` for conditionals.
+`scripts/validate-skill.sh` (layout, manifests). Shell portability: [authoring-ci-gotchas](references/authoring-ci-gotchas.md).
 
 ## References (`references/`)
 
-**Distribution:** [installation-methods](references/installation-methods.md), [composer-setup](references/composer-setup.md), [release-discipline](references/release-discipline.md), [review-replies](references/review-replies.md) · **SKILL text:** [skill-quality](references/skill-quality.md) · **Repo/README:** [repository-quality-rules](references/repository-quality-rules.md), [readme-template](references/readme-template.md) · **Discovery:** [skill-discovery-metadata](references/skill-discovery-metadata.md) · **Done:** [validation-checklist](references/validation-checklist.md) · **Sync:** [marketplace-integration](references/marketplace-integration.md) · **Retro:** [materialization-contract](references/materialization-contract.md) · **Gotchas:** [authoring-ci-gotchas](references/authoring-ci-gotchas.md) · **Retirement:** [skill-retirement](references/skill-retirement.md)
+[agent-plugins-compat](references/agent-plugins-compat.md) · [installation-methods](references/installation-methods.md) · [composer-setup](references/composer-setup.md) · [release-discipline](references/release-discipline.md) · [review-replies](references/review-replies.md) · [skill-quality](references/skill-quality.md) · [repository-quality-rules](references/repository-quality-rules.md) · [readme-template](references/readme-template.md) · [skill-discovery-metadata](references/skill-discovery-metadata.md) · [validation-checklist](references/validation-checklist.md) · [marketplace-integration](references/marketplace-integration.md) · [materialization-contract](references/materialization-contract.md) · [authoring-ci-gotchas](references/authoring-ci-gotchas.md) · [skill-retirement](references/skill-retirement.md)
 
 ## See Also
 

--- a/skills/skill-repo/references/agent-plugins-compat.md
+++ b/skills/skill-repo/references/agent-plugins-compat.md
@@ -76,7 +76,9 @@ migrated yet.
 1. Create `./plugin.json` with the fields above, copying the current values out
    of `.claude-plugin/plugin.json`. Drop `skills`/`agents`/`support` — they stay
    in the Claude manifest.
-2. Run `sync-plugin-manifest.sh` and confirm the diff is only a key reorder.
+2. `sync-plugin-manifest.sh --check` — it passes without rewriting anything when
+   the values were copied correctly. Run it without `--check` only when you want
+   the canonical rendering.
 3. If the repo ships a root `SKILL.md` instead of `skills/<name>/SKILL.md`, move
    it: Agent Plugins clients do not discover a root `SKILL.md`. Claude Code
    loads either layout, so the move is safe there — but the plugin's skill name

--- a/skills/skill-repo/references/agent-plugins-compat.md
+++ b/skills/skill-repo/references/agent-plugins-compat.md
@@ -66,8 +66,10 @@ bash skills/skill-repo/scripts/sync-plugin-manifest.sh --repo DIR # fleet driver
 The script copies `name`, `version`, `description`, `author`, `homepage`,
 `repository`, `license` and `keywords` into `.claude-plugin/plugin.json`,
 preserves every Claude-only key already there, and never copies `$schema` or
-`extensions`. Without a root `plugin.json` it is a no-op, so it is safe to run
-across repos that have not migrated yet.
+`extensions`. `--check` compares those shared values in both directions — key
+order and formatting in the Claude manifest are not enforced. Without a root
+`plugin.json` it is a no-op, so it is safe to run across repos that have not
+migrated yet.
 
 ## Migrating a repo
 

--- a/skills/skill-repo/references/agent-plugins-compat.md
+++ b/skills/skill-repo/references/agent-plugins-compat.md
@@ -1,0 +1,105 @@
+# Agent Plugins 1.0.0 compatibility
+
+Netresearch skill repos ship **two** manifests. This page says what each one is
+for, which is authoritative, and how to migrate a repo that has only the
+Claude Code one.
+
+Spec: <https://agent-plugins.org/specification> ·
+Schema: <https://agent-plugins.org/schemas/1.0.0/plugin.schema.json> ·
+Skill format: <https://agentskills.io/specification>
+
+## Why two files
+
+| File | Read by | Role |
+|---|---|---|
+| `./plugin.json` | every Agent Plugins client (Cursor, Copilot, …) | **source of truth** for shared metadata |
+| `./.claude-plugin/plugin.json` | Claude Code only | generated projection + Claude-only keys |
+
+Claude Code reads its manifest from `.claude-plugin/plugin.json` and nowhere
+else; Agent Plugins clients read `plugin.json` at the package root and nowhere
+else. One file cannot serve both: the portable schema is **closed**
+(`additionalProperties: false`), so `skills`, `agents`, `commands`,
+`outputStyles`, `hooks`, `mcpServers`, `metadata` and `support` are schema
+violations there. Conversely Claude Code ignores fields it does not know, which
+is why the projection into `.claude-plugin/plugin.json` is safe.
+
+Skills need no change: `skills/<name>/SKILL.md` is what both specs discover.
+
+## The portable manifest
+
+```json
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "skill-repo",
+  "version": "1.27.0",
+  "description": "Guide for structuring Netresearch skill repositories",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de"
+  },
+  "repository": "https://github.com/netresearch/skill-repo-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)"
+}
+```
+
+Allowed top-level fields — nothing else:
+
+| Field | Required | Notes |
+|---|---|---|
+| `$schema` | yes | exactly the 1.0.0 URL above |
+| `name` | yes | 1–64 chars, `a-z0-9` plus `-` and `.`, starts and ends alphanumeric, no `--` or `..`. Matches the Claude manifest name (and, for single-skill repos, the SKILL.md `name`) |
+| `version` | no | SemVer; same value as `.claude-plugin/plugin.json` and SKILL.md `metadata.version` |
+| `description` | no | short purpose statement |
+| `author` | no | object with `name`, `email`, `url` only — `"author": "Name"` is invalid |
+| `homepage`, `repository`, `license` | no | strings; license stays the SPDX expression `(MIT AND CC-BY-SA-4.0)` |
+| `keywords` | no | array of strings |
+| `extensions` | no | object keyed by **reverse-domain namespaces owned by the client vendor**. We do not invent namespaces for clients — Claude-specific data lives in `.claude-plugin/`, not here |
+
+## Generating the Claude manifest
+
+```bash
+bash skills/skill-repo/scripts/sync-plugin-manifest.sh            # write
+bash skills/skill-repo/scripts/sync-plugin-manifest.sh --check    # CI gate
+bash skills/skill-repo/scripts/sync-plugin-manifest.sh --repo DIR # fleet driver
+```
+
+The script copies `name`, `version`, `description`, `author`, `homepage`,
+`repository`, `license` and `keywords` into `.claude-plugin/plugin.json`,
+preserves every Claude-only key already there, and never copies `$schema` or
+`extensions`. Without a root `plugin.json` it is a no-op, so it is safe to run
+across repos that have not migrated yet.
+
+## Migrating a repo
+
+1. Create `./plugin.json` with the fields above, copying the current values out
+   of `.claude-plugin/plugin.json`. Drop `skills`/`agents`/`support` — they stay
+   in the Claude manifest.
+2. Run `sync-plugin-manifest.sh` and confirm the diff is only a key reorder.
+3. If the repo ships a root `SKILL.md` instead of `skills/<name>/SKILL.md`, move
+   it: Agent Plugins clients do not discover a root `SKILL.md`. Claude Code
+   loads either layout, so the move is safe there — but the plugin's skill name
+   then comes from the directory, so keep the directory name equal to the
+   frontmatter `name`.
+4. `bash skills/skill-repo/scripts/validate-skill.sh .` — 0 errors.
+
+## What validation enforces
+
+`validate-skill.sh` checks, when `./plugin.json` exists: the `$schema` constant,
+the `name` pattern, that no field outside the closed schema is present, the
+`author`/`keywords`/`extensions` shapes, that the shared fields match
+`.claude-plugin/plugin.json`, and that at least one `skills/<name>/SKILL.md`
+exists. A **missing** `./plugin.json` is a warning, not an error — the validator
+runs fleet-wide from `main` while repos adopt the manifest one PR at a time.
+
+`check-version-parity.sh` treats the root `plugin.json` version as
+authoritative and fails when `.claude-plugin/plugin.json` disagrees.
+
+## Out of scope
+
+Agent Plugins defines packaging only. Distribution, installation, marketplaces
+and permissions stay client-specific, so `claude-code-marketplace` entries and
+the composer/npm channels are unaffected by this standard.
+
+An `mcp.json` at the package root is the portable way to ship MCP servers. No
+Netresearch skill repo ships one today; add it only alongside a real server, and
+keep its `$schema` version equal to the one in `plugin.json`.

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -37,6 +37,7 @@ batch). Pass `--repo`, or `cd` into the checkout first.
 
 What it checks:
 
+- Root `plugin.json` (Agent Plugins manifest), when present, is the **source of truth**: bump it first, run `sync-plugin-manifest.sh`, and the check fails if `.claude-plugin/plugin.json` still disagrees. Repos that have not adopted the portable manifest are unaffected — see [`agent-plugins-compat.md`](agent-plugins-compat.md).
 - `.claude-plugin/plugin.json` has a `.version` field — exits with an error if missing.
 - `composer.json` does **not** have a `.version` field — composer versions come from the git tag via the Release workflow, so a hard-coded version drifts silently.
 - If a tag argument is provided, `plugin.json.version` equals that tag with the `v` prefix stripped.

--- a/skills/skill-repo/references/validation-checklist.md
+++ b/skills/skill-repo/references/validation-checklist.md
@@ -1,6 +1,6 @@
 # Validation checklist — skill repository changes
 
-Agents **must** walk through this list before declaring a skill-repo task complete.  
+Agents **must** walk through this list before declaring a skill-repo task complete.
 Marketplace-only checks live in **`netresearch/claude-code-marketplace`/`AGENTS.md`** — do not merge those steps here.
 
 ## README
@@ -16,6 +16,14 @@ Marketplace-only checks live in **`netresearch/claude-code-marketplace`/`AGENTS.
 - [ ] Optional keys only if needed: `license`, `compatibility`, `metadata`, `allowed-tools` (per validator).
 - [ ] `description` starts with `Use when`.
 - [ ] Body describes triggers and use cases without duplicating full README marketing copy.
+
+## Manifests
+
+- [ ] Root **`plugin.json`** exists and targets `https://agent-plugins.org/schemas/1.0.0/plugin.schema.json`.
+- [ ] It carries **only** the fields of the closed schema — no `skills`, `agents`, `support`, … — see [`agent-plugins-compat.md`](agent-plugins-compat.md).
+- [ ] `.claude-plugin/plugin.json` regenerated: `bash skills/skill-repo/scripts/sync-plugin-manifest.sh` leaves the tree clean (`--check` exits 0).
+- [ ] Version bumped in the **root** `plugin.json` (source of truth), then synced; `check-version-parity.sh` exits 0.
+- [ ] Every skill lives at `skills/<name>/SKILL.md` — a root `SKILL.md` is invisible to Agent Plugins clients.
 
 ## Agents / OpenAI
 

--- a/skills/skill-repo/scripts/check-version-parity.sh
+++ b/skills/skill-repo/scripts/check-version-parity.sh
@@ -58,6 +58,7 @@ fi
 TAG_VERSION="${TAG_ARG#v}"  # strip leading v if present (empty stays empty)
 
 PLUGIN_JSON=".claude-plugin/plugin.json"
+PORTABLE_JSON="plugin.json"
 COMPOSER_JSON="composer.json"
 
 if [[ ! -f "$PLUGIN_JSON" ]]; then
@@ -70,6 +71,21 @@ PLUGIN_VERSION=$(jq -r '.version // empty' "$PLUGIN_JSON")
 if [[ -z "$PLUGIN_VERSION" ]]; then
   echo "ERROR: $PLUGIN_JSON has no .version field" >&2
   exit 1
+fi
+
+# Root plugin.json (Agent Plugins 1.0.0) is the source of truth for the version
+# once a repo has adopted it; .claude-plugin/plugin.json is generated from it.
+if [[ -f "$PORTABLE_JSON" ]]; then
+  PORTABLE_VERSION=$(jq -r '.version // empty' "$PORTABLE_JSON")
+  if [[ -z "$PORTABLE_VERSION" ]]; then
+    echo "ERROR: $PORTABLE_JSON has no .version field" >&2
+    exit 1
+  fi
+  if [[ "$PORTABLE_VERSION" != "$PLUGIN_VERSION" ]]; then
+    echo "ERROR: $PORTABLE_JSON=$PORTABLE_VERSION does not match $PLUGIN_JSON=$PLUGIN_VERSION" >&2
+    echo "       Bump the root plugin.json, then run sync-plugin-manifest.sh." >&2
+    exit 1
+  fi
 fi
 
 # composer.json MUST NOT have a version field

--- a/skills/skill-repo/scripts/sync-plugin-manifest.sh
+++ b/skills/skill-repo/scripts/sync-plugin-manifest.sh
@@ -100,6 +100,20 @@ for key, value in current.items():
 
 rendered = json.dumps(generated, indent=2, ensure_ascii=False) + "\n"
 
+if check:
+    # Value parity, not byte identity: key order and formatting in the Claude
+    # manifest are nobody's business, drift in the shared metadata is.
+    drift = [k for k in SHARED if portable.get(k) != current.get(k)]
+    if not drift:
+        print(f"OK: {claude_path} is in sync with {portable_path}")
+        sys.exit(0)
+    print(f"ERROR: {claude_path} is out of sync with {portable_path}", file=sys.stderr)
+    print("       Run: bash skills/skill-repo/scripts/sync-plugin-manifest.sh", file=sys.stderr)
+    for key in drift:
+        print(f"       {key}: portable={portable.get(key)!r} claude={current.get(key)!r}",
+              file=sys.stderr)
+    sys.exit(1)
+
 try:
     with open(claude_path, encoding="utf-8") as fh:
         on_disk = fh.read()
@@ -109,15 +123,6 @@ except OSError:
 if on_disk == rendered:
     print(f"OK: {claude_path} is in sync with {portable_path}")
     sys.exit(0)
-
-if check:
-    print(f"ERROR: {claude_path} is out of sync with {portable_path}", file=sys.stderr)
-    print("       Run: bash skills/skill-repo/scripts/sync-plugin-manifest.sh", file=sys.stderr)
-    for key in SHARED:
-        if key in portable and current.get(key) != portable[key]:
-            print(f"       {key}: portable={portable[key]!r} claude={current.get(key)!r}",
-                  file=sys.stderr)
-    sys.exit(1)
 
 os.makedirs(os.path.dirname(claude_path) or ".", exist_ok=True)
 with open(claude_path, "w", encoding="utf-8") as fh:

--- a/skills/skill-repo/scripts/sync-plugin-manifest.sh
+++ b/skills/skill-repo/scripts/sync-plugin-manifest.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# sync-plugin-manifest.sh — project the portable Agent Plugins manifest
+# (./plugin.json) into the Claude Code manifest (.claude-plugin/plugin.json).
+#
+# Usage:
+#   sync-plugin-manifest.sh                 # write .claude-plugin/plugin.json
+#   sync-plugin-manifest.sh --check         # verify it is in sync, write nothing
+#   sync-plugin-manifest.sh --repo DIR ...  # operate on DIR instead of cwd
+#
+# Root ./plugin.json is the source of truth for the shared metadata: name,
+# version, description, author, homepage, repository, license, keywords.
+# .claude-plugin/plugin.json is generated from it and keeps its Claude-only
+# keys (skills, agents, commands, outputStyles, hooks, mcpServers, metadata,
+# support, …) untouched — those fields have no place in the portable manifest,
+# whose schema is closed.
+#
+# Exit codes: 0 = written / in sync (or no portable manifest to sync from),
+#             1 = out of sync (--check) or invalid input.
+
+set -euo pipefail
+
+REPO_DIR="."
+CHECK=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) CHECK=1; shift ;;
+    --repo)
+      REPO_DIR="${2:-}"
+      [[ -n "$REPO_DIR" ]] || { echo "ERROR: --repo needs a directory" >&2; exit 1; }
+      shift 2
+      ;;
+    --repo=*) REPO_DIR="${1#--repo=}"; shift ;;
+    -h|--help)
+      grep -E '^#' "$0" | sed -e '1d' -e 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "ERROR: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 is required" >&2; exit 1; }
+
+PORTABLE="$REPO_DIR/plugin.json"
+CLAUDE="$REPO_DIR/.claude-plugin/plugin.json"
+
+if [[ ! -f "$PORTABLE" ]]; then
+  echo "SKIP: $PORTABLE not found — nothing to sync from"
+  exit 0
+fi
+
+CHECK="$CHECK" PORTABLE="$PORTABLE" CLAUDE="$CLAUDE" python3 <<'PYEOF'
+import json
+import os
+import sys
+
+check = os.environ["CHECK"] == "1"
+portable_path = os.environ["PORTABLE"]
+claude_path = os.environ["CLAUDE"]
+
+# Shared metadata, in the order the generated manifest lists it.
+SHARED = ["name", "version", "description", "author",
+          "homepage", "repository", "license", "keywords"]
+
+try:
+    with open(portable_path, encoding="utf-8") as fh:
+        portable = json.load(fh)
+except (OSError, ValueError) as exc:
+    print(f"ERROR: cannot read {portable_path}: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if not isinstance(portable, dict):
+    print(f"ERROR: {portable_path} must contain a JSON object", file=sys.stderr)
+    sys.exit(1)
+
+current = {}
+if os.path.isfile(claude_path):
+    try:
+        with open(claude_path, encoding="utf-8") as fh:
+            current = json.load(fh)
+    except (OSError, ValueError) as exc:
+        print(f"ERROR: cannot read {claude_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(current, dict):
+        print(f"ERROR: {claude_path} must contain a JSON object", file=sys.stderr)
+        sys.exit(1)
+
+generated = {}
+for key in SHARED:
+    if key in portable:
+        generated[key] = portable[key]
+
+# Claude-only keys survive: everything the portable manifest does not own.
+# `$schema` and `extensions` are portable-manifest concerns and never copied.
+for key, value in current.items():
+    if key in SHARED or key in ("$schema", "extensions"):
+        continue
+    generated[key] = value
+
+rendered = json.dumps(generated, indent=2, ensure_ascii=False) + "\n"
+
+try:
+    with open(claude_path, encoding="utf-8") as fh:
+        on_disk = fh.read()
+except OSError:
+    on_disk = None
+
+if on_disk == rendered:
+    print(f"OK: {claude_path} is in sync with {portable_path}")
+    sys.exit(0)
+
+if check:
+    print(f"ERROR: {claude_path} is out of sync with {portable_path}", file=sys.stderr)
+    print("       Run: bash skills/skill-repo/scripts/sync-plugin-manifest.sh", file=sys.stderr)
+    for key in SHARED:
+        if key in portable and current.get(key) != portable[key]:
+            print(f"       {key}: portable={portable[key]!r} claude={current.get(key)!r}",
+                  file=sys.stderr)
+    sys.exit(1)
+
+os.makedirs(os.path.dirname(claude_path) or ".", exist_ok=True)
+with open(claude_path, "w", encoding="utf-8") as fh:
+    fh.write(rendered)
+print(f"WROTE: {claude_path}")
+PYEOF

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -408,6 +408,143 @@ else
     error ".claude-plugin/plugin.json not found"
 fi
 
+# --- Portable manifest checks (Agent Plugins 1.0.0) ---
+# Root ./plugin.json is the portable manifest every Agent Plugins client reads.
+# It is the source of truth for shared metadata; .claude-plugin/plugin.json is
+# generated from it by sync-plugin-manifest.sh. A missing portable manifest is
+# a warning, not an error: repos adopt it one PR at a time and this validator
+# runs fleet-wide from main.
+PORTABLE_FILE="$REPO_DIR/plugin.json"
+if [[ -f "$PORTABLE_FILE" ]]; then
+    PORTABLE_REPORT=$(python3 - "$PORTABLE_FILE" "$PLUGIN_FILE" "$REPO_DIR" <<'PYEOF' 2>&1 || true
+import json
+import os
+import re
+import sys
+
+portable_path, claude_path, repo_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+
+SCHEMA_URL = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+# Closed schema: agent-plugins.org/schemas/1.0.0/plugin.schema.json
+ALLOWED = ["$schema", "name", "version", "description", "author",
+           "homepage", "repository", "license", "keywords", "extensions"]
+SHARED = ["name", "version", "description", "author",
+          "homepage", "repository", "license", "keywords"]
+NAME_RE = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$")
+
+out = []
+
+
+def err(msg):
+    out.append("ERROR:" + msg)
+
+
+def ok(msg):
+    out.append("OK:" + msg)
+
+
+try:
+    with open(portable_path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except ValueError as exc:
+    err(f"plugin.json is not valid JSON: {exc}")
+    data = None
+except OSError as exc:
+    err(f"plugin.json could not be read: {exc}")
+    data = None
+
+if isinstance(data, dict):
+    ok("plugin.json (portable Agent Plugins manifest) exists")
+
+    if data.get("$schema") != SCHEMA_URL:
+        err(f'plugin.json $schema must be "{SCHEMA_URL}" (got: {data.get("$schema")!r})')
+    else:
+        ok("plugin.json targets Agent Plugins 1.0.0")
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        err("plugin.json is missing the required 'name' field")
+    elif len(name) > 64 or not NAME_RE.match(name):
+        err(f"plugin.json name is invalid: {name!r} "
+            "(1-64 chars, lowercase a-z0-9 . -, must start and end alphanumeric, no -- or ..)")
+    else:
+        ok(f"plugin.json name valid: {name}")
+
+    unknown = [k for k in data if k not in ALLOWED]
+    if unknown:
+        err("plugin.json has fields outside the Agent Plugins schema: "
+            + ", ".join(sorted(unknown))
+            + " (client-specific data belongs in 'extensions' or in .claude-plugin/plugin.json)")
+    else:
+        ok("plugin.json has no fields outside the Agent Plugins schema")
+
+    for key in ("version", "description", "homepage", "repository", "license"):
+        if key in data and not isinstance(data[key], str):
+            err(f"plugin.json {key} must be a string")
+    if "keywords" in data and (not isinstance(data["keywords"], list)
+                               or not all(isinstance(k, str) for k in data["keywords"])):
+        err("plugin.json keywords must be an array of strings")
+    if "author" in data:
+        author = data["author"]
+        if not isinstance(author, dict):
+            err("plugin.json author must be an object with name/email/url")
+        else:
+            extra = [k for k in author if k not in ("name", "email", "url")]
+            if extra:
+                err("plugin.json author allows only name, email, url — got: "
+                    + ", ".join(sorted(extra)))
+            for k, v in author.items():
+                if not isinstance(v, str):
+                    err(f"plugin.json author.{k} must be a string")
+    if "extensions" in data:
+        ext = data["extensions"]
+        if not isinstance(ext, dict) or not all(isinstance(v, dict) for v in ext.values()):
+            err("plugin.json extensions must be an object of reverse-domain "
+                "namespace keys mapping to objects")
+
+    # Parity with the generated Claude Code manifest.
+    if os.path.isfile(claude_path):
+        try:
+            with open(claude_path, encoding="utf-8") as fh:
+                claude = json.load(fh)
+        except (OSError, ValueError):
+            claude = None
+        if isinstance(claude, dict):
+            drift = [k for k in SHARED if k in data and claude.get(k) != data[k]]
+            if drift:
+                err(".claude-plugin/plugin.json is out of sync with plugin.json on: "
+                    + ", ".join(drift)
+                    + " — run skills/skill-repo/scripts/sync-plugin-manifest.sh")
+            else:
+                ok(".claude-plugin/plugin.json is in sync with plugin.json")
+
+    # Agent Plugins clients discover skills only under skills/<name>/SKILL.md.
+    skills_dir = os.path.join(repo_dir, "skills")
+    found = []
+    if os.path.isdir(skills_dir):
+        found = sorted(d for d in os.listdir(skills_dir)
+                       if os.path.isfile(os.path.join(skills_dir, d, "SKILL.md")))
+    if found:
+        ok(f"skills/ holds {len(found)} portable skill(s): " + ", ".join(found))
+    else:
+        err("no skills/<name>/SKILL.md found — Agent Plugins clients do not "
+            "discover a SKILL.md at the repository root")
+
+print("\n".join(out))
+PYEOF
+)
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        case "$line" in
+            OK:*) success "${line#OK:}" ;;
+            ERROR:*) error "${line#ERROR:}" ;;
+            *) error "portable manifest check produced unexpected output: $line" ;;
+        esac
+    done <<< "$PORTABLE_REPORT"
+else
+    warning "plugin.json (portable Agent Plugins 1.0.0 manifest) not found at repo root — Agent Plugins clients (Cursor, Copilot, …) cannot load this plugin; see skill-repo skills/skill-repo/references/agent-plugins-compat.md"
+fi
+
 # --- README.md quality checks (warnings by default) ---
 # Heading misses are warnings unless STRICT_README=1 promotes them to errors.
 # The default must stay warnings-only: consumer repos run this script from

--- a/skills/skill-repo/templates/plugin.json.template
+++ b/skills/skill-repo/templates/plugin.json.template
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "{skill-name}",
+  "version": "0.1.0",
+  "description": "{Skill description}",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de"
+  },
+  "repository": "https://github.com/netresearch/{repo-name}",
+  "license": "(MIT AND CC-BY-SA-4.0)"
+}

--- a/tests/portable-manifest.sh
+++ b/tests/portable-manifest.sh
@@ -195,6 +195,27 @@ else
     echo "  FAIL sync: \$schema leaked into the Claude manifest"; ((FAIL++))
 fi
 
+# key order in the Claude manifest is not the check's business
+d="$(fixture sync_reordered)"
+python3 - "$d/.claude-plugin/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+open(p, "w").write(json.dumps(dict(reversed(list(d.items()))), indent=4) + "\n")
+PY
+assert_cmd 0 "sync: reordered/reformatted Claude manifest still passes --check" bash "$SYNC" --repo "$d" --check
+
+# a shared key present only in the Claude manifest is drift too
+d="$(fixture sync_claude_only_key)"
+python3 - "$d/.claude-plugin/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["keywords"] = ["extra"]
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_cmd 1 "sync: Claude-only shared key fails --check" bash "$SYNC" --repo "$d" --check
+
 d="$(fixture sync_absent)"
 rm "$d/plugin.json"
 assert_cmd 0 "sync: no portable manifest is a no-op" bash "$SYNC" --repo "$d" --check

--- a/tests/portable-manifest.sh
+++ b/tests/portable-manifest.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# tests/portable-manifest.sh — cover the Agent Plugins 1.0.0 portable manifest:
+#   * validate-skill.sh verdicts for ./plugin.json (schema, name, closed field
+#     set, parity with .claude-plugin/plugin.json, skills/ discoverability)
+#   * sync-plugin-manifest.sh generate + --check behaviour
+#
+# Fixtures are minimal on purpose: the validator also reports missing
+# composer.json/README.md, so every assertion matches a specific verdict line
+# instead of the overall exit code.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+VALIDATOR="$REPO_ROOT/skills/skill-repo/scripts/validate-skill.sh"
+SYNC="$REPO_ROOT/skills/skill-repo/scripts/sync-plugin-manifest.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+SCHEMA="https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+
+# fixture <name> — repo with a valid skill, Claude manifest and portable manifest
+fixture() {
+    local dir="$TMP/$1"
+    rm -rf "$dir"
+    mkdir -p "$dir/skills/demo" "$dir/.claude-plugin"
+    printf -- '---\nname: demo\ndescription: "Use when demoing."\n---\n\n# Demo\n' \
+        > "$dir/skills/demo/SKILL.md"
+    cat > "$dir/plugin.json" <<JSON
+{
+  "\$schema": "$SCHEMA",
+  "name": "demo",
+  "version": "1.0.0",
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de"
+  }
+}
+JSON
+    cat > "$dir/.claude-plugin/plugin.json" <<'JSON'
+{
+  "name": "demo",
+  "version": "1.0.0",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de"
+  },
+  "license": "(MIT AND CC-BY-SA-4.0)",
+  "skills": [
+    "./skills/demo"
+  ]
+}
+JSON
+    printf '%s' "$dir"
+}
+
+# assert_line <expect|reject> <dir> <needle> <label>
+assert_line() {
+    local want="$1" dir="$2" needle="$3" label="$4" out
+    out="$(bash "$VALIDATOR" "$dir" 2>&1)"
+    case "$want" in
+        expect)
+            if grep -qF -- "$needle" <<<"$out"; then ((PASS++)); else
+                echo "  FAIL $label: expected a line containing '$needle'"; ((FAIL++)); fi ;;
+        reject)
+            if grep -qF -- "$needle" <<<"$out"; then
+                echo "  FAIL $label: did not expect '$needle'"; ((FAIL++)); else ((PASS++)); fi ;;
+    esac
+    return 0
+}
+
+# assert_cmd <expect_exit> <label> <command...>
+assert_cmd() {
+    local want="$1" label="$2"; shift 2
+    "$@" >/dev/null 2>&1
+    local rc=$?
+    if [[ $rc -eq $want ]]; then ((PASS++)); else
+        echo "  FAIL $label: exit $rc, wanted $want"; ((FAIL++)); fi
+    return 0
+}
+
+echo "== validate-skill.sh: portable manifest =="
+
+d="$(fixture happy)"
+assert_line expect "$d" "plugin.json (portable Agent Plugins manifest) exists" "happy: detected"
+assert_line expect "$d" "plugin.json targets Agent Plugins 1.0.0" "happy: schema"
+assert_line expect "$d" "plugin.json name valid: demo" "happy: name"
+assert_line expect "$d" ".claude-plugin/plugin.json is in sync" "happy: parity"
+assert_line expect "$d" "skills/ holds 1 portable skill(s): demo" "happy: discovery"
+
+d="$(fixture no_portable)"
+rm "$d/plugin.json"
+assert_line expect "$d" "portable Agent Plugins 1.0.0 manifest) not found" "missing: warns"
+# The absence must stay a warning: the fleet adopts the manifest one PR at a
+# time while this validator runs everywhere from main.
+out="$(bash "$VALIDATOR" "$d" 2>&1)"
+if grep -E "ERROR.*(Agent Plugins|portable)" <<<"$out" >/dev/null; then
+    echo "  FAIL missing: absence of plugin.json must not raise an ERROR"; ((FAIL++))
+else
+    ((PASS++))
+fi
+
+d="$(fixture bad_schema)"
+python3 - "$d/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["$schema"] = "https://agent-plugins.org/schemas/0.9.0/plugin.schema.json"
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_line expect "$d" "plugin.json \$schema must be" "bad schema: rejected"
+
+d="$(fixture bad_name)"
+python3 - "$d/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["name"] = "Demo--Skill"
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_line expect "$d" "plugin.json name is invalid" "bad name: rejected"
+
+d="$(fixture unknown_field)"
+python3 - "$d/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["skills"] = ["./skills/demo"]
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_line expect "$d" "fields outside the Agent Plugins schema: skills" "unknown field: rejected"
+
+d="$(fixture drift)"
+python3 - "$d/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["version"] = "2.0.0"
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_line expect "$d" "out of sync with plugin.json on: version" "drift: rejected"
+
+d="$(fixture root_skill_only)"
+rm -rf "$d/skills"
+printf -- '---\nname: demo\ndescription: "Use when demoing."\n---\n\n# Demo\n' > "$d/SKILL.md"
+assert_line expect "$d" "no skills/<name>/SKILL.md found" "root SKILL.md: rejected"
+
+d="$(fixture bad_author)"
+python3 - "$d/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["author"] = "Netresearch DTT GmbH"
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_line expect "$d" "author must be an object" "author string: rejected"
+
+echo "== sync-plugin-manifest.sh =="
+
+d="$(fixture sync_ok)"
+assert_cmd 0 "sync: in-sync fixture passes --check" bash "$SYNC" --repo "$d" --check
+
+d="$(fixture sync_drift)"
+python3 - "$d/plugin.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+d = json.load(open(p))
+d["version"] = "2.0.0"
+json.dump(d, open(p, "w"), indent=2)
+PY
+assert_cmd 1 "sync: drift fails --check" bash "$SYNC" --repo "$d" --check
+assert_cmd 0 "sync: writes the Claude manifest" bash "$SYNC" --repo "$d"
+assert_cmd 0 "sync: --check passes after write" bash "$SYNC" --repo "$d" --check
+
+if [[ "$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["version"])' "$d/.claude-plugin/plugin.json")" == "2.0.0" ]]; then
+    ((PASS++))
+else
+    echo "  FAIL sync: version not projected into the Claude manifest"; ((FAIL++))
+fi
+
+if [[ "$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("skills"))' "$d/.claude-plugin/plugin.json")" == "['./skills/demo']" ]]; then
+    ((PASS++))
+else
+    echo "  FAIL sync: Claude-only 'skills' key was not preserved"; ((FAIL++))
+fi
+
+# shellcheck disable=SC2016  # "$schema" is a Python string literal, not a shell expansion
+if python3 -c 'import json,sys;sys.exit(0 if "$schema" not in json.load(open(sys.argv[1])) else 1)' "$d/.claude-plugin/plugin.json"; then
+    ((PASS++))
+else
+    echo "  FAIL sync: \$schema leaked into the Claude manifest"; ((FAIL++))
+fi
+
+d="$(fixture sync_absent)"
+rm "$d/plugin.json"
+assert_cmd 0 "sync: no portable manifest is a no-op" bash "$SYNC" --repo "$d" --check
+
+echo "----------------------------------------"
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || { echo "Portable manifest tests FAILED"; exit 1; }
+echo "All portable manifest tests passed"


### PR DESCRIPTION
Makes the repo loadable by [Agent Plugins 1.0.0](https://agent-plugins.org) clients and establishes the standard the other 55 skill repos will follow.

## The gap

Agent Plugins clients read `plugin.json` at the package root. Claude Code reads `.claude-plugin/plugin.json` and nothing else ([plugins reference](https://code.claude.com/docs/en/plugins-reference)). The portable [schema](https://agent-plugins.org/schemas/1.0.0/plugin.schema.json) is closed (`additionalProperties: false`), so `skills`, `agents`, `commands`, `outputStyles` and `support` are schema violations there. One file cannot serve both; this repo now ships both.

Skills needed no change — `skills/<name>/SKILL.md` is what both specs discover.

## Contract

| File | Read by | Role |
|---|---|---|
| `plugin.json` | any Agent Plugins client | source of truth for name, version, description, author, homepage, repository, license, keywords |
| `.claude-plugin/plugin.json` | Claude Code | generated projection + Claude-only keys |

`skills/skill-repo/scripts/sync-plugin-manifest.sh` writes the projection, preserves every Claude-only key, and never copies `$schema`/`extensions`. `--check` gates it in CI; without a root `plugin.json` it is a no-op, so it is safe for the repos that have not migrated.

## Validation

`validate-skill.sh` checks the schema constant, the name pattern, the closed field set, the `author`/`keywords`/`extensions` shapes, parity with the Claude manifest, and that at least one `skills/<name>/SKILL.md` exists. A **missing** `plugin.json` is a warning, not an error — this validator runs fleet-wide from `main` while repos adopt one PR at a time. `check-version-parity.sh` now treats the root manifest version as authoritative.

`lint.yml` gains a `self-test` job. The reusable `validate.yml` runs the validator from `main`, so a PR that changes the validator did not gate itself; the new job runs the scripts and their tests from the PR's own tree.

## Tests

`tests/portable-manifest.sh` — 21 assertions: happy path, missing manifest stays a warning, bad `$schema`, invalid name, unknown field, drift against the Claude manifest, root-`SKILL.md`-only layout, non-object author, and the sync script's generate/`--check`/no-op/key-preservation behaviour.

## Collateral

SKILL.md was at 498 of its 500-word cap. To fit the manifest section: the cross-platform shell rules moved out (they are verbatim in `references/authoring-ci-gotchas.md`), the installed-paths release rule moved out (it is in `references/release-discipline.md`), and the reference-index category labels were dropped.

Version bumped 1.26.5 → 1.27.0.