### PR TITLE
feat(scripts): central bump-version.sh so no repo needs its own release target

### DIFF
--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -46,6 +46,10 @@ If called without an argument and all parity passes, the script prints an adviso
 
 Bump tooling must handle the same two frontmatter forms: a bump script that only rewrites the indented `metadata.version` silently leaves a top-level `version:` at the old value, and the tag pipeline's `validate:skill` then fails on exactly that mismatch (it-maintenance-skill v1.10.0 died this way; typo3-upgrade-estimator-skill nearly repeated it in the 2026-07-16 sweep).
 
+Use `scripts/bump-version.sh <version> [--apply]` rather than a per-repo helper. It writes every surface `check-version-parity.sh` validates — `plugin.json` plus *each* frontmatter `version:` line in *every* `skills/*/SKILL.md`, both forms, indentation and quoting preserved — refuses when `composer.json` carries a version, and re-runs the parity check afterwards. Dry-run by default.
+
+It deliberately does not commit, tag or push. A helper that bumps and tags in one step is how the canonical order above gets skipped: the tag then lands on an unmerged branch, or on a tree where only one of the version surfaces moved. Two repos grew such a target locally (`make release` in it-account-lifecycle-skill and it-maintenance-skill) and both diverged from this page — one bumped only `plugin.json`, the other hard-coded a single skill path and produced the v1.10.0 failure above.
+
 ## Changelog Rollover in the Bump Commit
 
 If the repo maintains a `CHANGELOG.md`, the version-bump commit moves the `[Unreleased]` content under a new `## [X.Y.Z] - YYYY-MM-DD` heading and leaves a fresh empty `[Unreleased]` section. A bump commit that skips this leaves shipped content labeled `[Unreleased]` — the next release then has to relabel history after the fact (typo3-upgrade-estimator-skill shipped its entire v2.2.0 changelog block as `[Unreleased]` and it was only relabeled in v2.2.1).

