### PR TITLE
chore(deps): bump actions/attest-build-provenance to v4.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
             SHA256SUMS.txt
 
       - name: Generate SLSA build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             dist/releases/*.zip


### PR DESCRIPTION
Same change as #201, re-submitted so the required checks can run.

#201 was opened by the Renovate app. Renovate has no `workflows` permission here, so a PR that touches `.github/workflows/**` does not trigger most workflows: only 3 of the 9 required status checks ever start on it. The other six — `composer-audit / Composer Audit`, `composer-audit / Preflight (event gate)`, `composer-audit / SAST (Opengrep)`, `gitleaks / Secret Scanning`, `pack / Verify tarball contents`, `Skill Validation / Skill Validation` — never report, so #201 stays BLOCKED permanently. No amount of waiting fixes it, and clearing it by admin bypass is not on the table.

This PR carries the identical one-line diff from a normal user branch, where all workflows run.

## Pin verified

- `4d101475d8b20a2381f78447822ac1eab6504dd8` resolves to `refs/tags/v4.2.2` — the comment matches the SHA.
- The replaced pin `0f67c3f4856b2e3261c31976d6725780e5e4c373` resolves to `v4.1.1`.
- `v4.2.2` is the newest release (2026-08-06); the `v4` major tag peels to the same commit. No `v5` exists.
- v4.2.2 content: `Bump actions/attest from 4.2.0 to 4.2.1 in the actions-minor group (#862)` — a transitive bump inside the action, no input or behaviour change.
- Still SHA-pinned.

Closes #201.