### PR TITLE
feat(validate): require the portable manifest

### DIFF
--- a/skills/skill-repo/references/agent-plugins-compat.md
+++ b/skills/skill-repo/references/agent-plugins-compat.md
@@ -92,8 +92,9 @@ migrated yet.
 the `name` pattern, that no field outside the closed schema is present, the
 `author`/`keywords`/`extensions` shapes, that the shared fields match
 `.claude-plugin/plugin.json`, and that at least one `skills/<name>/SKILL.md`
-exists. A **missing** `./plugin.json` is a warning, not an error — the validator
-runs fleet-wide from `main` while repos adopt the manifest one PR at a time.
+exists. A **missing** `./plugin.json` is an error: the fleet finished adopting
+the manifest on 2026-08-07, so a repo without one is a new gap rather than a
+repo still waiting its turn.
 
 `check-version-parity.sh` treats the root `plugin.json` version as
 authoritative and fails when `.claude-plugin/plugin.json` disagrees.

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -411,9 +411,9 @@ fi
 # --- Portable manifest checks (Agent Plugins 1.0.0) ---
 # Root ./plugin.json is the portable manifest every Agent Plugins client reads.
 # It is the source of truth for shared metadata; .claude-plugin/plugin.json is
-# generated from it by sync-plugin-manifest.sh. A missing portable manifest is
-# a warning, not an error: repos adopt it one PR at a time and this validator
-# runs fleet-wide from main.
+# generated from it by sync-plugin-manifest.sh. Its absence is an error: the
+# fleet finished adopting it on 2026-08-07, so a repo without one is a new gap,
+# not a repo still waiting its turn.
 PORTABLE_FILE="$REPO_DIR/plugin.json"
 if [[ -f "$PORTABLE_FILE" ]]; then
     PORTABLE_REPORT=$(python3 - "$PORTABLE_FILE" "$PLUGIN_FILE" "$REPO_DIR" <<'PYEOF' 2>&1 || true
@@ -542,7 +542,7 @@ PYEOF
         esac
     done <<< "$PORTABLE_REPORT"
 else
-    warning "plugin.json (portable Agent Plugins 1.0.0 manifest) not found at repo root — Agent Plugins clients (Cursor, Copilot, …) cannot load this plugin; see skill-repo skills/skill-repo/references/agent-plugins-compat.md"
+    error "plugin.json (portable Agent Plugins 1.0.0 manifest) not found at repo root — Agent Plugins clients (Cursor, Copilot, …) cannot load this plugin; see skill-repo skills/skill-repo/references/agent-plugins-compat.md"
 fi
 
 # --- README.md quality checks (warnings by default) ---

--- a/tests/portable-manifest.sh
+++ b/tests/portable-manifest.sh
@@ -94,14 +94,13 @@ assert_line expect "$d" "skills/ holds 1 portable skill(s): demo" "happy: discov
 
 d="$(fixture no_portable)"
 rm "$d/plugin.json"
-assert_line expect "$d" "portable Agent Plugins 1.0.0 manifest) not found" "missing: warns"
-# The absence must stay a warning: the fleet adopts the manifest one PR at a
-# time while this validator runs everywhere from main.
+assert_line expect "$d" "portable Agent Plugins 1.0.0 manifest) not found" "missing: reported"
+# The absence is an error since the fleet finished adopting the manifest.
 out="$(bash "$VALIDATOR" "$d" 2>&1)"
-if grep -E "ERROR.*(Agent Plugins|portable)" <<<"$out" >/dev/null; then
-    echo "  FAIL missing: absence of plugin.json must not raise an ERROR"; ((FAIL++))
-else
+if grep -E "ERROR.*portable Agent Plugins 1\.0\.0 manifest\) not found" <<<"$out" >/dev/null; then
     ((PASS++))
+else
+    echo "  FAIL missing: absence of plugin.json must raise an ERROR"; ((FAIL++))
 fi
 
 d="$(fixture bad_schema)"


### PR DESCRIPTION
The announced follow-up to [#202](https://github.com/netresearch/skill-repo-skill/pull/202), now that the sweep has merged.

`validate-skill.sh` reported a missing root `plugin.json` as a **warning**, because it runs fleet-wide from `main` while repos adopted the manifest one PR at a time. That is done: verified against the API, every non-archived skill repo carries it — 43 on GitHub, 31 in `coding-ai` on GitLab. A repo without one is now a new gap, so the verdict becomes an **error**.

Not covered, and not able to go red: `netresearch/claude-coach-plugin` and `netresearch/typo3-frontend-patterns-skill` are archived — read-only, no CI.

## Verification

```
$ bash tests/portable-manifest.sh
Passed: 23  Failed: 0
$ bash tests/validate-skill.sh
Passed: 21  Failed: 0
$ bash skills/skill-repo/scripts/validate-skill.sh .
Errors:   0    Warnings: 0
```