--- a/skills/skill-repo/scripts/bump-version.sh
+++ b/skills/skill-repo/scripts/bump-version.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# bump-version.sh — set the release version on every surface check-version-parity
+# validates, and nothing else.
+#
+# Usage:
+#   bump-version.sh 1.2.3                 # dry run: print the diff, write nothing
+#   bump-version.sh v1.2.3 --apply        # write the files
+#   bump-version.sh --repo DIR 1.2.3      # operate on DIR instead of cwd
+#
+# Exit codes: 0 = done (or dry run clean), 1 = refused or nothing to write.
+#
+# Behavior:
+#   * Rewrites .claude-plugin/plugin.json .version (required, must exist)
+#   * Rewrites EVERY version: line inside the YAML frontmatter of every
+#     skills/*/SKILL.md — both the indented metadata.version and a top-level
+#     version: key, preserving indentation and quote style.
+#   * Refuses when composer.json carries a version field: the release workflow
+#     derives that from the git tag, so a bumped composer version would drift.
+#   * Verifies the result with check-version-parity.sh when it is present.
+#
+# What it deliberately does NOT do: commit, tag, or push. The release order is
+# bump PR -> merge -> pull -> signed tag -> push (references/release-discipline.md).
+# A helper that tags in the same breath is how an unsigned tag reaches the wild
+# and how a half-bumped tree gets an immutable release; both have happened.
+#
+# Why every version: line and not just the first one: SKILL.md frontmatter in
+# the fleet carries either form, and some carry both. A bump that rewrites only
+# the indented metadata.version leaves a stale top-level version: behind, which
+# the tag pipeline then rejects (it-maintenance-skill v1.10.0 died this way).
+
+set -euo pipefail
+
+REPO_DIR=""
+VERSION=""
+APPLY=0
+
+usage() {
+  echo "Usage: bump-version.sh [--repo DIR] <version> [--apply]" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO_DIR="${2:-}"
+      [[ -n "$REPO_DIR" ]] || usage
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    -*)
+      echo "ERROR: unknown option $1" >&2
+      usage
+      ;;
+    *)
+      [[ -z "$VERSION" ]] || usage
+      VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$VERSION" ]] || usage
+[[ -z "$REPO_DIR" ]] || cd "$REPO_DIR"
+
+VERSION="${VERSION#v}"
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "ERROR: '$VERSION' is not a semantic version" >&2
+  exit 1
+fi
+
+PLUGIN_JSON=".claude-plugin/plugin.json"
+COMPOSER_JSON="composer.json"
+
+if [[ ! -f "$PLUGIN_JSON" ]]; then
+  echo "ERROR: $PLUGIN_JSON not found — run this from the repo root or pass --repo" >&2
+  exit 1
+fi
+if ! jq -e 'has("version")' "$PLUGIN_JSON" > /dev/null 2>&1; then
+  echo "ERROR: $PLUGIN_JSON has no .version field" >&2
+  exit 1
+fi
+
+# Mirror the parity check: composer.json must not carry a version at all, so
+# refuse rather than bump it into existence.
+if [[ -f "$COMPOSER_JSON" ]] && jq -e 'has("version")' "$COMPOSER_JSON" > /dev/null 2>&1; then
+  echo "ERROR: $COMPOSER_JSON has a version field — remove it first" >&2
+  echo "       Git tag is the source of truth for composer packages." >&2
+  exit 1
+fi
+
+OLD_PLUGIN_VERSION=$(jq -r '.version' "$PLUGIN_JSON")
+CHANGES=0
+
+report() { # path old new
+  printf '  %-46s %s -> %s\n' "$1" "$2" "$3"
+}
+
+if [[ "$OLD_PLUGIN_VERSION" != "$VERSION" ]]; then
+  report "$PLUGIN_JSON" "$OLD_PLUGIN_VERSION" "$VERSION"
+  CHANGES=1
+  if (( APPLY )); then
+    tmp=$(mktemp)
+    # jq already terminates its output with a single newline; adding one here
+    # produces a blank line at EOF that the end-of-file hook then strips back.
+    jq --arg v "$VERSION" '.version = $v' "$PLUGIN_JSON" > "$tmp"
+    mv "$tmp" "$PLUGIN_JSON"
+  fi
+fi
+
+shopt -s nullglob
+SKILL_FILES=(skills/*/SKILL.md)
+shopt -u nullglob
+
+if [[ ${#SKILL_FILES[@]} -eq 0 ]]; then
+  echo "WARN: no skills/*/SKILL.md files found" >&2
+fi
+
+for skill_md in "${SKILL_FILES[@]}"; do
+  # Every version: line inside the frontmatter block, both forms, indentation
+  # and quote style preserved. Frontmatter only: a version: in the body stays.
+  before=$(awk '
+    /^---$/ { fm = !fm; next }
+    fm && /^[[:space:]]*version:[[:space:]]*/ {
+      line = $0
+      sub(/^[[:space:]]*version:[[:space:]]*/, "", line)
+      gsub(/["\047]/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      print line
+    }
+  ' "$skill_md" | sort -u | paste -sd, -)
+
+  [[ -n "$before" ]] || continue
+  [[ "$before" != "$VERSION" ]] || continue
+
+  report "$skill_md" "$before" "$VERSION"
+  CHANGES=1
+
+  if (( APPLY )); then
+    tmp=$(mktemp)
+    awk -v ver="$VERSION" '
+      /^---$/ { fm = !fm; print; next }
+      fm && match($0, /^[[:space:]]*version:[[:space:]]*/) {
+        indent = substr($0, 1, RLENGTH)
+        rest = substr($0, RLENGTH + 1)
+        # keep the original quoting: "x", '"'"'x'"'"' or bare
+        q = ""
+        if (rest ~ /^"/) q = "\""
+        else if (rest ~ /^\047/) q = "\047"
+        print indent q ver q
+        next
+      }
+      { print }
+    ' "$skill_md" > "$tmp"
+    mv "$tmp" "$skill_md"
+  fi
+done
+
+if (( ! CHANGES )); then
+  echo "Nothing to do: every version surface is already at $VERSION"
+  exit 0
+fi
+
+if (( ! APPLY )); then
+  echo
+  echo "Dry run — nothing written. Re-run with --apply."
+  exit 0
+fi
+
+PARITY="$(dirname "${BASH_SOURCE[0]}")/check-version-parity.sh"
+if [[ -x "$PARITY" ]]; then
+  echo
+  "$PARITY" "$VERSION"
+fi
+
+cat <<EOF
+
+Files written. Nothing was committed, tagged or pushed — on purpose.
+
+Next (references/release-discipline.md):
+  1. commit the bump and open a PR
+  2. merge it, then pull the default branch
+  3. git tag -s -m "v$VERSION" "v$VERSION" && git push origin "v$VERSION"
+
+Tagging before the bump PR is merged releases the old code.
+EOF


### PR DESCRIPTION
`references/release-discipline.md` states the bump rule but ships no tool for it. So two repos grew their own `make release` target, and both got it wrong in a different way:

| repo | what its target does | result |
|---|---|---|
| `it-account-lifecycle-skill` | bumps `plugin.json` only | four `SKILL.md` left behind → `validate:skill` fails on the tagged commit |
| `it-maintenance-skill` | `sed` on one hard-coded skill path, indented `metadata.version` only | the exact failure this page already records: **it-maintenance-skill v1.10.0 died this way** |

Both also `git tag -a` (signed only if the machine happens to set `tag.gpgsign`) and commit + tag in one shot, skipping the bump-PR-then-tag order.

Measured across the fleet: **61 skill repos, 3 with a Makefile, 2 with their own `release:` target**. So this is not widespread duplication — it is two outliers drifting from a documented process because the documented process had no executable form.

## What this adds

`scripts/bump-version.sh <version> [--apply]` writes every surface `check-version-parity.sh` validates, and only those:

- `.claude-plugin/plugin.json` `.version`
- **every** `version:` line inside the frontmatter of **every** `skills/*/SKILL.md` — both the indented `metadata.version` and a top-level `version:`, indentation and quote style preserved
- refuses when `composer.json` carries a version field (the tag is the source of truth there)
- re-runs `check-version-parity.sh` after writing
- dry-run by default

## What it deliberately does not do

Commit, tag, or push. A helper that tags in the same breath is how the canonical order gets skipped — the tag lands on an unmerged branch, or on a tree where only one version surface moved. It is the same reason the release workflow dropped its own bump job (its header: the API-created tag was unsigned and *"burning a v-tag in the wild"*). A script that cannot tag cannot reintroduce that.

## Verified

Against two real repo trees, not fixtures invented for the test:

- a four-skill repo → all five surfaces moved, `check-version-parity.sh` OK
- a tree carrying **both** frontmatter forms in one file (the v1.10.0 shape) → both rewritten, parity OK

```
before:  version: "0.0.1"   /   metadata.version: "1.10.12"
after:   version: "9.9.9"   /   metadata.version: "9.9.9"
OK: plugin.json and tag match at 9.9.9
```

Also checked: idempotent re-run exits 0 with "nothing to do"; non-semver refused (exit 1); `composer.json` with a version refused; a `version:` line in the **body** of a SKILL.md left untouched; unquoted frontmatter stays unquoted; and `plugin.json` comes out byte-identical except the one line — an early draft appended a second trailing newline, which the end-of-file hook would have stripped back.

`shellcheck` clean, `markdownlint` clean, `validate-skill.sh` 0 errors.

## Note on SKILL.md

Not touched. It sits at **498 of its 500-word budget**, so adding the command there fails the repo's own validator. `release-discipline.md` is already linked from the References line, which is where the rule lives anyway.

## Follow-up

The two `make release` targets get removed in their own repos, pointing here instead.
