### PR TITLE
feat(scripts): fleet-release driver for the public GitHub fleet

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,12 @@ Auto-merge for Dependabot/Renovate PRs is delegated to `netresearch/.github/.git
 - `skills/skill-repo/scripts/migrate-licensing.sh` -- Migrates repos from single LICENSE to split licensing (LICENSE-MIT + LICENSE-CC-BY-SA-4.0).
 - `Build/Scripts/check-plugin-version.sh` -- Validates plugin.json version format.
 
+### Release Tooling
+
+- `skills/skill-repo/scripts/bump-version.sh` / `check-version-parity.sh` / `sync-plugin-manifest.sh` -- Single-repo version surfaces: bump, parity check, manifest projection.
+- `skills/skill-repo/scripts/roll-changelog.py` -- Shape-aware CHANGELOG rollover (all five fleet heading shapes, fence-aware, fails on a no-op roll).
+- `skills/skill-repo/scripts/fleet-release-github.sh` -- Fleet release driver for the public GitHub org; shared host-neutral engine in `fleet-release-common.sh` (private-host fleets vendor the engine and ship their own driver in their own infrastructure), default repo list in `fleet-repos-github.txt`. Flow and guarantees: `skills/skill-repo/references/release-discipline.md`.
+
 ### Templates
 
 `skills/skill-repo/templates/` provides starter files for bootstrapping new skill repos (README, licenses, workflows, composer.json).

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -2,6 +2,28 @@
 
 Every step that caused the "30 failed plugin releases" incident, codified as rules.
 
+## Fleet sweeps: use the shipped driver, do not hand-write a new one
+
+Everything below that a fleet sweep needs is mechanized in
+`scripts/fleet-release-github.sh` on top of the host-neutral
+`scripts/fleet-release-common.sh` engine. The driver runs `survey` →
+`manifest` (stops for human approval; versions and PR bodies are operator
+judgment the scripts never invent) → `bump` → `finish`, resumable from remote
+reality at every step. The changelog rollover below is its own tool,
+`scripts/roll-changelog.py`. Fleets on other hosts keep their driver, their
+repo list and their host specifics in their own (private) repository — that
+driver vendors the shared engine and implements the `host_*` callbacks its
+header documents; host knowledge stays with the host. Every sweep before
+these existed re-implemented this page as one-off scripts and re-earned the
+same bugs (#218 records the last one: brace-group exits, pretty-printed survey
+rows, `//` on empty strings — all now encoded as tests). Deliberately out of
+scope, by design: merging anyone else's PR, unarchiving, cloning missing
+checkouts, writing CI files (a NO-RELEASE-JOB manifest row means adopt the
+shared release CI first), and non-default-branch releases — the
+`--latest=false` rule below stays a manual concern. When a sweep needs
+something the driver lacks, extend it in a PR; a session-local driver script
+is how the next incident starts.
+
 ## Canonical Order: Bump PR Merged → Tag Pushed
 
 **Tag a version only after the version-bump PR is merged to the default branch.** Tagging first causes the Release workflow to run against the old code, fail CI, and produce an immutable GitHub release locked to a bad tag.

--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -1,0 +1,989 @@
+# shellcheck shell=bash
+# fleet-release-common.sh — shared engine for the fleet-release drivers.
+#
+# Sourced by a host driver (fleet-release-github.sh here; a private-host fleet
+# ships its own driver in its own infrastructure and vendors this engine); not
+# executable on its own. Everything host-independent lives here so a bug fixed
+# for one host is fixed for both (the 2026-08-13 sweep's phase_b scripts were
+# literally identical for 20 lines — twice).
+#
+# The driver must define these host callbacks before calling a phase:
+#   host_survey_repo REPO          emit ONE normalized survey row (compact JSON)
+#   host_remote_tip REPO BRANCH    print the remote head SHA of BRANCH
+#   host_create_pr REPO BRANCH TITLE BODY TARGET
+#                                  create the PR/MR against TARGET; print '<id> <url>'
+#   host_find_release_pr REPO BRANCH
+#                                  print '<id> <url> <state> <author>' of the
+#                                  newest PR/MR for BRANCH, or nothing
+#   host_arm_automerge REPO ID     arm auto-merge (or no-op); never fails the repo
+#   host_merge_gate REPO ID        wait until merged; 0 merged, 1 failed/timeout
+#   host_merge_commit REPO ID      print the SHA the merged PR/MR produced
+#   host_release_verify REPO TAG   wait for the Release object; 0 ok, 1 missing
+#   host_origin_suffix REPO        expected origin URL suffix, e.g. 'org/repo'
+#   host_display REPO              display identity, e.g. 'netresearch/repo'
+#
+# Normalized survey row schema (both hosts emit exactly these keys):
+#   host repo resolved default archived empty unreachable duplicate_of
+#   last_release last_tag root_plugin claude_plugin composer_has_version
+#   release_gate ci_status ahead nonci files_truncated subjects files
+#   open_release_prs [{id,url,author,branch,title}] ci_tag_rules notes
+#
+# Every phase writes into $FR_WORKDIR:
+#   survey.jsonl   one row per repo (jq -nc: ROW COUNTS MUST EQUAL LINE COUNTS)
+#   manifest.md    the approval manifest
+#   plan.skeleton.jsonl / plan.jsonl
+#   opened.jsonl   the PRs/MRs THIS sweep opened — the only ones finish may
+#                  ever wait on or merge (a colleague's bump PR is never
+#                  covered by sweep approval; release-discipline.md)
+#   logs/<phase>/<repo>.log
+
+# ---------------------------------------------------------------------------
+# Globals (drivers may override before sourcing or via flags)
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC2034  # consumed across the lib/driver file boundary
+FR_BASE_DIR="${FR_BASE_DIR:-$HOME/projects}"
+FR_POLL_SECONDS="${FR_POLL_SECONDS:-20}"
+FR_MERGE_TIMEOUT="${FR_MERGE_TIMEOUT:-1800}"
+FR_RELEASE_TIMEOUT="${FR_RELEASE_TIMEOUT:-600}"
+FR_SELF_LOGIN="${FR_SELF_LOGIN:-}"        # resolved by the driver (gh/glab)
+FR_BRANCH_PREFIX="release/v"              # owned by github-release-skill
+FR_COMMIT_PREFIX="chore(release): v"      # owned by github-release-skill
+# CI-only delta filter: commits touching only these paths ship a byte-identical
+# archive — not a release (release-discipline.md).
+# shellcheck disable=SC2034  # consumed by the host drivers' survey callbacks
+FR_CI_ONLY_RE='^\.github/|^\.gitlab-ci\.yml$|^renovate\.json$'
+# The only files a bump commit may touch.
+FR_ALLOWLIST_RE='^(plugin\.json|\.claude-plugin/plugin\.json|skills/[^/]+/SKILL\.md|CHANGELOG\.md)$'
+# Version-aware compare/sort, shared by every jq call site. Extracts the
+# TRAILING semver so custom tag conventions (tender-estimation--v0.6.1) order
+# correctly too — a parse that degrades them all to [0] makes max_by pick an
+# arbitrary old tag and misclassify the repo as diverged (seen live 2026-08-13).
+# Input with no trailing semver at all degrades to 0.0.0; the manifest flags
+# those rows as nonstandard instead of trusting the math.
+FR_JQ_VPARSE='def vparse: (capture("(?<v>[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?)$") // {v: "0.0.0"}) | .v | split("-")[0] | split("+")[0] | split(".") | map(tonumber? // 0);'
+
+FR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fr_tool() { # NAME — locate a skill-repo tool (bump-version.sh, roll-changelog.py,
+    # …). A driver vendored into another repo has no sibling copies, so the
+    # lookup falls back to the INSTALLED skill-repo skill (reading/executing
+    # installed paths is fine; editing them is what cache-safety forbids).
+    # FR_TOOLS_DIR pins an explicit source-of-truth checkout when set.
+    local name="$1" d
+    for d in "${FR_TOOLS_DIR:-}" "$FR_SCRIPT_DIR" \
+        "$HOME/.claude/skills/skill-repo/scripts"; do
+        [[ -n "$d" && -f "$d/$name" ]] && { echo "$d/$name"; return 0; }
+    done
+    d=$(find "$HOME/.claude/plugins/cache" -path '*/skills/skill-repo/scripts/'"$name" 2> /dev/null | sort -V | tail -1)
+    [[ -n "$d" ]] && { echo "$d"; return 0; }
+    fr_err "cannot locate $name (set FR_TOOLS_DIR to a skill-repo-skill checkout's skills/skill-repo/scripts)"
+    return 1
+}
+
+fr_note() { printf '%s\n' "$*"; }
+fr_err()  { printf 'ERROR: %s\n' "$*" >&2; }
+fr_die()  { fr_err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+fr_preflight() { # PHASE TOOL...
+    local phase="$1"; shift
+    [[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]] \
+        || fr_die "bash >= 4 required (this is bash ${BASH_VERSION:-unknown}); on macOS: brew install bash"
+    local t
+    for t in git jq "$@"; do
+        command -v "$t" > /dev/null 2>&1 || fr_die "required tool missing: $t"
+    done
+    case "$phase" in
+        bump)
+            command -v python3 > /dev/null 2>&1 \
+                || fr_die "python3 required for the changelog roll"
+            ;;
+        *) : ;;
+    esac
+    # Never write into installed/cache paths (release-discipline.md,
+    # "Cache Safety") — neither the workdir nor the checkouts base.
+    local p
+    for p in "$FR_WORKDIR" "$FR_BASE_DIR"; do
+        case "$p" in
+            */.claude/skills*|*/.claude/plugins*|*/.bare|*/.bare/*)
+                fr_die "refusing to operate under installed/cache path: $p"
+                ;;
+            *) : ;;
+        esac
+    done
+    mkdir -p "$FR_WORKDIR/logs/$phase"
+    # Signing preflight: an agent that silently dropped the key fails every
+    # repo mid-fleet; fail here instead. FR_SKIP_SIGN_CHECK=1 for GPG setups
+    # the check cannot see.
+    if [[ "$phase" == "bump" || "$phase" == "finish" ]] \
+        && [[ "${FR_SKIP_SIGN_CHECK:-0}" != "1" ]]; then
+        local fmt
+        fmt=$(git config --get gpg.format 2> /dev/null || echo openpgp)
+        if [[ "$fmt" == "ssh" ]] && ! ssh-add -l > /dev/null 2>&1; then
+            fr_die "gpg.format=ssh but ssh-add -l lists no key — signing every commit/tag would fail (FR_SKIP_SIGN_CHECK=1 to override)"
+        fi
+    fi
+    fr_lock "$phase"
+}
+
+fr_lock() { # PHASE — one sweep per workdir; stale locks (dead PID) are taken over
+    local lock="$FR_WORKDIR/.lock" pid
+    if mkdir "$lock" 2> /dev/null; then
+        echo "$$" > "$lock/pid"
+    else
+        pid=$(cat "$lock/pid" 2> /dev/null || echo "")
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2> /dev/null; then
+            fr_die "workdir locked by running pid $pid ($lock) — a second sweep on the same workdir would interleave logs and state"
+        fi
+        fr_note "taking over stale lock (pid ${pid:-unknown} is gone)"
+        echo "$$" > "$lock/pid"
+    fi
+    # shellcheck disable=SC2064  # expand $lock now: it is stable and local
+    trap "rm -rf '$lock'" EXIT
+}
+
+# ---------------------------------------------------------------------------
+# Small shared helpers
+# ---------------------------------------------------------------------------
+fr_vercmp() { # A B — prints -1|0|1 (numeric per component; never lexicographic:
+    # bash [[ < ]] and BSD sort would call 1.10.0 older than 1.9.0)
+    jq -rn --arg a "$1" --arg b "$2" \
+        "$FR_JQ_VPARSE"' ($a|vparse) as $A | ($b|vparse) as $B
+         | if $A > $B then "1" elif $A < $B then "-1" else "0" end'
+}
+
+fr_resolve_gitdir() { # DIR — three checkout layouts coexist (release-discipline.md)
+    local d="$1"
+    if [[ -d "$d/.bare" ]]; then
+        echo "$d/.bare"
+    elif git -C "$d" rev-parse --absolute-git-dir 2> /dev/null; then
+        return 0
+    elif git -C "$d/main" rev-parse --absolute-git-dir 2> /dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+fr_check_origin() { # GITDIR EXPECTED — folder names lie; origin URLs don't.
+    # A checkout whose origin points elsewhere would receive the wrong repo's
+    # release branch. Normalize scheme/user/port away and compare host/path
+    # EXACTLY — a suffix match would accept a crafted path whose tail merely
+    # mimics host/org/repo.
+    local gitdir="$1" want="$2" url
+    url=$(git -C "$gitdir" config --get remote.origin.url 2> /dev/null || echo "")
+    [[ -n "$url" ]] || { fr_err "no remote.origin.url in $gitdir"; return 1; }
+    local norm="${url%.git}"
+    norm="${norm#*://}"          # scheme
+    norm="${norm#*@}"            # user
+    if [[ "$norm" =~ ^([^/:]+):[0-9]+(/.*)$ ]]; then
+        norm="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"   # host:PORT/path -> host/path
+    fi
+    norm="${norm//:/\/}"         # scp-style host:org/repo -> host/org/repo
+    if [[ "$norm" == "$want" ]]; then
+        return 0
+    fi
+    fr_err "origin of $gitdir is '$url' (normalized $norm), expected $want — refusing to push there"
+    return 1
+}
+
+fr_worktree_path() { # DIR VERSION — layout-aware worktree location
+    local d="$1" v="$2"
+    if [[ -d "$d/.bare" ]]; then
+        echo "$d/release-$v"
+    else
+        echo "$d-release-$v"
+    fi
+}
+
+fr_fetch_branches() { # GITDIR — branches only: one stale tag would fail the
+    # whole fetch ('would clobber existing tag') and take the branches with it
+    git -C "$1" fetch origin --prune --no-tags \
+        "+refs/heads/*:refs/remotes/origin/*" 2>&1
+}
+
+fr_show_version() { # GITDIR REF FILE — .version of a JSON file at a ref, or empty
+    git -C "$1" show "$2:$3" 2> /dev/null | jq -r '.version // empty' 2> /dev/null || true
+}
+
+fr_parity_from_ref() { # GITDIR REF VERSION — parity read from the ref, never a
+    # working tree (worktrees drift; ~6 of 23 disagreed in one sweep)
+    local gitdir="$1" ref="$2" want="$3" fail=0 cp root f sv
+    cp=$(fr_show_version "$gitdir" "$ref" ".claude-plugin/plugin.json")
+    if [[ -z "$cp" ]]; then
+        fr_err "parity: $ref has no .claude-plugin/plugin.json version"
+        return 1
+    fi
+    [[ "$cp" == "$want" ]] || { fr_err "parity: .claude-plugin/plugin.json=$cp != $want"; fail=1; }
+    if git -C "$gitdir" cat-file -e "$ref:plugin.json" 2> /dev/null; then
+        root=$(fr_show_version "$gitdir" "$ref" "plugin.json")
+        [[ "$root" == "$want" ]] || { fr_err "parity: plugin.json=$root != $want"; fail=1; }
+    fi
+    # composer.json must NOT carry a version — the tag is the source of truth,
+    # and TAG-ONLY repos never pass through bump-version.sh's own refusal.
+    if git -C "$gitdir" show "$ref:composer.json" 2> /dev/null \
+        | jq -e 'has("version")' > /dev/null 2>&1; then
+        fr_err "parity: composer.json at $ref carries a version field"
+        fail=1
+    fi
+    while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        sv=$(git -C "$gitdir" show "$ref:$f" | awk '
+            # Frontmatter is the FIRST --- ... --- block only; a --- rule in
+            # the body must not reopen it (a body "version:" would then be
+            # parsed as the skill version).
+            /^---$/ { if (fm) exit; fm = 1; next }
+            fm && /^[[:space:]]*version:[[:space:]]*/ {
+                gsub(/^[[:space:]]*version:[[:space:]]*/, "")
+                gsub(/["\047]/, "")
+                gsub(/[[:space:]]+$/, "")
+                print
+                exit
+            }')
+        if [[ -n "$sv" && "$sv" != "$want" ]]; then
+            fr_err "parity: $f version=$sv != $want"
+            fail=1
+        fi
+    done < <(git -C "$gitdir" ls-tree -r --name-only "$ref" \
+        | grep -E '^skills/[^/]+/SKILL\.md$' || true)
+    return "$fail"
+}
+
+fr_remote_tag_commit() { # GITDIR TAG — the COMMIT a remote tag points at, or
+    # empty. Signed tags are annotated: ls-remote's plain line is the tag
+    # OBJECT sha; only the peeled ^{} line is the commit. Comparing unpeeled
+    # would call every resumed signed tag "wrong SHA".
+    # Exit 2 when the remote could not be read at all — "cannot see the tag"
+    # must never read as "tag absent", or a network blip triggers a doomed
+    # duplicate tag push.
+    local gitdir="$1" tag="$2" out
+    out=$(git -C "$gitdir" ls-remote origin \
+        "refs/tags/$tag" "refs/tags/$tag^{}" 2> /dev/null) || return 2
+    if printf '%s\n' "$out" | grep -q "refs/tags/$tag\^{}$"; then
+        printf '%s\n' "$out" | awk '/\^\{\}$/ { print $1 }'
+    else
+        printf '%s\n' "$out" | awk 'NF { print $1; exit }'
+    fi
+}
+
+fr_tag_is_signed() { # GITDIR TAG — annotated AND carrying a signature block;
+    # a crashed run's own tag was created with -s, anything else is suspect
+    [[ "$(git -C "$1" cat-file -t "$2" 2> /dev/null)" == "tag" ]] || return 1
+    git -C "$1" cat-file tag "$2" | grep -Eq -- '-----BEGIN (PGP|SSH) SIGNATURE-----'
+}
+
+fr_tag_on_tip() { # GITDIR TAG TIP — signed tag on the verified remote tip; no
+    # checkout, no working tree (a parked worktree stays untouched). Idempotent
+    # across the crash windows: tag already remote, tag local-only.
+    local gitdir="$1" tag="$2" tip="$3" remote local_commit rc
+    rc=0
+    remote=$(fr_remote_tag_commit "$gitdir" "$tag") || rc=$?
+    if [[ "$rc" -eq 2 ]]; then
+        fr_err "cannot read remote tags for $tag (ls-remote failed) — not tagging blind"
+        return 1
+    fi
+    if [[ -n "$remote" ]]; then
+        if [[ "$remote" == "$tip" ]]; then
+            fr_note "tag $tag already on remote at the tip — skipping to verification"
+            return 0
+        fi
+        fr_err "tag $tag exists on remote at $remote, tip is $tip — a released tag is immutable; this needs a human"
+        return 1
+    fi
+    if git -C "$gitdir" rev-parse -q --verify "refs/tags/$tag" > /dev/null 2>&1; then
+        local_commit=$(git -C "$gitdir" rev-parse "$tag^{commit}")
+        if [[ "$local_commit" == "$tip" ]] && fr_tag_is_signed "$gitdir" "$tag"; then
+            fr_note "local signed tag $tag already at the tip (crashed before push) — pushing it"
+        elif [[ "$local_commit" == "$tip" ]]; then
+            fr_err "local tag $tag is at the tip but UNSIGNED — not this driver's work; inspect, 'git -C $gitdir tag -d $tag', re-run"
+            return 1
+        else
+            fr_err "local tag $tag points at $local_commit, tip is $tip — inspect and 'git -C $gitdir tag -d $tag' manually"
+            return 1
+        fi
+    else
+        git -C "$gitdir" tag -s "$tag" -m "$tag" "$tip" || { fr_err "tag -s failed"; return 1; }
+    fi
+    git -C "$gitdir" push origin "refs/tags/$tag"
+    local ec=$?
+    fr_note "TAG PUSH EXIT: $ec"
+    return "$ec"
+}
+
+fr_check_log_invariant() { # LOGDIR EXPECTED — a killed batch 'completes' with
+    # fewer logs than repos and nothing says so; count before trusting anything
+    local logdir="$1" expected="$2" actual
+    actual=$(find "$logdir" -maxdepth 1 -name '*.log' | wc -l | tr -d ' ')
+    if [[ "$actual" -ne "$expected" ]]; then
+        fr_err "log invariant violated: $actual logs for $expected repos in $logdir"
+        return 1
+    fi
+    fr_note "log invariant holds: $actual/$expected"
+}
+
+fr_summarize_logs() { # LOGDIR — count explicit end-state markers; a truncated
+    # log (hard kill mid-repo) is neither OK nor FAIL and must be visible
+    local logdir="$1" f ok=0 failed=0 other=0
+    for f in "$logdir"/*.log; do
+        [[ -e "$f" ]] || continue
+        if grep -q '^OK ' "$f"; then
+            ok=$((ok + 1))
+        elif grep -q '^FAIL ' "$f"; then
+            failed=$((failed + 1))
+            fr_note "FAIL: $(basename "$f" .log): $(grep '^FAIL ' "$f" | tail -1)"
+        else
+            other=$((other + 1))
+            fr_note "INDETERMINATE (no OK/FAIL marker — truncated?): $f"
+        fi
+    done
+    fr_note "summary: $ok ok, $failed failed, $other indeterminate"
+    [[ "$failed" -eq 0 && "$other" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Survey
+# ---------------------------------------------------------------------------
+fr_survey() { # REPO... — remote-first; per-repo failures become rows, not aborts.
+    # A re-survey of a SUBSET (the manifest's own "re-run survey --repos X"
+    # advice) replaces exactly those rows and keeps the rest — truncating the
+    # whole file would throw away the sweep it is trying to repair.
+    local out="$FR_WORKDIR/survey.jsonl" seen="$FR_WORKDIR/.seen-resolved" repo row resolved tmp
+    if [[ -s "$out" ]]; then
+        tmp=$(mktemp)
+        jq -c --args 'select(.repo as $r | $ARGS.positional | index($r) | not)' "$@" < "$out" > "$tmp"
+        mv "$tmp" "$out"
+        jq -r 'select((.resolved // "") != "") | .resolved' "$out" > "$seen"
+        fr_note "keeping $(wc -l < "$out" | tr -d ' ') existing rows; re-surveying: $*"
+    else
+        : > "$out"
+        : > "$seen"
+    fi
+    for repo in "$@"; do
+        fr_note "surveying $(host_display "$repo") ..."
+        row=$(host_survey_repo "$repo" < /dev/null) \
+            || row=$(jq -nc --arg r "$repo" --arg h "$FR_HOST" \
+                '{host:$h, repo:$r, unreachable:true}')
+        # A renamed repo answers on both names (API redirect) — the SECOND row
+        # for one resolved identity must not become a second bump PR.
+        resolved=$(jq -r '.resolved // empty' <<< "$row")
+        if [[ -n "$resolved" ]] && grep -Fxq "$resolved" "$seen"; then
+            row=$(jq -nc --arg r "$repo" --arg h "$FR_HOST" --arg d "$resolved" \
+                '{host:$h, repo:$r, duplicate_of:$d}')
+        elif [[ -n "$resolved" ]]; then
+            printf '%s\n' "$resolved" >> "$seen"
+        fi
+        printf '%s\n' "$row" >> "$out"   # rows are compact: wc -l == repo count
+    done
+    fr_note ""
+    fr_note "survey: $(wc -l < "$out" | tr -d ' ') rows -> $out"
+    fr_note "next: $FR_DRIVER manifest --workdir $FR_WORKDIR"
+}
+
+# ---------------------------------------------------------------------------
+# Classification + manifest
+# ---------------------------------------------------------------------------
+fr_classify() { # ROW-JSON — one shared implementation for both hosts; blocks
+    # outrank actions (a composer-version repo must never reach TAG-ONLY)
+    jq -r --arg self "$FR_SELF_LOGIN" "$FR_JQ_VPARSE"'
+        if .unreachable == true then "UNREACHABLE"
+        elif (.duplicate_of // "") != "" then "DUPLICATE"
+        elif .empty == true then "EMPTY"
+        elif .archived == true then "BLOCKED-ARCHIVED"
+        elif .composer_has_version == true then "BLOCKED-COMPOSER-VERSION"
+        elif ([.open_release_prs[]? | select(.author != $self)] | length) > 0 then "BLOCKED-FOREIGN-PR"
+        elif ([.open_release_prs[]? | select(.author == $self)] | length) > 0 then "OWN-PR-OPEN"
+        elif .release_gate == false then "NO-RELEASE-JOB"
+        elif (.last_release // "") == "" and (.last_tag // "") == "" then "FIRST-RELEASE"
+        elif (.last_tag // "") != "" and (.last_tag != (.last_release // "")) then "TAG-RELEASE-DIVERGED"
+        else
+            ((.claude_plugin // "") | vparse) as $p
+            | ((.last_tag // "") | vparse) as $t
+            | if $p > $t then "TAG-ONLY"
+              elif $p < $t then "BEHIND-TAG"
+              # ahead/nonci < 0 = the compare MEASUREMENT failed, which must
+              # never read as "no delta": a transient API blip would silently
+              # drop a repo with releasable commits from the sweep.
+              elif (.ahead // 0) < 0 or (.nonci // 0) < 0 then "SURVEY-INCOMPLETE"
+              elif (.ahead // 0) == 0 then "UP-TO-DATE"
+              elif (.nonci // 0) == 0 then "SKIP-CI-ONLY"
+              else "BUMP"
+              end
+        end' <<< "$1"
+}
+
+fr_manifest() {
+    local survey="$FR_WORKDIR/survey.jsonl" manifest="$FR_WORKDIR/manifest.md"
+    local skeleton="$FR_WORKDIR/plan.skeleton.jsonl" row cls
+    [[ -s "$survey" ]] || fr_die "no survey at $survey — run: $FR_DRIVER survey first"
+    [[ -n "$FR_SELF_LOGIN" ]] || fr_die "FR_SELF_LOGIN unresolved — cannot apply the foreign-PR author gate"
+    : > "$skeleton"
+    {
+        echo "# Fleet Release Manifest ($FR_HOST, $(date +%F))"
+        echo
+        echo "Approval covers ONLY the PRs this sweep opens. Rows marked"
+        echo "BLOCKED-FOREIGN-PR need that author's separate go-ahead."
+        echo
+        echo "| Repo | Class | Last tag | Release | plugin.json | Ahead | Non-CI | CI on default | Notes |"
+        echo "|---|---|---|---|---|---|---|---|---|"
+    } > "$manifest"
+    while IFS= read -u 3 -r row; do
+        cls=$(fr_classify "$row")
+        jq -r --arg cls "$cls" "$FR_JQ_VPARSE"'
+            def ordash: if . == null or . == "" then "—" else . end;
+            [ .repo,
+              $cls,
+              (.last_tag | ordash),
+              (.last_release | ordash),
+              (.claude_plugin | ordash),
+              ((.ahead // "") | tostring | ordash),
+              ((.nonci // "") | tostring | ordash),
+              (.ci_status | ordash),
+              ([ (if (.open_release_prs // []) | length > 0
+                  then "PRs: " + ([.open_release_prs[] | "\(.url) by @\(.author)"] | join("; "))
+                  else empty end),
+                 (if (.last_tag // "") != "" and ((.last_tag | test("^v?[0-9]+\\.[0-9]+\\.[0-9]+")) | not)
+                  then "nonstandard tag convention" else empty end),
+                 (if .files_truncated == true then "compare file list truncated" else empty end),
+                 (if $cls == "NO-RELEASE-JOB"
+                  then "no tag-triggered release job — adopt the shared release CI first; this driver does not write CI files"
+                  else empty end),
+                 (if $cls == "TAG-RELEASE-DIVERGED"
+                  then "tag exists without a matching Release — check the release job matched the tag pattern; usually a CI fix plus a NEW version (re-plan as BUMP)"
+                  else empty end),
+                 (if $cls == "BLOCKED-ARCHIVED"
+                  then "unarchive is a human decision; afterwards re-run survey --repos \(.repo)"
+                  else empty end),
+                 (if $cls == "SURVEY-INCOMPLETE"
+                  then "the compare MEASUREMENT failed (this is not a no-delta result) — re-run survey --repos \(.repo)"
+                  else empty end),
+                 (if (.ci_tag_rules // "") != ""
+                  then "tag rules: " + (.ci_tag_rules | gsub("\\|"; "¦"))
+                  else empty end),
+                 ((.notes // "") | if . == "" then empty else gsub("\\|"; "¦") end)
+               ] | join(". ") | ordash)
+            ] | "| " + join(" | ") + " |"' <<< "$row" >> "$manifest"
+        case "$cls" in
+            BUMP|FIRST-RELEASE|TAG-ONLY|TAG-RELEASE-DIVERGED|OWN-PR-OPEN)
+                # TAG-ONLY carries its committed version — tagging a prepared
+                # repo at that version keeps parity true by construction.
+                # OWN-PR-OPEN carries the version its open PR branch encodes,
+                # so a crashed sweep's own PR re-enters the flow instead of
+                # being silently dropped. BUMP versions and bodies are operator
+                # judgment: the driver never invents either. `head` is the
+                # surveyed default-branch tip — finish refuses to tag a
+                # TAG-ONLY repo whose branch moved past it.
+                jq -c --arg cls "$cls" \
+                    '{repo, classification: $cls, default: (.default // "main"),
+                      last: (.claude_plugin // ""), last_tag: (.last_tag // ""),
+                      head: (.head // ""),
+                      version: (if $cls == "TAG-ONLY" then (.claude_plugin // "")
+                                elif $cls == "OWN-PR-OPEN"
+                                then ([.open_release_prs[]? | .branch
+                                      | capture("^release/v(?<v>.+)$") | .v] | first // "")
+                                else "" end),
+                      body: "", tag: "",
+                      subjects: (.subjects // [])}' <<< "$row" >> "$skeleton"
+                ;;
+        esac
+    done 3< "$survey"
+    {
+        echo
+        echo "Preconditions are per-repo MEASURED values above (CI on default,"
+        echo "open PRs, composer version field) — never assumed checkmarks."
+        echo
+        echo "Scope: this driver releases the DEFAULT branch tip only. Maintenance-line"
+        echo "releases (--latest=false handling) are out of scope — do those by hand."
+    } >> "$manifest"
+    cat "$manifest"
+    fr_note ""
+    fr_note "manifest -> $manifest"
+    fr_note "plan skeleton -> $skeleton"
+    fr_note "next: 1. review the manifest with the operator/user and get approval"
+    fr_note "      2. cp $skeleton $FR_WORKDIR/plan.jsonl"
+    fr_note "      3. fill 'version' (and 'body') for every BUMP/FIRST-RELEASE row; drop rows to skip"
+    fr_note "      4. $FR_DRIVER bump --workdir $FR_WORKDIR"
+}
+
+# ---------------------------------------------------------------------------
+# Plan handling
+# ---------------------------------------------------------------------------
+fr_plan_validate() { # PLAN — refuse the whole phase before mutating anything
+    local plan="$1" bad
+    [[ -s "$plan" ]] || fr_die "no plan at $plan (copy plan.skeleton.jsonl and fill it)"
+    jq -e . > /dev/null 2>&1 < "$plan" || fr_die "plan is not valid JSON lines: $plan"
+    # Repo names become branch names, log paths and worktree paths — a slash
+    # (GitLab subgroup) or space would land the log/worktree somewhere else.
+    bad=$(jq -r 'select((.repo // "") | test("^[A-Za-z0-9._-]+$") | not) | .repo // "<empty>"' < "$plan")
+    [[ -z "$bad" ]] || fr_die "plan rows with unusable repo names (subgroups are unsupported): $(tr '\n' ' ' <<< "$bad")"
+    # One row per repo: two rows with different versions would open two bump
+    # PRs against one repo.
+    bad=$(jq -r '.repo' < "$plan" | sort | uniq -d)
+    [[ -z "$bad" ]] || fr_die "duplicate plan rows for: $(tr '\n' ' ' <<< "$bad")"
+    bad=$(jq -r 'select((.classification == "BUMP" or .classification == "FIRST-RELEASE" or .classification == "TAG-ONLY" or .classification == "OWN-PR-OPEN")
+                  and ((.version // "") == "")) | .repo' < "$plan")
+    [[ -z "$bad" ]] || fr_die "plan rows without a version: $(tr '\n' ' ' <<< "$bad")— fill them or drop them"
+    bad=$(jq -r 'select((.version // "") != "")
+                 | select((.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?$")) | not) | .repo' < "$plan")
+    [[ -z "$bad" ]] || fr_die "plan rows with a non-semver version: $(tr '\n' ' ' <<< "$bad")"
+    # Monotonicity: a planned version below or equal to the surveyed one would
+    # ship a parity-consistent version REGRESSION that no later gate can see.
+    # TAG-ONLY is the exception and must equal the committed version exactly.
+    bad=$(jq -r "$FR_JQ_VPARSE"'
+        select((.version // "") != "" and (.last // "") != "")
+        | if .classification == "TAG-ONLY"
+          then select(.version != .last)
+               | "\(.repo) (TAG-ONLY must tag the committed \(.last), not \(.version))"
+          else select((.version | vparse) <= (.last | vparse))
+               | "\(.repo) (\(.version) is not above the surveyed \(.last))"
+          end' < "$plan")
+    [[ -z "$bad" ]] || fr_die "plan version ordering: $(tr '\n' ';' <<< "$bad")"
+}
+
+fr_record_opened() { # REPO ID URL BRANCH — append-only; survives crashes
+    jq -nc --arg h "$FR_HOST" --arg r "$1" --arg i "$2" --arg u "$3" --arg b "$4" \
+        '{host: $h, repo: $r, id: $i, url: $u, branch: $b}' >> "$FR_WORKDIR/opened.jsonl"
+}
+
+fr_opened_lookup() { # REPO — id of the PR/MR this sweep opened, or empty.
+    # Host-filtered: a workdir reused across both drivers must never resolve
+    # the other host's PR number.
+    [[ -f "$FR_WORKDIR/opened.jsonl" ]] || return 0
+    jq -r --arg r "$1" --arg h "$FR_HOST" \
+        'select(.repo == $r and .host == $h) | .id' "$FR_WORKDIR/opened.jsonl" | tail -1
+}
+
+# ---------------------------------------------------------------------------
+# Bump phase
+# ---------------------------------------------------------------------------
+fr_bump_one() { # ROW — runs inside the per-repo subshell; log via redirection
+    local row="$1"
+    local repo version body default last cls
+    repo=$(jq -r '.repo' <<< "$row")
+    version=$(jq -r '.version // ""' <<< "$row")
+    body=$(jq -r '.body // ""' <<< "$row")
+    default=$(jq -r '.default // "main"' <<< "$row")
+    last=$(jq -r '.last // ""' <<< "$row")
+    cls=$(jq -r '.classification // "BUMP"' <<< "$row")
+    local branch="${FR_BRANCH_PREFIX}${version}"
+    echo "=== $(host_display "$repo") v$version ($cls) ==="
+    [[ -n "$version" ]] || { echo "FAIL $repo: plan row has no version"; return 1; }
+
+    if [[ "$cls" == "TAG-ONLY" ]]; then
+        echo "OK $repo v$version no bump needed (prepared repo; finish will tag)"
+        return 0
+    fi
+    # OWN-PR-OPEN re-enters here on purpose: the remote-reality checks below
+    # find the sweep's own open PR and record it instead of double-bumping.
+    if [[ "$cls" != "BUMP" && "$cls" != "FIRST-RELEASE" && "$cls" != "OWN-PR-OPEN" ]]; then
+        echo "FAIL $repo: classification $cls does not belong in the bump phase"
+        return 1
+    fi
+
+    local dir="$FR_BASE_DIR/$repo" gitdir
+    gitdir=$(fr_resolve_gitdir "$dir") \
+        || { echo "FAIL $repo: no checkout at $dir (survey is remote-first; bump needs a local checkout — clone it deliberately, this driver will not)"; return 1; }
+    fr_check_origin "$gitdir" "$(host_origin_suffix "$repo")" \
+        || { echo "FAIL $repo: origin mismatch"; return 1; }
+    fr_fetch_branches "$gitdir" || { echo "FAIL $repo: fetch"; return 1; }
+
+    # Freshness gate: classification happened at survey time and approval is
+    # human-paced. If the fleet moved since (a colleague released), writing the
+    # planned version would be a parity-consistent version REGRESSION that
+    # every later gate happily waves through — refuse instead.
+    local cur
+    cur=$(fr_show_version "$gitdir" "origin/$default" ".claude-plugin/plugin.json")
+    if [[ "$cur" == "$version" ]]; then
+        echo "OK $repo v$version already at $version on origin/$default (nothing to bump; finish will tag)"
+        return 0
+    fi
+    if [[ "$cur" != "$last" ]]; then
+        echo "FAIL $repo: fleet moved since survey (surveyed $last, origin/$default now $cur) — re-run survey and re-plan this repo"
+        return 1
+    fi
+
+    # Remote reality is the resume truth, interrogated per step; the crash
+    # windows (after commit, after push, after PR create) each land in one of
+    # these branches instead of a dead end.
+    if git -C "$gitdir" rev-parse -q --verify "refs/remotes/origin/$branch" > /dev/null 2>&1; then
+        local pr prid prurl prstate prauthor
+        pr=$(host_find_release_pr "$repo" "$branch" < /dev/null || true)
+        if [[ -n "$pr" ]]; then
+            read -r prid prurl prstate prauthor <<< "$pr"
+            case "$prstate" in
+                merged|MERGED)
+                    echo "OK $repo v$version bump already merged ($prurl) — run finish"
+                    return 0
+                    ;;
+                open|OPEN|opened)
+                    if [[ "$prauthor" != "$FR_SELF_LOGIN" ]]; then
+                        echo "FAIL $repo: open release PR $prurl by @$prauthor — a colleague's PR needs their go, not sweep approval"
+                        return 1
+                    fi
+                    [[ -n "$(fr_opened_lookup "$repo")" ]] || fr_record_opened "$repo" "$prid" "$prurl" "$branch"
+                    echo "OK $repo v$version PR already open: $prurl"
+                    return 0
+                    ;;
+            esac
+        fi
+        local bv extra
+        bv=$(fr_show_version "$gitdir" "origin/$branch" ".claude-plugin/plugin.json")
+        if [[ "$bv" == "$version" ]]; then
+            # Version alone does not prove the branch is a bump: an auto-merge
+            # will merge whatever else it carries unseen. Only the four version
+            # surfaces may differ from the base.
+            extra=$(git -C "$gitdir" diff --name-only "origin/$default" "origin/$branch" \
+                | grep -vE "$FR_ALLOWLIST_RE" || true)
+            if [[ -n "$extra" ]]; then
+                echo "FAIL $repo: remote branch $branch changes more than the version surfaces ($(tr '\n' ' ' <<< "$extra")) — not adopting it for auto-merge; inspect it"
+                return 1
+            fi
+            echo "branch $branch already pushed at $version (crashed before PR create) — creating the PR"
+            fr_create_and_record "$repo" "$branch" "$version" "$body" "$default" || return 1
+            echo "OK $repo v$version PR created from existing branch"
+            return 0
+        fi
+        echo "FAIL $repo: leftover remote branch $branch at version '${bv:-unknown}' != $version — inspect and delete it first"
+        return 1
+    fi
+
+    local wt
+    wt=$(fr_worktree_path "$dir" "$version")
+    if [[ -e "$wt" ]]; then
+        fr_resume_worktree "$repo" "$wt" "$branch" "$version" "$default" "$gitdir" || return 1
+    else
+        git -C "$gitdir" worktree add "$wt" -b "$branch" "origin/$default" \
+            || { echo "FAIL $repo: worktree add"; return 1; }
+    fi
+
+    if [[ "$(fr_show_version "$gitdir" "$branch" ".claude-plugin/plugin.json" 2> /dev/null)" != "$version" ]]; then
+        local bump_tool roll_tool
+        bump_tool=$(fr_tool bump-version.sh) || { echo "FAIL $repo: bump-version.sh not found"; return 1; }
+        bash "$bump_tool" --repo "$wt" "$version" --apply \
+            || { echo "FAIL $repo: bump"; return 1; }
+        if [[ -f "$wt/CHANGELOG.md" ]]; then
+            roll_tool=$(fr_tool roll-changelog.py) || { echo "FAIL $repo: roll-changelog.py not found"; return 1; }
+            python3 "$roll_tool" "$wt/CHANGELOG.md" "$version" \
+                || { echo "FAIL $repo: changelog roll"; return 1; }
+            fr_lint_changelog "$wt"
+        fi
+        fr_commit_allowlisted "$repo" "$wt" "$version" || return 1
+    else
+        echo "bump already committed on $branch (crashed before push)"
+    fi
+
+    ( cd "$wt" && git push -u origin "$branch" )
+    local ec=$?
+    echo "PUSH EXIT: $ec"
+    [[ "$ec" -eq 0 ]] || { echo "FAIL $repo: push"; return 1; }
+
+    fr_create_and_record "$repo" "$branch" "$version" "$body" "$default" || return 1
+    echo "OK $repo v$version bump PR open"
+}
+
+fr_resume_worktree() { # REPO WT BRANCH VERSION DEFAULT GITDIR — reuse only what
+    # is provably this sweep's own half-done work; anything else is a loud stop
+    local repo="$1" wt="$2" branch="$3" version="$4" default="$5" gitdir="$6"
+    local head cur
+    head=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2> /dev/null || echo "")
+    if [[ "$head" != "$branch" ]]; then
+        echo "FAIL $repo: $wt exists on branch '${head:-?}' (expected $branch) — not this sweep's worktree, inspect manually"
+        return 1
+    fi
+    if [[ -n "$(git -C "$wt" status --porcelain)" ]]; then
+        echo "FAIL $repo: $wt is dirty — a half-written bump; inspect, then 'git -C $gitdir worktree remove --force $wt'"
+        return 1
+    fi
+    cur=$(jq -r '.version // empty' "$wt/.claude-plugin/plugin.json" 2> /dev/null || echo "")
+    if [[ "$cur" == "$version" ]]; then
+        echo "reusing $wt: bump already committed"
+        return 0
+    fi
+    if [[ "$(git -C "$wt" rev-parse HEAD)" == "$(git -C "$gitdir" rev-parse "origin/$default")" ]]; then
+        echo "reusing $wt: fresh worktree, bump not yet applied"
+        return 0
+    fi
+    echo "FAIL $repo: $wt is clean but at version '$cur' on a stale base — inspect, then remove it"
+    return 1
+}
+
+fr_lint_changelog() { # WT — the roll is generated text and generated text is
+    # what nobody proofreads; 16 of 63 repos went red on MD022/MD032 once.
+    # Advisory when no runner exists (the roll itself emits clean structure).
+    # Only an ALREADY-INSTALLED binary is used — an on-demand `npx --yes`
+    # would download and execute an unpinned package mid-sweep.
+    local wt="$1"
+    if command -v markdownlint-cli2 > /dev/null 2>&1; then
+        ( cd "$wt" && markdownlint-cli2 CHANGELOG.md ) \
+            && echo "markdownlint: CHANGELOG.md clean" \
+            || echo "WARN: markdownlint flagged CHANGELOG.md — fix before merge goes red"
+    else
+        echo "markdownlint-cli2 not installed — structural guarantees from roll-changelog.py only"
+    fi
+}
+
+fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces may
+    # move; -z parsing (paths with spaces exist in the fleet), no add -A ever
+    local repo="$1" wt="$2" version="$3"
+    local entry status path
+    local paths=()
+    echo "--- porcelain:"
+    git -C "$wt" status --porcelain
+    while IFS= read -r -d '' entry; do
+        [[ -n "$entry" ]] || continue
+        status="${entry:0:2}"
+        path="${entry:3}"
+        case "$status" in
+            R*|C*)
+                echo "FAIL $repo: unexpected rename/copy in bump tree: $entry"
+                return 1
+                ;;
+        esac
+        if ! grep -qE "$FR_ALLOWLIST_RE" <<< "$path"; then
+            echo "FAIL $repo: unexpected change outside the version surfaces: $path"
+            return 1
+        fi
+        paths+=("$path")
+    done < <(git -C "$wt" status --porcelain -z)
+    [[ "${#paths[@]}" -gt 0 ]] || { echo "FAIL $repo: nothing to commit after bump"; return 1; }
+    ( cd "$wt" && git add -- "${paths[@]}" \
+        && git commit -S --signoff -m "${FR_COMMIT_PREFIX}${version}" )
+    local ec=$?
+    echo "COMMIT EXIT: $ec"   # bare exit code — a pipe here once hid a hook abort
+    [[ "$ec" -eq 0 ]] || { echo "FAIL $repo: commit"; return 1; }
+}
+
+fr_create_and_record() { # REPO BRANCH VERSION BODY TARGET
+    local repo="$1" branch="$2" version="$3" body="$4" target="$5" out prid prurl
+    out=$(host_create_pr "$repo" "$branch" "${FR_COMMIT_PREFIX}${version}" "$body" "$target" < /dev/null) \
+        || { echo "FAIL $repo: PR/MR create: $out"; return 1; }
+    read -r prid prurl <<< "$out"
+    fr_record_opened "$repo" "$prid" "$prurl" "$branch"
+    echo "PR: $prurl"
+    # Arm failure is not repo failure — finish merges plainly when green.
+    host_arm_automerge "$repo" "$prid" < /dev/null || true
+}
+
+fr_bump() { # PLAN
+    local plan="$1" logdir="$FR_WORKDIR/logs/bump" row repo n=0 rc=0
+    fr_plan_validate "$plan"
+    # Logs are per-RUN evidence: stale ones from a previous run would fail the
+    # count invariant and resurrect old FAIL lines into this run's summary.
+    find "$logdir" -maxdepth 1 -name '*.log' -delete 2> /dev/null || true
+    while IFS= read -u 3 -r row || [[ -n "$row" ]]; do
+        [[ -n "$row" ]] || continue
+        repo=$(jq -r '.repo' <<< "$row")
+        n=$((n + 1))
+        fr_note "bump: $repo ..."
+        # Subshell, never a brace group: a per-repo exit inside { } > log kills
+        # the whole driver and the batch "completes" with missing logs.
+        ( fr_bump_one "$row" ) > "$logdir/$repo.log" 2>&1 || rc=1
+        tail -1 "$logdir/$repo.log" 2> /dev/null || rc=1
+    done 3< "$plan"
+    fr_check_log_invariant "$logdir" "$n" || rc=1
+    fr_summarize_logs "$logdir" || rc=1
+    fr_note ""
+    fr_note "opened PRs recorded in $FR_WORKDIR/opened.jsonl"
+    fr_note "next: $FR_DRIVER finish --workdir $FR_WORKDIR"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Finish phase
+# ---------------------------------------------------------------------------
+fr_finish_one() { # ROW — exit 0 ok, 1 pre-tag failure (loop continues),
+    # 2 post-tag failure (systemic: the release machinery itself broke — the
+    # loop HALTS, because "halt all further releases if this one fails" is a
+    # numbered step of the spec's execution order)
+    local row="$1"
+    local repo version default cls tag_override
+    repo=$(jq -r '.repo' <<< "$row")
+    version=$(jq -r '.version // ""' <<< "$row")
+    default=$(jq -r '.default // "main"' <<< "$row")
+    cls=$(jq -r '.classification // "BUMP"' <<< "$row")
+    tag_override=$(jq -r '.tag // ""' <<< "$row")
+    local tag="${tag_override:-v$version}"
+    local branch="${FR_BRANCH_PREFIX}${version}"
+    local head
+    head=$(jq -r '.head // ""' <<< "$row")
+    echo "=== $(host_display "$repo") $tag ($cls) ==="
+    [[ -n "$version" ]] || { echo "FAIL $repo: plan row has no version"; return 1; }
+    case "$cls" in
+        BUMP|FIRST-RELEASE|TAG-ONLY|OWN-PR-OPEN) ;;
+        *)
+            echo "FAIL $repo: classification $cls does not belong in the finish phase — resolve it first"
+            return 1
+            ;;
+    esac
+
+    local dir="$FR_BASE_DIR/$repo" gitdir
+    gitdir=$(fr_resolve_gitdir "$dir") || { echo "FAIL $repo: no checkout at $dir"; return 1; }
+    fr_check_origin "$gitdir" "$(host_origin_suffix "$repo")" || { echo "FAIL $repo: origin mismatch"; return 1; }
+
+    # Idempotent re-run: a tag already on the remote means this repo released
+    # (or a human tagged it) — verify the Release and stop, instead of failing
+    # on "tip moved past the tag" after later commits landed on the default
+    # branch.
+    local pre_rc=0 pre_existing
+    pre_existing=$(fr_remote_tag_commit "$gitdir" "$tag") || pre_rc=$?
+    if [[ "$pre_rc" -eq 2 ]]; then
+        echo "FAIL $repo: cannot read remote tags — not proceeding blind"
+        return 1
+    fi
+    if [[ -n "$pre_existing" ]]; then
+        echo "tag $tag already on the remote at $pre_existing — verifying its Release"
+        host_release_verify "$repo" "$tag" < /dev/null \
+            || { echo "FAIL $repo: tag $tag exists but has no verified Release (post-tag — halting the sweep)"; return 2; }
+        fr_cleanup_release_branch "$dir" "$gitdir" "$branch" "$version" "$(fr_opened_lookup "$repo")"
+        echo "OK $repo $tag released (verified on re-run)"
+        return 0
+    fi
+
+    local prid
+    prid=$(fr_opened_lookup "$repo")
+    if [[ -z "$prid" ]]; then
+        # No PR recorded: legitimate for TAG-ONLY / already-at-version repos.
+        # An open release PR by SELF from a crashed earlier workdir is adopted;
+        # anyone else's PR is never touched.
+        local pr prurl prstate prauthor
+        pr=$(host_find_release_pr "$repo" "$branch" < /dev/null || true)
+        if [[ -n "$pr" ]]; then
+            read -r prid prurl prstate prauthor <<< "$pr"
+            case "$prstate" in
+                open|OPEN|opened)
+                    if [[ "$prauthor" == "$FR_SELF_LOGIN" ]]; then
+                        echo "adopting own open PR $prurl (crashed earlier sweep)"
+                        fr_record_opened "$repo" "$prid" "$prurl" "$branch"
+                    else
+                        echo "FAIL $repo: open release PR $prurl by @$prauthor — needs their go-ahead, not this sweep's"
+                        return 1
+                    fi
+                    ;;
+                *) prid="" ;;
+            esac
+        fi
+    fi
+    local target i
+    if [[ -n "$prid" ]]; then
+        host_merge_gate "$repo" "$prid" < /dev/null || { echo "FAIL $repo: merge gate"; return 1; }
+        echo "merged."
+        # Tag the MERGE COMMIT, not whatever the tip is by now: between merge
+        # and tag a colleague's push can land, and tagging the live tip would
+        # release unsurveyed commits. The merge commit is exactly what the
+        # sweep's approval covered.
+        target=$(host_merge_commit "$repo" "$prid" < /dev/null || true)
+        [[ -n "$target" ]] || { echo "FAIL $repo: cannot resolve the merge commit of the bump PR"; return 1; }
+        for i in 1 2 3 4 5; do
+            fr_fetch_branches "$gitdir" > /dev/null
+            git -C "$gitdir" cat-file -e "$target^{commit}" 2> /dev/null && break
+            [[ "$i" -lt 5 ]] && sleep "$FR_POLL_SECONDS"
+        done
+        git -C "$gitdir" cat-file -e "$target^{commit}" 2> /dev/null \
+            || { echo "FAIL $repo: merge commit $target never became fetchable"; return 1; }
+        git -C "$gitdir" merge-base --is-ancestor "$target" "origin/$default" \
+            || { echo "FAIL $repo: merge commit $target is not on origin/$default"; return 1; }
+    else
+        echo "no bump PR for this repo (${cls}) — tagging the committed version directly"
+        target=$(host_remote_tip "$repo" "$default" < /dev/null) \
+            || { echo "FAIL $repo: cannot read remote tip"; return 1; }
+        for i in 1 2 3 4 5; do
+            fr_fetch_branches "$gitdir" > /dev/null
+            [[ "$(git -C "$gitdir" rev-parse "origin/$default")" == "$target" ]] && break
+            [[ "$i" -lt 5 ]] && sleep "$FR_POLL_SECONDS"
+        done
+        [[ "$(git -C "$gitdir" rev-parse "origin/$default")" == "$target" ]] \
+            || { echo "FAIL $repo: origin/$default never reached the remote tip $target"; return 1; }
+        # Freshness: the sweep's approval covered the SURVEYED tip. Commits
+        # since then are acceptable only if they touch nothing but the version
+        # surfaces (i.e. the bump itself landed in between) — anything else on
+        # the branch was never surveyed and must not ride into this tag.
+        if [[ -n "$head" && "$target" != "$head" ]]; then
+            local drift
+            if ! drift=$(git -C "$gitdir" diff --name-only "$head" "$target" 2> /dev/null); then
+                echo "FAIL $repo: surveyed head $head is unknown here (force-push?) — re-run survey"
+                return 1
+            fi
+            drift=$(grep -vE "$FR_ALLOWLIST_RE" <<< "$drift" || true)
+            if [[ -n "$drift" ]]; then
+                echo "FAIL $repo: $default moved past the surveyed head with non-bump changes ($(tr '\n' ' ' <<< "$drift")) — re-run survey and re-plan"
+                return 1
+            fi
+            echo "tip moved past the surveyed head by version-surface changes only — acceptable"
+        elif [[ -z "$head" ]]; then
+            echo "WARN: plan row carries no surveyed head — tagging the current tip unverified against the survey"
+        fi
+    fi
+
+    fr_parity_from_ref "$gitdir" "$target" "$version" \
+        || { echo "FAIL $repo: version parity at $target"; return 1; }
+    echo "parity OK ($version at $target)"
+
+    fr_tag_on_tip "$gitdir" "$tag" "$target" || { echo "FAIL $repo: tag"; return 1; }
+
+    # Past this point a failure means the tag is on the remote but the release
+    # machinery did not produce a verified Release object — that class is
+    # contagious (a broken shared workflow breaks every following repo too).
+    host_release_verify "$repo" "$tag" < /dev/null \
+        || { echo "FAIL $repo: no verified Release for $tag (post-tag — halting the sweep)"; return 2; }
+
+    fr_cleanup_release_branch "$dir" "$gitdir" "$branch" "$version" "$prid"
+    echo "OK $repo $tag released"
+}
+
+fr_cleanup_release_branch() { # DIR GITDIR BRANCH VERSION PRID — tolerant;
+    # the REMOTE branch is deleted only when this sweep owns a PR for it —
+    # deleting a branch the sweep never created is not cleanup, it is damage
+    local dir="$1" gitdir="$2" branch="$3" version="$4" prid="$5" wt
+    wt=$(fr_worktree_path "$dir" "$version")
+    if [[ -e "$wt" ]]; then
+        git -C "$gitdir" worktree remove "$wt" 2> /dev/null && echo "worktree removed"
+    fi
+    git -C "$gitdir" branch -D "$branch" > /dev/null 2>&1 || true
+    if [[ -n "$prid" ]]; then
+        git -C "$gitdir" push origin --delete "$branch" 2> /dev/null \
+            && echo "remote branch deleted" || echo "remote branch already gone"
+    fi
+}
+
+fr_finish() { # PLAN [--continue]
+    local plan="$1" cont="${2:-}" logdir="$FR_WORKDIR/logs/finish" row repo n=0 rc=0 ec
+    fr_plan_validate "$plan"
+    find "$logdir" -maxdepth 1 -name '*.log' -delete 2> /dev/null || true
+    while IFS= read -u 3 -r row || [[ -n "$row" ]]; do
+        [[ -n "$row" ]] || continue
+        repo=$(jq -r '.repo' <<< "$row")
+        n=$((n + 1))
+        fr_note "finish: $repo ..."
+        ec=0
+        # Tested context on purpose: it suppresses errexit inside the subshell
+        # so the explicit FAIL/return handling governs, not set -e.
+        ( fr_finish_one "$row" ) > "$logdir/$repo.log" 2>&1 || ec=$?
+        tail -1 "$logdir/$repo.log" 2> /dev/null || rc=1
+        if [[ "$ec" -eq 2 && "$cont" != "--continue" ]]; then
+            rc=1
+            fr_err "post-tag failure in $repo — halting (release-discipline: halt all further releases if one fails). Diagnose, then re-run finish; --continue overrides."
+            break
+        fi
+        [[ "$ec" -eq 0 ]] || rc=1
+    done 3< "$plan"
+    fr_summarize_logs "$logdir" || rc=1
+    fr_note ""
+    fr_note "logs: $logdir"
+    return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Repo-list resolution
+# ---------------------------------------------------------------------------
+fr_repos_from() { # REPOS_INLINE REPOS_FILE DEFAULT_FILE — echoes the list;
+    # '#' comment lines and blanks in files are skipped
+    local inline="$1" file="$2" fallback="$3"
+    if [[ -n "$inline" ]]; then
+        printf '%s\n' "$inline" | tr ' ' '\n' | grep -v '^$' || true
+    elif [[ -n "$file" ]]; then
+        grep -vE '^\s*(#|$)' "$file" || true
+    elif [[ -f "$fallback" ]]; then
+        grep -vE '^\s*(#|$)' "$fallback" || true
+    fi
+}

--- a/skills/skill-repo/scripts/fleet-release-github.sh
+++ b/skills/skill-repo/scripts/fleet-release-github.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+#
+# fleet-release-github.sh — fleet release driver for the PUBLIC GitHub skill
+# repos (github.com/<org>, default netresearch).
+#
+# Mechanizes references/release-discipline.md so a sweep stops hand-writing
+# driver scripts and re-earning their bugs (issue #218). Fleets on other hosts
+# ship their own driver in their own (private) infrastructure — the API shapes
+# differ enough that one script serving several hosts is how jq filters
+# silently return empty. Everything host-independent lives in
+# fleet-release-common.sh; a foreign-host driver vendors that engine and
+# defines the host_* callbacks documented in its header.
+#
+# Usage:
+#   fleet-release-github.sh survey   --workdir DIR [--repos "r1 r2"|--repos-file F] [--org ORG]
+#   fleet-release-github.sh manifest --workdir DIR
+#   fleet-release-github.sh bump     --workdir DIR [--plan F]
+#   fleet-release-github.sh finish   --workdir DIR [--plan F] [--continue]
+#
+# Flow: survey (read-only API) -> manifest (offline classification; STOPS for
+# human approval) -> bump (worktree, bump-version.sh, changelog roll, PR,
+# auto-merge arm) -> finish (merge gate, parity from origin/<default>, signed
+# tag on the remote tip, Release verification, cleanup). Re-running any phase
+# is resumable: remote reality, not local state, decides what is left to do.
+#
+# The driver never merges a PR this sweep did not open, never unarchives,
+# never clones, never invents versions or PR bodies, never touches CI files,
+# and only releases the default-branch tip.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=fleet-release-common.sh
+# shellcheck disable=SC1091  # resolved at runtime relative to this script
+source "$SCRIPT_DIR/fleet-release-common.sh"
+
+FR_HOST=github
+# shellcheck disable=SC2034  # consumed by the sourced engine's epilogues
+FR_DRIVER="$0"
+FR_ORG="${FR_ORG:-netresearch}"
+
+usage() {
+    sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-1}"
+}
+
+# ---------------------------------------------------------------------------
+# Host callbacks (see the contract in fleet-release-common.sh)
+# ---------------------------------------------------------------------------
+host_display() { echo "$FR_ORG/$1"; }
+host_origin_suffix() { echo "github.com/$FR_ORG/$1"; }
+
+host_remote_tip() { # REPO BRANCH
+    gh api "repos/$FR_ORG/$1/commits/$2" --jq .sha
+}
+
+gh_json() { # ARGS... — gh api that NEVER leaks an HTTP error body as data:
+    # on 403/404/5xx gh prints the JSON error to STDOUT (verified with gh
+    # 2.97), so every `$(gh api ... || echo "")` capture is poisoned. Output
+    # only reaches the caller when the call succeeded.
+    local out
+    if out=$(gh api "$@" 2> /dev/null); then
+        printf '%s\n' "$out"
+        return 0
+    fi
+    return 1
+}
+
+host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
+    local r="$1" meta resolved archived def
+    meta=$(gh_json "repos/$FR_ORG/$r") || return 1
+    resolved=$(jq -r '.full_name' <<< "$meta")
+    archived=$(jq -r '.archived' <<< "$meta")
+    def=$(jq -r '.default_branch' <<< "$meta")
+
+    local head
+    head=$(gh_json "repos/$FR_ORG/$r/commits/$def" | jq -r '.sha // empty' || echo "")
+
+    local rel last_tag tags
+    rel=$(gh_json "repos/$FR_ORG/$r/releases/latest" | jq -r '.tag_name // empty' || echo "")
+    # releases/latest 404s for never-released AND for tag-without-Release repos
+    # (a release workflow that ran and died). The tags list tells them apart —
+    # and it is NOT date-ordered, so pick the max by version, never .[0].
+    # --paginate: one page would hide the newest tag of a >100-tag repo.
+    tags=$(gh api --paginate "repos/$FR_ORG/$r/tags?per_page=100" 2> /dev/null \
+        | jq -s '[.[][]]' || echo '[]')
+    last_tag=$(jq -r "$FR_JQ_VPARSE"' map(.name) | max_by(vparse) // empty' <<< "$tags")
+
+    local rootv cpv composer_has_version release_gate
+    rootv=$(gh_json -H "Accept: application/vnd.github.raw" \
+        "repos/$FR_ORG/$r/contents/plugin.json?ref=$def" \
+        | jq -r '.version // empty' 2> /dev/null || echo "")
+    cpv=$(gh_json -H "Accept: application/vnd.github.raw" \
+        "repos/$FR_ORG/$r/contents/.claude-plugin/plugin.json?ref=$def" \
+        | jq -r '.version // empty' 2> /dev/null || echo "")
+    # bump-version.sh refuses a composer version field mid-bump with a
+    # half-written tree — surface it as a manifest row instead.
+    if gh_json -H "Accept: application/vnd.github.raw" \
+        "repos/$FR_ORG/$r/contents/composer.json?ref=$def" \
+        | jq -e 'has("version")' > /dev/null 2>&1; then
+        composer_has_version=true
+    else
+        composer_has_version=false
+    fi
+    if gh_json "repos/$FR_ORG/$r/contents/.github/workflows/release.yml?ref=$def" \
+        > /dev/null; then
+        release_gate=true
+    else
+        release_gate=false
+    fi
+
+    # Measured CI state of the default branch — the manifest's precondition
+    # column must show a value, never an assumed checkmark.
+    local ci_status
+    ci_status=$(gh_json "repos/$FR_ORG/$r/commits/$def/check-runs?per_page=100" \
+        | jq -r '[.check_runs[]] as $r
+            | ([$r[] | select(.status != "completed")] | length) as $pending
+            | ([$r[] | select(.status == "completed"
+                and (.conclusion | IN("success","skipped","neutral") | not)) | .name]) as $failed
+            | if ($r | length) == 0 then "none"
+              elif .total_count > 100 then "truncated(\(.total_count) runs)"
+              elif ($failed | length) > 0 then "failed: " + ($failed | join(","))
+              elif $pending > 0 then "pending(\($pending))"
+              else "success" end' 2> /dev/null || echo "unknown")
+
+    # --limit 100: the default of 30 would let a foreign release PR beyond the
+    # first page slip past the BLOCKED-FOREIGN-PR gate.
+    local prs
+    prs=$(gh pr list --repo "$FR_ORG/$r" --state open --limit 100 \
+        --json number,title,author,headRefName,url 2> /dev/null \
+        | jq '[.[] | select((.headRefName | startswith("release/"))
+                        or (.title | startswith("chore(release)"))
+                        or (.title | startswith("chore: release")))
+               | {id: (.number | tostring), url, author: .author.login,
+                  branch: .headRefName, title}]' || echo '[]')
+
+    local base ahead=-1 nonci=-1 subjects='[]' files='[]' files_truncated=false cmp
+    base="$rel"
+    [[ -n "$base" ]] || base="$last_tag"
+    if [[ -z "$base" ]]; then
+        ahead=0   # first release: there is no base, and -1 must mean only
+        nonci=0   # "measurement FAILED" (SURVEY-INCOMPLETE), never "no base"
+    else
+        # compare runs for archived repos too: the unarchive decision needs to
+        # see whether anything (e.g. a deprecation banner) is unshipped.
+        # A FAILED call keeps the -1 sentinel -> SURVEY-INCOMPLETE, because a
+        # transient 403 must never read as "no delta".
+        cmp=$(gh_json "repos/$FR_ORG/$r/compare/$base...$def" || echo "")
+        if [[ -n "$cmp" ]]; then
+            ahead=$(jq -r '.ahead_by // 0' <<< "$cmp")
+            nonci=$(jq --arg f "$FR_CI_ONLY_RE" \
+                '[.files[].filename] | map(select(test($f) | not)) | length' <<< "$cmp" 2> /dev/null || echo -1)
+            subjects=$(jq '[.commits[].commit.message | split("\n")[0]]' <<< "$cmp" 2> /dev/null || echo '[]')
+            files=$(jq --arg f "$FR_CI_ONLY_RE" \
+                '[.files[].filename | select(test($f) | not)]' <<< "$cmp" 2> /dev/null || echo '[]')
+            # the compare API caps .files at 300 — 0-vs-nonzero stays valid,
+            # the file list itself may be partial
+            [[ "$(jq '.files | length' <<< "$cmp")" -ge 300 ]] && files_truncated=true
+        fi
+    fi
+
+    jq -nc \
+        --arg host "$FR_HOST" --arg repo "$r" --arg resolved "$resolved" \
+        --arg def "$def" --arg head "$head" --argjson archived "$archived" \
+        --arg rel "$rel" --arg last_tag "$last_tag" \
+        --arg rootv "$rootv" --arg cpv "$cpv" \
+        --argjson chv "$composer_has_version" --argjson gate "$release_gate" \
+        --arg ci "$ci_status" --argjson ahead "$ahead" --argjson nonci "$nonci" \
+        --argjson subjects "$subjects" --argjson files "$files" \
+        --argjson trunc "$files_truncated" --argjson prs "$prs" \
+        '{host: $host, repo: $repo, resolved: $resolved, default: $def, head: $head,
+          archived: $archived, empty: false, unreachable: false, duplicate_of: "",
+          last_release: $rel, last_tag: $last_tag,
+          root_plugin: $rootv, claude_plugin: $cpv,
+          composer_has_version: $chv, release_gate: $gate, ci_status: $ci,
+          ahead: $ahead, nonci: $nonci, files_truncated: $trunc,
+          subjects: $subjects, files: $files,
+          open_release_prs: $prs, ci_tag_rules: "", notes: ""}'
+}
+
+host_create_pr() { # REPO BRANCH TITLE BODY TARGET -> "<number> <url>"
+    local r="$1" branch="$2" title="$3" body="$4" target="$5" url num
+    url=$(gh pr create --repo "$FR_ORG/$r" --head "$branch" --base "$target" \
+        --title "$title" --body "$body") || return 1
+    num=$(gh pr view "$branch" --repo "$FR_ORG/$r" --json number --jq .number) || return 1
+    echo "$num $url"
+}
+
+host_find_release_pr() { # REPO BRANCH -> "<number> <url> <state> <author>"
+    gh pr list --repo "$FR_ORG/$1" --head "$2" --state all \
+        --json number,url,state,author --limit 1 \
+        --jq '.[0] | select(. != null)
+              | "\(.number) \(.url) \(.state | ascii_downcase) \(.author.login)"'
+}
+
+host_arm_automerge() { # REPO NUMBER
+    if gh pr merge --auto --merge "$2" --repo "$FR_ORG/$1" 2>&1; then
+        echo "auto-merge armed"
+    else
+        echo "auto-merge not armed (finish will merge plainly when green)"
+    fi
+}
+
+host_merge_gate() { # REPO NUMBER — completion-first: a QUEUED check reports
+    # conclusion "" (not null) and must read as pending, never as failure
+    local r="$1" num="$2" deadline j state mss failed pending automerge merr
+    deadline=$(($(date +%s) + FR_MERGE_TIMEOUT))
+    while true; do
+        j=$(gh pr view "$num" --repo "$FR_ORG/$r" \
+            --json state,mergeStateStatus,statusCheckRollup,autoMergeRequest 2> /dev/null) || j=""
+        if [[ -z "$j" ]]; then
+            echo "cannot read PR #$num"
+            return 1
+        fi
+        state=$(jq -r '.state' <<< "$j")
+        [[ "$state" == "MERGED" ]] && return 0
+        if [[ "$state" == "CLOSED" ]]; then
+            echo "PR #$num was closed without merge"
+            return 1
+        fi
+        mss=$(jq -r '.mergeStateStatus // "UNKNOWN"' <<< "$j")
+        failed=$(jq '[.statusCheckRollup[]
+            | select(.__typename == "CheckRun" and .status == "COMPLETED"
+                and (.conclusion | IN("SUCCESS","SKIPPED","NEUTRAL") | not))
+            | .name]
+            + [.statusCheckRollup[]
+            | select(.__typename == "StatusContext"
+                and (.state | IN("SUCCESS","PENDING","EXPECTED") | not))
+            | .context]' <<< "$j")
+        if [[ "$(jq length <<< "$failed")" -gt 0 ]]; then
+            echo "red checks on PR #$num: $(jq -c . <<< "$failed") — PR left open"
+            return 1
+        fi
+        pending=$(jq '[.statusCheckRollup[]
+            | select((.__typename == "CheckRun" and .status != "COMPLETED")
+                  or (.__typename == "StatusContext" and (.state | IN("PENDING","EXPECTED"))))]
+            | length' <<< "$j")
+        automerge=$(jq -r '.autoMergeRequest // empty | tostring' <<< "$j")
+        echo "poll: state=$state mergeState=$mss pending=$pending automerge=${automerge:+armed}${automerge:-no}"
+        # Merge plainly ONLY on GitHub's own CLEAN verdict — an empty or
+        # not-yet-reported rollup is NOT green (queued workflows are invisible
+        # to the rollup; pending==0 never meant "all reported").
+        if [[ "$mss" == "CLEAN" && -z "$automerge" ]] \
+            && ! merr=$(gh pr merge --merge "$num" --repo "$FR_ORG/$r" 2>&1); then
+            echo "$merr"
+            case "$merr" in
+                *"not allowed"*|*"protected branch"*)
+                    echo "merge method rejected for PR #$num — needs a human (merge it per repo policy)"
+                    return 1
+                    ;;
+                *) : ;;
+            esac
+        fi
+        if [[ "$(date +%s)" -ge "$deadline" ]]; then
+            echo "TIMEOUT waiting for PR #$num to merge (state=$state mergeState=$mss pending=$pending)"
+            return 1
+        fi
+        sleep "$FR_POLL_SECONDS"
+    done
+}
+
+host_merge_commit() { # REPO NUMBER — the SHA the merged PR produced
+    gh pr view "$2" --repo "$FR_ORG/$1" --json mergeCommit \
+        --jq '.mergeCommit.oid // empty'
+}
+
+host_release_verify() { # REPO TAG — a pushed tag is not a release; assert the
+    # Release object and its assets, then link it
+    local r="$1" tag="$2" deadline rel assets
+    deadline=$(($(date +%s) + FR_RELEASE_TIMEOUT))
+    while true; do
+        rel=$(gh api "repos/$FR_ORG/$r/releases/tags/$tag" 2> /dev/null || echo "")
+        if [[ -n "$rel" ]]; then
+            assets=$(jq '[.assets[].name] | length' <<< "$rel")
+            if [[ "$assets" -gt 0 ]]; then
+                echo "RELEASE: $(jq -r '.html_url' <<< "$rel") assets: $(jq -c '[.assets[].name]' <<< "$rel")"
+                return 0
+            fi
+        fi
+        if [[ "$(date +%s)" -ge "$deadline" ]]; then
+            echo "no Release with assets for $tag — last workflow runs:"
+            gh run list --repo "$FR_ORG/$r" --limit 3 2>&1 || true
+            return 1
+        fi
+        sleep "$FR_POLL_SECONDS"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+[[ $# -ge 1 ]] || usage
+CMD="$1"
+shift
+case "$CMD" in -h|--help) usage 0 ;; esac
+REPOS_INLINE=""
+REPOS_FILE=""
+PLAN=""
+CONTINUE=""
+FR_WORKDIR=""
+# shellcheck disable=SC2034  # FR_BASE_DIR is read by the sourced engine
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --workdir)    FR_WORKDIR="${2:?}"; shift 2 ;;
+        --repos)      REPOS_INLINE="${2:?}"; shift 2 ;;
+        --repos-file) REPOS_FILE="${2:?}"; shift 2 ;;
+        --org)        FR_ORG="${2:?}"; shift 2 ;;
+        --plan)       PLAN="${2:?}"; shift 2 ;;
+        --base-dir)   FR_BASE_DIR="${2:?}"; shift 2 ;;
+        --continue)   CONTINUE="--continue"; shift ;;
+        -h|--help)    usage 0 ;;
+        *)            fr_err "unknown option: $1"; usage ;;
+    esac
+done
+[[ -n "$FR_WORKDIR" ]] || { fr_err "--workdir is required"; usage; }
+mkdir -p "$FR_WORKDIR"
+PLAN="${PLAN:-$FR_WORKDIR/plan.jsonl}"
+
+case "$CMD" in
+    survey)
+        fr_preflight survey gh
+        REPOS=$(fr_repos_from "$REPOS_INLINE" "$REPOS_FILE" "$SCRIPT_DIR/fleet-repos-github.txt")
+        [[ -n "$REPOS" ]] || fr_die "no repos: pass --repos/--repos-file or ship fleet-repos-github.txt"
+        # shellcheck disable=SC2086  # word splitting is the point
+        fr_survey $REPOS
+        ;;
+    manifest)
+        FR_SELF_LOGIN="${FR_SELF_LOGIN:-$(gh api user --jq .login)}"
+        fr_preflight manifest gh
+        fr_manifest
+        ;;
+    bump)
+        FR_SELF_LOGIN="${FR_SELF_LOGIN:-$(gh api user --jq .login)}"
+        fr_preflight bump gh
+        fr_bump "$PLAN"
+        ;;
+    finish)
+        FR_SELF_LOGIN="${FR_SELF_LOGIN:-$(gh api user --jq .login)}"
+        fr_preflight finish gh
+        fr_finish "$PLAN" "$CONTINUE"
+        ;;
+    *)
+        fr_err "unknown subcommand: $CMD"
+        usage
+        ;;
+esac

--- a/skills/skill-repo/scripts/fleet-repos-github.txt
+++ b/skills/skill-repo/scripts/fleet-repos-github.txt
@@ -1,0 +1,53 @@
+# Default repo list for fleet-release-github.sh survey (--repos/--repos-file
+# override it). One repo per line, org-relative; '#' and blank lines ignored.
+#
+# Snapshot of the public GitHub skill fleet as of the 2026-08-13 sweep.
+# Naming conventions do NOT enumerate this fleet (plugins and oddly-named
+# repos exist), so the list is maintained here — reviewable, and cheap to
+# refresh:
+#   gh repo list netresearch --limit 300 --no-archived \
+#     --json name --jq '.[].name' | grep -E -- '-(skill|plugin)$' | sort
+# The survey dedupes rename redirects by resolved full_name, so a stale name
+# here becomes a DUPLICATE row, never a second bump PR.
+agent-harness-skill
+agent-rules-skill
+agents-skill
+automated-assessment-skill
+claude-coach-skill
+cli-tools-skill
+concourse-ci-skill
+context7-skill
+data-tools-skill
+docker-development-skill
+enterprise-readiness-skill
+file-search-skill
+german-technical-writing-skill
+git-workflow-skill
+github-project-skill
+github-release-skill
+go-development-skill
+jira-skill
+jujutsu-workflow-skill
+markdown-to-pdf-skill
+matrix-skill
+netresearch-branding-skill
+orocommerce-skill
+pagerangers-skill
+peer-qa-review-skill
+php-modernization-skill
+retro-skill
+security-audit-skill
+skill-repo-skill
+typo3-a11y-skill
+typo3-ckeditor5-skill
+typo3-conformance-skill
+typo3-core-contributions-skill
+typo3-ddev-skill
+typo3-docs-skill
+typo3-extension-upgrade-skill
+typo3-project-upgrade-skill
+typo3-site-conformance-skill
+typo3-testing-skill
+typo3-typoscript-ref-skill
+typo3-upgrade-effort-model-skill
+typo3-vite-skill

--- a/skills/skill-repo/scripts/roll-changelog.py
+++ b/skills/skill-repo/scripts/roll-changelog.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""roll-changelog.py — move the [Unreleased] section of a CHANGELOG.md under a
+new released heading, reproducing the repo's own heading shape.
+
+Usage:
+    roll-changelog.py FILE VERSION [--date YYYY-MM-DD] [--dry-run]
+
+Why this exists (references/release-discipline.md, "Changelog Rollover"):
+five released-heading shapes coexist in the fleet, and a roll anchored on one
+shape matches nothing in the others and exits 0 — the release then ships with
+its content still under Unreleased and nobody sees an error. This script
+detects the shape from the newest *released* heading and reproduces it,
+including the dash character and, for the linked form, the tag inside the URL.
+
+Shapes:
+    bracketed dash      ## [1.2.3] - 2026-08-08
+    bare paren          ## 1.2.3 (2026-08-08)
+    bracketed em dash   ## [0.3.23] — 2026-07-02
+    linked              ## [v2.6.0](https://.../releases/tag/v2.6.0) — 2026-02-28
+    none yet            first release: default to the keep-a-changelog
+                        bracketed-dash form the [Unreleased] bracket implies
+
+Guards:
+    * exactly one Unreleased heading outside code fences, or abort;
+    * the Unreleased section must have content — rolling nothing is an error,
+      never a silent success;
+    * heading-looking lines inside fenced code blocks are ignored (a ^##
+      anchored scan is fence-blind and splices sections into examples);
+    * output keeps a blank line after each heading so the rolled file stays
+      markdownlint-clean (MD022/MD032 red-lit 16 of 63 repos mid-sweep once).
+
+Exit codes: 0 = rolled (or clean --dry-run), 1 = refused; the file is never
+partially written (temp file + atomic replace).
+"""
+
+import argparse
+import datetime
+import os
+import re
+import sys
+import tempfile
+
+UNRELEASED_RE = re.compile(r"^##\s+\[?unreleased\]?\s*$", re.IGNORECASE)
+FENCE_RE = re.compile(r"^ {0,3}(```|~~~)")
+# Newest released heading, one regex per shape. Order matters: the linked form
+# also starts with "## [" and must win over plain bracketed.
+LINKED_RE = re.compile(
+    r"^##\s+\[(?P<tag>[^\]]+)\]\((?P<url>[^)]+)\)\s+(?P<dash>[-—–])\s+(?P<date>.+?)\s*$"
+)
+BRACKETED_RE = re.compile(
+    r"^##\s+\[(?P<tag>[^\]]+)\]\s+(?P<dash>[-—–])\s+(?P<date>.+?)\s*$"
+)
+BARE_PAREN_RE = re.compile(r"^##\s+(?P<tag>\S+)\s+\((?P<date>[^)]+)\)\s*$")
+
+
+def fail(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def scan(lines):
+    """Yield (index, line, in_fence) tracking fenced code blocks."""
+    fence = None
+    for i, line in enumerate(lines):
+        m = FENCE_RE.match(line)
+        if m:
+            marker = m.group(1)
+            if fence is None:
+                fence = marker
+            elif fence == marker:
+                fence = None
+            yield i, line, True
+            continue
+        yield i, line, fence is not None
+
+
+def released_heading(version: str, sample: str, date: str) -> str:
+    """Reproduce the shape of `sample` (a released heading) for `version`."""
+    m = LINKED_RE.match(sample)
+    if m:
+        old_tag = m.group("tag")
+        new_tag = f"v{version}" if old_tag.startswith("v") else version
+        url = m.group("url")
+        if old_tag not in url:
+            fail(
+                f"linked heading URL does not contain its own tag "
+                f"('{old_tag}' not in '{url}') — refusing to guess the rewrite"
+            )
+        new_url = url.replace(old_tag, new_tag)
+        return f"## [{new_tag}]({new_url}) {m.group('dash')} {date}"
+    m = BRACKETED_RE.match(sample)
+    if m:
+        old_tag = m.group("tag")
+        new_tag = f"v{version}" if old_tag.startswith("v") else version
+        return f"## [{new_tag}] {m.group('dash')} {date}"
+    m = BARE_PAREN_RE.match(sample)
+    if m:
+        old_tag = m.group("tag")
+        new_tag = f"v{version}" if old_tag.startswith("v") else version
+        return f"## {new_tag} ({date})"
+    fail(f"unrecognized released-heading shape: '{sample.rstrip()}'")
+    raise AssertionError  # unreachable; fail() exits
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Roll the [Unreleased] CHANGELOG section into a release."
+    )
+    parser.add_argument("file", help="path to CHANGELOG.md")
+    parser.add_argument("version", help="release version (leading v stripped)")
+    parser.add_argument(
+        "--date",
+        default=datetime.datetime.now(datetime.timezone.utc)
+        .astimezone()
+        .date()
+        .isoformat(),
+        help="release date (default: today, ISO 8601)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the new heading and moved-section size, write nothing",
+    )
+    args = parser.parse_args()
+    args.version = args.version.lstrip("v")
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", args.version):
+        fail(f"'{args.version}' is not a semantic version")
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", args.date):
+        fail(f"--date '{args.date}' is not YYYY-MM-DD")
+    return args
+
+
+def read_changelog(path):
+    """Return (lines, eol, trailing_newline), preserving the file's own line
+    endings — rewriting a CRLF changelog wholesale to LF buries the roll in a
+    whole-file diff."""
+    try:
+        with open(path, encoding="utf-8", newline="") as fh:
+            text = fh.read()
+    except OSError as exc:
+        fail(str(exc))
+    eol = "\r\n" if text.count("\r\n") > text.count("\n") - text.count("\r\n") else "\n"
+    return (
+        text.replace("\r\n", "\n").splitlines(),
+        eol,
+        text.endswith(("\n", "\r\n")),
+    )
+
+
+def locate_headings(lines):
+    """Return (unreleased_index, first_released) or refuse: exactly one
+    Unreleased heading outside code fences, and no released heading above it."""
+    unreleased_at = []
+    first_released = None  # (index, line)
+    for i, line, in_fence in scan(lines):
+        if in_fence:
+            continue
+        if UNRELEASED_RE.match(line):
+            unreleased_at.append(i)
+        elif first_released is None and line.startswith("## "):
+            first_released = (i, line)
+    if len(unreleased_at) != 1:
+        fail(
+            f"{len(unreleased_at)} Unreleased headings outside code fences "
+            f"(need exactly 1)"
+        )
+    idx = unreleased_at[0]
+    if first_released is not None and first_released[0] < idx:
+        fail(
+            f"a released heading (line {first_released[0] + 1}) precedes the "
+            f"Unreleased heading (line {idx + 1}) — refusing to roll a "
+            f"non-standard layout"
+        )
+    return idx, first_released
+
+
+def splice_roll(lines, idx, end, new_heading):
+    """Return (new_lines, moved_count): the Unreleased heading stays as found,
+    one blank line, the new released heading, one blank line, then the old
+    section content — blank-line hygiene keeps markdownlint green."""
+    content = lines[idx + 1 : end]
+    while content and not content[0].strip():
+        content.pop(0)
+    # Exactly one blank line between the moved content and the next heading.
+    while content and not content[-1].strip():
+        content.pop()
+    tail = lines[end:]
+    new_lines = lines[:idx] + [lines[idx], "", new_heading, ""] + content
+    if tail:
+        new_lines += [""] + tail
+    return new_lines, len(content)
+
+
+def write_atomic(path, out):
+    directory = os.path.dirname(os.path.abspath(path))
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".roll-changelog.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(out)
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        os.unlink(tmp_path)
+        fail(str(exc))
+
+
+def main() -> None:
+    args = parse_args()
+    version = args.version
+    lines, eol, trailing_newline = read_changelog(args.file)
+    idx, first_released = locate_headings(lines)
+
+    if first_released is None:
+        # First release: no shape to copy. The [Unreleased] bracket implies
+        # keep-a-changelog, so default to its bracketed-dash form.
+        new_heading = f"## [{version}] - {args.date}"
+    else:
+        new_heading = released_heading(version, first_released[1], args.date)
+
+    # The section to be rolled must contain content — and HTML comments are
+    # not content: rolling a comment-only section would ship a visually empty
+    # release.
+    end = first_released[0] if first_released else len(lines)
+    section = "\n".join(lines[idx + 1 : end])
+    if not re.sub(r"<!--.*?-->", "", section, flags=re.DOTALL).strip():
+        fail(
+            "the Unreleased section is empty (comments are not content) — nothing to release"
+        )
+
+    new_lines, moved = splice_roll(lines, idx, end, new_heading)
+    if new_lines == lines:
+        fail("the roll changed no lines — refusing to report success")
+
+    defs_note = update_link_reference_definitions(new_lines, new_heading, version)
+
+    if args.dry_run:
+        print(f"would insert: {new_heading}")
+        print(f"would move: {moved} lines out of Unreleased")
+    else:
+        write_atomic(args.file, eol.join(new_lines) + (eol if trailing_newline else ""))
+        print(f"rolled Unreleased -> {new_heading}")
+    if defs_note:
+        print(defs_note)
+
+
+def update_link_reference_definitions(new_lines, new_heading, version):
+    """Keep-a-changelog ref-style links: `[Unreleased]: …/compare/vOLD...HEAD`
+    at the bottom, one definition per released heading. After a roll the
+    Unreleased range must restart at the new tag and the new heading needs its
+    own definition — otherwise the new release renders as a dead link and the
+    Unreleased diff keeps showing released commits. Mutates new_lines in
+    place; returns a note (updated/warning) or None when no definitions exist.
+    """
+    def_re = re.compile(r"^\[(?P<label>[Uu]nreleased)\]:\s*(?P<url>\S+)\s*$")
+    for i, line in enumerate(new_lines):
+        m = def_re.match(line)
+        if not m:
+            continue
+        url = m.group("url")
+        # Parsed from the right — a lazy .*? prefix before the version would
+        # backtrack super-linearly on crafted input. The range URL must end in
+        # <old-tag>...HEAD.
+        stem = url[: -len("...HEAD")] if url.endswith("...HEAD") else None
+        old_m = re.search(r"v?\d+\.\d+\.\d+$", stem) if stem else None
+        head_m = re.match(r"^##\s+\[(?P<label>[^\]]+)\]", new_heading)
+        if not old_m or not head_m:
+            return (
+                "WARNING: link-reference definitions found but not in the "
+                "known compare-range shape — update [Unreleased] and add "
+                f"[{version}] manually"
+            )
+        old = old_m.group(0)
+        new_tag = f"v{version}" if old.startswith("v") else version
+        base = stem[: old_m.start()]
+        new_lines[i] = f"[{m.group('label')}]: {base}{new_tag}...HEAD"
+        new_lines.insert(i + 1, f"[{head_m.group('label')}]: {base}{old}...{new_tag}")
+        return f"updated link-reference definitions ([Unreleased] -> {new_tag}...HEAD)"
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# tests/fleet-release.sh — exercises the fleet-release driver set:
+#   skills/skill-repo/scripts/fleet-release-common.sh   (shared engine)
+#   skills/skill-repo/scripts/fleet-release-github.sh   (public GitHub driver)
+#   skills/skill-repo/scripts/fleet-repos-github.txt    (default fleet list)
+#
+# Everything here is offline: classification, version ordering, parity from a
+# ref, tag idempotency, checkout-layout resolution, plan validation, the log
+# invariant — the logic classes that historically broke in hand-written sweep
+# drivers. Each guard tested HERE is observed to fail on a violating fixture,
+# not just to pass on a clean one. Scope limit, stated plainly: the network
+# phases (survey/bump/finish API calls, merge gates, Release polling) have no
+# offline test — they are exercised against live hosts before releases, and
+# their guards (freshness gate, foreign-PR stop, merge-commit anchoring) are
+# enforced by code review plus the read-only live runs, not by this file.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "$HERE/.." && pwd)/skills/skill-repo/scripts"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+export GIT_AUTHOR_NAME=test GIT_AUTHOR_EMAIL=test@example.invalid
+export GIT_COMMITTER_NAME=test GIT_COMMITTER_EMAIL=test@example.invalid
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+# The lib is sourced, not executed; give it a self identity for the author gate.
+# shellcheck disable=SC2034  # both are read by the sourced engine
+declare FR_SELF_LOGIN=sweep-bot FR_HOST=test
+FR_WORKDIR="$WORK/wd"
+mkdir -p "$FR_WORKDIR"
+# shellcheck source=../skills/skill-repo/scripts/fleet-release-common.sh
+# shellcheck disable=SC1091  # resolved at runtime relative to this test
+source "$SCRIPTS/fleet-release-common.sh"
+
+echo "fleet-release-common.sh"
+
+# --- version ordering: the 1.10.0 > 1.9.0 class -----------------------------
+check "vercmp 1.10.0 > 1.9.0 (never lexicographic)" 1 "$(fr_vercmp 1.10.0 1.9.0)"
+check "vercmp 1.9.0 < 1.10.0" -1 "$(fr_vercmp 1.9.0 1.10.0)"
+check "vercmp equal" 0 "$(fr_vercmp 1.2.3 1.2.3)"
+check "vercmp strips v prefix" 0 "$(fr_vercmp v1.2.3 1.2.3)"
+# Custom tag conventions order by their TRAILING semver — a parse that degrades
+# them all to zero made max_by pick an arbitrary old tag, and tender-estimation
+# (deliberate `<repo>--vX.Y.Z` convention) read as DIVERGED live on 2026-08-13.
+check "vercmp orders custom-prefixed tags by trailing semver" 1 \
+    "$(fr_vercmp tender-estimation--v0.7.0 tender-estimation--v0.6.1)"
+check "vercmp custom-prefixed tag equals its bare version" 0 \
+    "$(fr_vercmp tender-estimation--v0.7.0 0.7.0)"
+
+# --- checkout-layout resolution ----------------------------------------------
+mk_repo() { # DIR — a minimal committed repo
+    git init -q -b main "$1"
+    ( cd "$1" && echo x > f && git add f && git commit -q -m init )
+}
+mkdir -p "$WORK/layout-bare"
+git init -q --bare "$WORK/layout-bare/.bare"
+check "layout: dir/.bare wins" "$WORK/layout-bare/.bare" \
+    "$(fr_resolve_gitdir "$WORK/layout-bare")"
+mk_repo "$WORK/layout-plain"
+check "layout: plain repo at top level" yes \
+    "$(fr_resolve_gitdir "$WORK/layout-plain" > /dev/null && echo yes || echo no)"
+mkdir -p "$WORK/layout-nested"
+mk_repo "$WORK/layout-nested/main"
+check "layout: plain clone under main/" yes \
+    "$(fr_resolve_gitdir "$WORK/layout-nested" > /dev/null && echo yes || echo no)"
+check "layout: nothing there refused" no \
+    "$(fr_resolve_gitdir "$WORK/does-not-exist" > /dev/null 2>&1 && echo yes || echo no)"
+
+# --- origin verification: folder names lie -----------------------------------
+mk_repo "$WORK/origin-check"
+git -C "$WORK/origin-check" remote add origin git@github.com:acme/right-repo.git
+check "origin match (ssh form)" yes \
+    "$(fr_check_origin "$WORK/origin-check" "github.com/acme/right-repo" 2> /dev/null && echo yes || echo no)"
+git -C "$WORK/origin-check" remote set-url origin https://github.com/acme/right-repo.git
+check "origin match (https form)" yes \
+    "$(fr_check_origin "$WORK/origin-check" "github.com/acme/right-repo" 2> /dev/null && echo yes || echo no)"
+check "origin MISMATCH refused (would push to a foreign remote)" no \
+    "$(fr_check_origin "$WORK/origin-check" "github.com/acme/other-repo" 2> /dev/null && echo yes || echo no)"
+git -C "$WORK/origin-check" remote set-url origin "ssh://git@github.com:2222/acme/right-repo.git"
+check "origin match survives an explicit port" yes \
+    "$(fr_check_origin "$WORK/origin-check" "github.com/acme/right-repo" 2> /dev/null && echo yes || echo no)"
+git -C "$WORK/origin-check" remote set-url origin "https://evil.example/github.com/acme/right-repo.git"
+check "crafted path tail mimicking host/org/repo refused (exact match, not suffix)" no \
+    "$(fr_check_origin "$WORK/origin-check" "github.com/acme/right-repo" 2> /dev/null && echo yes || echo no)"
+
+# --- parity from a ref, never a working tree ---------------------------------
+mk_parity_repo() { # DIR VERSION [composer-version|-] [skill-version]
+    local d="$1" v="$2" cv="${3:--}" sv="${4:-$2}"
+    git init -q -b main "$d"
+    mkdir -p "$d/.claude-plugin" "$d/skills/demo"
+    printf '{"name":"demo","version":"%s"}\n' "$v" > "$d/plugin.json"
+    printf '{"name":"demo","version":"%s"}\n' "$v" > "$d/.claude-plugin/plugin.json"
+    if [ "$cv" = "-" ]; then
+        printf '{"name":"acme/demo"}\n' > "$d/composer.json"
+    else
+        printf '{"name":"acme/demo","version":"%s"}\n' "$cv" > "$d/composer.json"
+    fi
+    printf -- '---\nname: demo\ndescription: "Use when testing."\nmetadata:\n  version: "%s"\n---\n# Demo\n' \
+        "$sv" > "$d/skills/demo/SKILL.md"
+    ( cd "$d" && git add -A && git commit -q -m x )
+}
+mk_parity_repo "$WORK/parity-ok" 1.2.3
+check "parity: consistent tree passes" yes \
+    "$(fr_parity_from_ref "$WORK/parity-ok" HEAD 1.2.3 2> /dev/null && echo yes || echo no)"
+check "parity: wrong expected version refused" no \
+    "$(fr_parity_from_ref "$WORK/parity-ok" HEAD 1.2.4 2> /dev/null && echo yes || echo no)"
+mk_parity_repo "$WORK/parity-composer" 1.2.3 9.9.9
+check "parity: composer version field refused (TAG-ONLY path has no bump-version.sh to catch it)" no \
+    "$(fr_parity_from_ref "$WORK/parity-composer" HEAD 1.2.3 2> /dev/null && echo yes || echo no)"
+mk_parity_repo "$WORK/parity-skill" 1.2.3 - 1.0.0
+check "parity: stale SKILL.md frontmatter refused" no \
+    "$(fr_parity_from_ref "$WORK/parity-skill" HEAD 1.2.3 2> /dev/null && echo yes || echo no)"
+# A --- rule in the BODY must not reopen frontmatter parsing — a stray body
+# "version:" line would otherwise be read as the skill version.
+mk_parity_repo "$WORK/parity-body" 1.2.3
+printf -- '---\nname: demo\ndescription: "Use when testing."\nmetadata:\n  version: "1.2.3"\n---\n# Demo\n\n---\n\nExample config:\n\n    version: "9.9.9"\n' \
+    > "$WORK/parity-body/skills/demo/SKILL.md"
+( cd "$WORK/parity-body" && git add -A && git commit -q -m body )
+check "parity: a version: line after a body --- rule is ignored" yes \
+    "$(fr_parity_from_ref "$WORK/parity-body" HEAD 1.2.3 2> /dev/null && echo yes || echo no)"
+
+# --- tag idempotency: peeled refs, local-tag recovery ------------------------
+ORIGIN="$WORK/tag-origin"
+git init -q --bare "$ORIGIN"
+CLONE="$WORK/tag-clone"
+mk_repo "$CLONE"
+git -C "$CLONE" remote add origin "$ORIGIN"
+git -C "$CLONE" push -q origin main
+TIP=$(git -C "$CLONE" rev-parse HEAD)
+# An annotated (unsigned, like signed-minus-signature) tag already on the remote:
+git -C "$CLONE" tag -a v1.0.0 -m v1.0.0 "$TIP"
+git -C "$CLONE" push -q origin v1.0.0
+check "remote tag commit is the PEELED sha (annotated object != commit)" "$TIP" \
+    "$(fr_remote_tag_commit "$CLONE" v1.0.0)"
+check "tag already on remote at tip: skip, not re-tag" yes \
+    "$(fr_tag_on_tip "$CLONE" v1.0.0 "$TIP" > /dev/null 2>&1 && echo yes || echo no)"
+check "tag on remote at a DIFFERENT commit: refused (immutable)" no \
+    "$(fr_tag_on_tip "$CLONE" v1.0.0 0000000000000000000000000000000000000000 > /dev/null 2>&1 && echo yes || echo no)"
+# Crash window: local tag created, push never happened. Only the driver's own
+# SIGNED tag may be pushed — an unsigned annotated tag at the tip is somebody
+# else's work.
+git -C "$CLONE" tag -a v1.9.9 -m v1.9.9 "$TIP"
+check "local UNSIGNED tag at tip: refused" no \
+    "$(fr_tag_on_tip "$CLONE" v1.9.9 "$TIP" > /dev/null 2>&1 && echo yes || echo no)"
+check "…and it never reached the remote" "" "$(fr_remote_tag_commit "$CLONE" v1.9.9)"
+ssh-keygen -q -t ed25519 -N "" -f "$WORK/sigkey"
+git -C "$CLONE" config gpg.format ssh
+git -C "$CLONE" config user.signingkey "$WORK/sigkey"
+if git -C "$CLONE" tag -s v1.1.0 -m v1.1.0 "$TIP" 2> /dev/null; then
+    check "local SIGNED tag at tip (crashed before push): pushed, not re-created" yes \
+        "$(fr_tag_on_tip "$CLONE" v1.1.0 "$TIP" > /dev/null 2>&1 && echo yes || echo no)"
+    check "…and it arrived on the remote" "$TIP" "$(fr_remote_tag_commit "$CLONE" v1.1.0)"
+else
+    echo "  skip signed-tag recovery tests (ssh signing unavailable)"
+fi
+( cd "$CLONE" && echo y >> f && git add f && git commit -q -m second )
+TIP2=$(git -C "$CLONE" rev-parse HEAD)
+git -C "$CLONE" tag -a v1.2.0 -m v1.2.0 "$TIP"   # points at the OLD commit
+check "local tag at the wrong commit: refused with instructions" no \
+    "$(fr_tag_on_tip "$CLONE" v1.2.0 "$TIP2" > /dev/null 2>&1 && echo yes || echo no)"
+# "Cannot see the remote" must never read as "tag absent": a doomed duplicate
+# push would follow.
+mk_repo "$WORK/no-remote"
+git -C "$WORK/no-remote" remote add origin /nonexistent/nowhere.git
+rc2=0; fr_remote_tag_commit "$WORK/no-remote" v1.0.0 > /dev/null 2>&1 || rc2=$?
+check "unreadable remote reports rc=2, not 'tag absent'" 2 "$rc2"
+check "tag_on_tip refuses to tag blind on an unreadable remote" no \
+    "$(fr_tag_on_tip "$WORK/no-remote" v1.0.0 "$TIP" > /dev/null 2>&1 && echo yes || echo no)"
+
+# --- log invariant + summary markers -----------------------------------------
+LOGD="$WORK/logs"
+mkdir -p "$LOGD"
+printf 'stuff\nOK repo-a done\n' > "$LOGD/repo-a.log"
+printf 'stuff\nFAIL repo-b: boom\n' > "$LOGD/repo-b.log"
+printf 'started and then nothing\n' > "$LOGD/repo-c.log"
+check "log invariant holds at 3/3" yes \
+    "$(fr_check_log_invariant "$LOGD" 3 > /dev/null 2>&1 && echo yes || echo no)"
+check "log invariant catches a missing log (a killed batch 'completes')" no \
+    "$(fr_check_log_invariant "$LOGD" 4 > /dev/null 2>&1 && echo yes || echo no)"
+summary=$(fr_summarize_logs "$LOGD" 2> /dev/null; echo "rc=$?")
+check "summary counts ok/fail/indeterminate" yes \
+    "$(grep -q '1 ok, 1 failed, 1 indeterminate' <<< "$summary" && echo yes || echo no)"
+check "summary is nonzero when anything is not OK" yes \
+    "$(grep -q 'rc=1' <<< "$summary" && echo yes || echo no)"
+
+# --- classification: one shared implementation, every class ------------------
+row() { # KEY=VALUE... — build a survey row over sane defaults
+    local json='{"host":"test","repo":"r","resolved":"o/r","default":"main",
+      "archived":false,"empty":false,"unreachable":false,"duplicate_of":"",
+      "last_release":"v1.9.0","last_tag":"v1.9.0","root_plugin":"1.9.0",
+      "claude_plugin":"1.9.0","composer_has_version":false,"release_gate":true,
+      "ci_status":"success","ahead":3,"nonci":2,"files_truncated":false,
+      "subjects":[],"files":[],"open_release_prs":[],"ci_tag_rules":"","notes":""}'
+    jq -c "$1" <<< "$json"
+}
+check "classify: BUMP" BUMP "$(fr_classify "$(row '.')")"
+check "classify: SKIP-CI-ONLY (nonci=0)" SKIP-CI-ONLY "$(fr_classify "$(row '.nonci = 0')")"
+check "classify: UP-TO-DATE (ahead=0)" UP-TO-DATE "$(fr_classify "$(row '.ahead = 0')")"
+check "classify: TAG-ONLY needs NUMERIC compare (1.10.0 vs v1.9.0)" TAG-ONLY \
+    "$(fr_classify "$(row '.claude_plugin = "1.10.0" | .root_plugin = "1.10.0"')")"
+check "classify: BEHIND-TAG anomaly" BEHIND-TAG \
+    "$(fr_classify "$(row '.claude_plugin = "1.8.0"')")"
+check "classify: FIRST-RELEASE" FIRST-RELEASE \
+    "$(fr_classify "$(row '.last_release = "" | .last_tag = ""')")"
+check "classify: TAG-RELEASE-DIVERGED (tag without Release)" TAG-RELEASE-DIVERGED \
+    "$(fr_classify "$(row '.last_release = ""')")"
+check "classify: BLOCKED-COMPOSER-VERSION" BLOCKED-COMPOSER-VERSION \
+    "$(fr_classify "$(row '.composer_has_version = true')")"
+check "classify: BLOCKED-ARCHIVED" BLOCKED-ARCHIVED \
+    "$(fr_classify "$(row '.archived = true')")"
+check "classify: composer block outranks TAG-ONLY (blocks before actions)" BLOCKED-COMPOSER-VERSION \
+    "$(fr_classify "$(row '.composer_has_version = true | .claude_plugin = "1.10.0"')")"
+check "classify: NO-RELEASE-JOB" NO-RELEASE-JOB \
+    "$(fr_classify "$(row '.release_gate = false')")"
+check "classify: foreign release PR blocks (author gate)" BLOCKED-FOREIGN-PR \
+    "$(fr_classify "$(row '.open_release_prs = [{"id":"1","url":"u","author":"colleague","branch":"release/v2.0.0","title":"chore(release): v2.0.0"}]')")"
+check "classify: own open PR is its own class, not a block" OWN-PR-OPEN \
+    "$(fr_classify "$(row '.open_release_prs = [{"id":"1","url":"u","author":"sweep-bot","branch":"release/v2.0.0","title":"chore(release): v2.0.0"}]')")"
+check "classify: foreign outranks own when both exist" BLOCKED-FOREIGN-PR \
+    "$(fr_classify "$(row '.open_release_prs = [{"id":"1","url":"u","author":"sweep-bot","branch":"b","title":"t"},{"id":"2","url":"u2","author":"colleague","branch":"b2","title":"t2"}]')")"
+check "classify: DUPLICATE (rename redirect)" DUPLICATE \
+    "$(fr_classify '{"host":"test","repo":"old-name","duplicate_of":"o/new-name"}')"
+check "classify: UNREACHABLE" UNREACHABLE \
+    "$(fr_classify '{"host":"test","repo":"gone","unreachable":true}')"
+check "classify: EMPTY" EMPTY \
+    "$(fr_classify '{"host":"test","repo":"bare","resolved":"o/bare","empty":true}')"
+# A FAILED compare measurement (sentinel -1) must never read as "no delta" —
+# that silently drops a repo with releasable commits from the sweep.
+check "classify: failed compare is SURVEY-INCOMPLETE, never UP-TO-DATE" SURVEY-INCOMPLETE \
+    "$(fr_classify "$(row '.ahead = -1 | .nonci = -1')")"
+check "classify: failed nonci alone is SURVEY-INCOMPLETE too" SURVEY-INCOMPLETE \
+    "$(fr_classify "$(row '.nonci = -1')")"
+
+# --- plan validation refuses before anything mutates -------------------------
+PLAN="$WORK/plan.jsonl"
+printf '%s\n' '{"repo":"a","classification":"BUMP","version":"1.2.3","default":"main","last":"1.2.2"}' > "$PLAN"
+check "plan: complete row passes" yes \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' '{"repo":"b","classification":"BUMP","version":"","default":"main"}' >> "$PLAN"
+check "plan: empty version on a BUMP row refused" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' '{"repo":"c","classification":"BUMP","version":"1.2","default":"main"}' > "$PLAN"
+check "plan: non-semver version refused" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' \
+    '{"repo":"d","classification":"BUMP","version":"1.3.0","default":"main","last":"1.2.0"}' \
+    '{"repo":"d","classification":"BUMP","version":"1.4.0","default":"main","last":"1.2.0"}' > "$PLAN"
+check "plan: duplicate rows for one repo refused (two bump PRs otherwise)" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' '{"repo":"sub/group","classification":"BUMP","version":"1.3.0","default":"main","last":"1.2.0"}' > "$PLAN"
+check "plan: repo name with a slash refused (log/worktree paths would escape)" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+# Monotonicity: a plan below or equal to the surveyed version would ship a
+# parity-consistent version REGRESSION no later gate can detect.
+printf '%s\n' '{"repo":"e","classification":"BUMP","version":"1.2.0","default":"main","last":"1.10.0"}' > "$PLAN"
+check "plan: version below the surveyed one refused" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' '{"repo":"f","classification":"BUMP","version":"1.10.0","default":"main","last":"1.10.0"}' > "$PLAN"
+check "plan: version equal to the surveyed one refused" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' '{"repo":"g","classification":"TAG-ONLY","version":"1.4.0","default":"main","last":"1.3.0"}' > "$PLAN"
+check "plan: TAG-ONLY must tag exactly the committed version" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+printf '%s\n' '{"repo":"h","classification":"OWN-PR-OPEN","version":"","default":"main","last":"1.3.0"}' > "$PLAN"
+check "plan: OWN-PR-OPEN needs its version filled" no \
+    "$( (fr_plan_validate "$PLAN" > /dev/null 2>&1) && echo yes || echo no)"
+
+# --- opened.jsonl: the author-gate record ------------------------------------
+fr_record_opened repo-x 42 https://example.invalid/pr/42 release/v1.0.0
+check "opened.jsonl lookup finds the sweep's own PR" 42 "$(fr_opened_lookup repo-x)"
+check "opened.jsonl lookup is empty for unopened repos" "" "$(fr_opened_lookup repo-y)"
+check "opened.jsonl lookup is host-scoped (cross-host workdir reuse)" "" \
+    "$(FR_HOST=otherhost fr_opened_lookup repo-x)"
+
+# --- repo-list resolution ----------------------------------------------------
+printf '# comment\n\nrepo-one\nrepo-two\n' > "$WORK/repos.txt"
+check "repos: inline wins" "a b" "$(fr_repos_from "a b" "$WORK/repos.txt" /dev/null | tr '\n' ' ' | sed 's/ $//')"
+check "repos: file skips comments and blanks" "repo-one repo-two" \
+    "$(fr_repos_from "" "$WORK/repos.txt" /dev/null | tr '\n' ' ' | sed 's/ $//')"
+check "repos: fallback file" "repo-one repo-two" \
+    "$(fr_repos_from "" "" "$WORK/repos.txt" | tr '\n' ' ' | sed 's/ $//')"
+
+# --- survey merge-mode: a partial re-survey must not truncate the rest ------
+# (the manifest's own BLOCKED/SURVEY-INCOMPLETE advice is "re-run survey
+# --repos X" — losing every other row on that command defeats the repair)
+# shellcheck disable=SC2329  # invoked indirectly by the sourced fr_survey
+host_survey_repo() { jq -nc --arg r "$1" --arg g "${SURVEY_GEN:-1}" \
+    '{host: "test", repo: $r, resolved: ("o/" + $r), gen: $g}'; }
+# shellcheck disable=SC2329  # invoked indirectly by the sourced fr_survey
+host_display() { echo "test/$1"; }
+# shellcheck disable=SC2034  # read by the sourced engine's epilogue
+FR_DRIVER="test-driver"
+( fr_survey alpha beta gamma > /dev/null 2>&1 )
+check "survey writes one row per repo" 3 "$(wc -l < "$FR_WORKDIR/survey.jsonl" | tr -d ' ')"
+( SURVEY_GEN=2 fr_survey beta > /dev/null 2>&1 )
+check "partial re-survey keeps the other rows" 3 "$(wc -l < "$FR_WORKDIR/survey.jsonl" | tr -d ' ')"
+check "partial re-survey replaced the requested row" 2 \
+    "$(jq -r 'select(.repo == "beta") | .gen' "$FR_WORKDIR/survey.jsonl")"
+check "partial re-survey left the others at gen 1" "1 1" \
+    "$(jq -r 'select(.repo != "beta") | .gen' "$FR_WORKDIR/survey.jsonl" | tr '\n' ' ' | sed 's/ $//')"
+
+# --- the shipped fleet list is non-empty and comment-clean -------------------
+n=$(grep -cvE '^\s*(#|$)' "$SCRIPTS/fleet-repos-github.txt")
+check "fleet-repos-github.txt ships a non-empty list" yes \
+    "$([ "$n" -gt 10 ] && echo yes || echo no)"
+
+# --- driver surfaces ----------------------------------------------------------
+echo
+echo "fleet-release-github.sh (offline surface)"
+check "github driver: --help exits 0" 0 \
+    "$(bash "$SCRIPTS/fleet-release-github.sh" --help > /dev/null 2>&1; echo $?)"
+check "github driver: unknown subcommand refused" no \
+    "$(bash "$SCRIPTS/fleet-release-github.sh" frobnicate --workdir "$WORK/x" > /dev/null 2>&1 && echo yes || echo no)"
+check "github driver: missing --workdir refused" no \
+    "$(bash "$SCRIPTS/fleet-release-github.sh" survey > /dev/null 2>&1 && echo yes || echo no)"
+
+# manifest is a pure offline transform — golden-test it through the driver
+if command -v gh > /dev/null 2>&1; then
+    MWD="$WORK/manifest-wd"
+    mkdir -p "$MWD"
+    {
+        row '.repo = "bump-me" | .resolved = "o/bump-me" | .head = "abc123"'
+        row '.repo = "prepared" | .resolved = "o/prepared" | .claude_plugin = "1.10.0" | .root_plugin = "1.10.0"'
+        row '.repo = "ci-only" | .resolved = "o/ci-only" | .nonci = 0'
+        row '.repo = "foreign" | .resolved = "o/foreign" | .open_release_prs = [{"id":"7","url":"https://example.invalid/7","author":"colleague","branch":"release/v9.9.9","title":"chore(release): v9.9.9"}]'
+        row '.repo = "own-pr" | .resolved = "o/own-pr" | .open_release_prs = [{"id":"8","url":"https://example.invalid/8","author":"sweep-bot","branch":"release/v2.5.0","title":"chore(release): v2.5.0"}]'
+        row '.repo = "blipped" | .resolved = "o/blipped" | .ahead = -1 | .nonci = -1'
+        row '.repo = "ruled" | .resolved = "o/ruled" | .ci_tag_rules = "12: rules | if CI_COMMIT_TAG;30:release_job:"'
+    } > "$MWD/survey.jsonl"
+    out=$(FR_SELF_LOGIN=sweep-bot bash "$SCRIPTS/fleet-release-github.sh" manifest --workdir "$MWD" 2>&1)
+    check "manifest: runs offline on a fixture survey" yes \
+        "$([ -f "$MWD/manifest.md" ] && echo yes || echo no)"
+    check "manifest: BUMP row classified" yes \
+        "$(grep -q '| bump-me | BUMP |' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: prepared repo is TAG-ONLY (numeric compare)" yes \
+        "$(grep -q '| prepared | TAG-ONLY |' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: CI-only delta skipped" yes \
+        "$(grep -q '| ci-only | SKIP-CI-ONLY |' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: foreign PR blocked with author named" yes \
+        "$(grep -q '| foreign | BLOCKED-FOREIGN-PR |.*@colleague' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: skeleton prefills TAG-ONLY version" 1.10.0 \
+        "$(jq -r 'select(.repo == "prepared") | .version' "$MWD/plan.skeleton.jsonl")"
+    # Assert the row EXISTS before asserting its emptiness — an absent row also
+    # prints "" and would make this a vacuous check.
+    check "manifest: skeleton has a row for the BUMP repo" bump-me \
+        "$(jq -r 'select(.repo == "bump-me") | .repo' "$MWD/plan.skeleton.jsonl")"
+    check "manifest: skeleton leaves BUMP version to the operator" "" \
+        "$(jq -r 'select(.repo == "bump-me") | .version' "$MWD/plan.skeleton.jsonl")"
+    check "manifest: skeleton carries the surveyed head for the finish gate" abc123 \
+        "$(jq -r 'select(.repo == "bump-me") | .head' "$MWD/plan.skeleton.jsonl")"
+    check "manifest: foreign-PR repo has NO skeleton row (never planned over a colleague)" "" \
+        "$(jq -r 'select(.repo == "foreign") | .repo' "$MWD/plan.skeleton.jsonl")"
+    check "manifest: own crashed PR gets a skeleton row with its branch version" 2.5.0 \
+        "$(jq -r 'select(.repo == "own-pr") | .version' "$MWD/plan.skeleton.jsonl")"
+    check "manifest: failed compare renders SURVEY-INCOMPLETE with a re-run note" yes \
+        "$(grep -q '| blipped | SURVEY-INCOMPLETE |.*re-run survey' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: host tag rules are rendered for the operator" yes \
+        "$(grep -q 'tag rules: 12:' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: pipe chars in rules are escaped so the table survives" yes \
+        "$(grep -q 'rules ¦ if CI_COMMIT_TAG' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: stops for approval (bump command only in 'next' steps)" yes \
+        "$(grep -q 'review the manifest' <<< "$out" && echo yes || echo no)"
+else
+    echo "  skip manifest golden tests (gh not installed)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "All fleet-release tests passed"
+else
+    echo "Some fleet-release tests FAILED"
+fi
+exit "$fail"

--- a/tests/roll-changelog.sh
+++ b/tests/roll-changelog.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# tests/roll-changelog.sh — exercises skills/skill-repo/scripts/roll-changelog.py.
+#
+# The five released-heading shapes documented in release-discipline.md each get
+# a round-trip, and every refusal guard is observed to actually fail on a
+# violating fixture — a guard that has never been seen red proves only that it
+# runs, not that it guards.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$(cd "$HERE/.." && pwd)/skills/skill-repo/scripts/roll-changelog.py"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+
+roll() { # roll <file> <version> [args...] — captured exit code
+    python3 "$SCRIPT" "$@" > "$WORK/out.txt" 2> "$WORK/err.txt"
+    echo "$?"
+}
+
+echo "roll-changelog.py"
+
+# --- 1. bracketed dash (keep-a-changelog) -----------------------------------
+f="$WORK/dash.md"
+cat > "$f" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- new fleet driver
+
+## [1.2.3] - 2026-08-01
+
+### Fixed
+
+- old fix
+EOF
+check "bracketed dash: exits 0" 0 "$(roll "$f" 1.3.0 --date 2026-08-13)"
+check "bracketed dash: new heading reproduced" yes \
+    "$(grep -qx '## \[1.3.0\] - 2026-08-13' "$f" && echo yes || echo no)"
+check "bracketed dash: fresh empty Unreleased kept" yes \
+    "$(grep -qx '## \[Unreleased\]' "$f" && echo yes || echo no)"
+check "bracketed dash: moved content intact" yes \
+    "$(grep -q -- '- new fleet driver' "$f" && echo yes || echo no)"
+check "bracketed dash: old release untouched" yes \
+    "$(grep -qx '## \[1.2.3\] - 2026-08-01' "$f" && echo yes || echo no)"
+# MD022: the new heading must have blank lines on both sides
+check "bracketed dash: blank line after new heading" blank \
+    "$(awk 'found { print ($0 == "" ? "blank" : "nonblank"); exit }
+            /^## \[1\.3\.0\] - 2026-08-13$/ { found = 1 }' "$f")"
+check "bracketed dash: blank line before new heading" blank \
+    "$(awk '/^## \[1\.3\.0\] - 2026-08-13$/ { print (prev == "" ? "blank" : "nonblank"); exit }
+            { prev = $0 }' "$f")"
+
+# --- 2. bare paren -----------------------------------------------------------
+f="$WORK/paren.md"
+cat > "$f" <<'EOF'
+# Changelog
+
+## Unreleased
+
+- something
+
+## 1.11.2 (2026-07-30)
+
+- earlier
+EOF
+check "bare paren: exits 0" 0 "$(roll "$f" 1.12.0 --date 2026-08-13)"
+check "bare paren: shape reproduced" yes \
+    "$(grep -qx '## 1.12.0 (2026-08-13)' "$f" && echo yes || echo no)"
+check "bare paren: unbracketed Unreleased preserved" yes \
+    "$(grep -qx '## Unreleased' "$f" && echo yes || echo no)"
+
+# --- 3. bracketed em dash ----------------------------------------------------
+f="$WORK/emdash.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- change
+
+## [0.3.23] — 2026-07-02
+
+- old
+EOF
+check "em dash: exits 0" 0 "$(roll "$f" 0.3.24 --date 2026-08-13)"
+check "em dash: dash character reproduced" yes \
+    "$(grep -qx '## \[0.3.24\] — 2026-08-13' "$f" && echo yes || echo no)"
+
+# --- 4. linked, with v prefix: tag rewritten inside the URL ------------------
+f="$WORK/linked.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- change
+
+## [v2.6.0](https://github.com/x/y/releases/tag/v2.6.0) — 2026-02-28
+
+- old
+EOF
+check "linked: exits 0" 0 "$(roll "$f" 2.7.0 --date 2026-08-13)"
+check "linked: v prefix + URL tag rewritten" yes \
+    "$(grep -qx '## \[v2.7.0\](https://github.com/x/y/releases/tag/v2.7.0) — 2026-08-13' "$f" && echo yes || echo no)"
+
+# --- 5. first release: no released heading yet -------------------------------
+f="$WORK/first.md"
+cat > "$f" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+- everything so far
+EOF
+check "first release: exits 0" 0 "$(roll "$f" 0.1.0 --date 2026-08-13)"
+check "first release: keep-a-changelog default shape" yes \
+    "$(grep -qx '## \[0.1.0\] - 2026-08-13' "$f" && echo yes || echo no)"
+
+# --- 6. fence-blindness ------------------------------------------------------
+f="$WORK/fence.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- documents the roll:
+
+```markdown
+## [Unreleased]
+
+## [9.9.9] - 2099-01-01
+```
+
+## [1.0.0] - 2026-01-01
+
+- old
+EOF
+check "fenced lookalikes: exits 0 (only the real Unreleased counts)" 0 \
+    "$(roll "$f" 1.1.0 --date 2026-08-13)"
+check "fenced example untouched" yes \
+    "$(grep -qx '## \[9.9.9\] - 2099-01-01' "$f" && echo yes || echo no)"
+check "shape came from the real heading, not the fenced one" yes \
+    "$(grep -qx '## \[1.1.0\] - 2026-08-13' "$f" && echo yes || echo no)"
+
+# --- guards: each one observed to fail --------------------------------------
+f="$WORK/empty.md"
+printf '# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\n- old\n' > "$f"
+check "empty Unreleased refused" 1 "$(roll "$f" 1.1.0)"
+check "empty Unreleased: file unchanged" yes \
+    "$(grep -qx '## \[1.1.0\].*' "$f" && echo no || echo yes)"
+
+f="$WORK/none.md"
+printf '# Changelog\n\n## [1.0.0] - 2026-01-01\n' > "$f"
+check "missing Unreleased refused" 1 "$(roll "$f" 1.1.0)"
+
+f="$WORK/twice.md"
+printf '## [Unreleased]\n\n- a\n\n## Unreleased\n\n- b\n' > "$f"
+check "duplicate Unreleased refused" 1 "$(roll "$f" 1.1.0)"
+
+f="$WORK/badver.md"
+printf '## [Unreleased]\n\n- a\n' > "$f"
+check "non-semver version refused" 1 "$(roll "$f" not-a-version)"
+check "bad date refused" 1 "$(roll "$f" 1.0.0 --date yesterday)"
+
+f="$WORK/inverted.md"
+printf '## [1.0.0] - 2026-01-01\n\n- old\n\n## [Unreleased]\n\n- new\n' > "$f"
+check "released heading before Unreleased refused" 1 "$(roll "$f" 1.1.0)"
+
+# --- second roll on the same file: Unreleased is empty now -> refused --------
+f="$WORK/dash.md"   # rolled successfully in test 1
+check "re-roll after a roll is refused (empty Unreleased)" 1 "$(roll "$f" 1.4.0)"
+
+# --- guard: unrecognized released-heading shape refused ----------------------
+f="$WORK/weird.md"
+printf '## [Unreleased]\n\n- a\n\n## Notes and thanks\n\n- b\n' > "$f"
+check "unrecognized released-heading shape refused" 1 "$(roll "$f" 1.1.0)"
+
+# --- guard: linked heading whose URL lacks its own tag refused ---------------
+f="$WORK/badlink.md"
+printf '## [Unreleased]\n\n- a\n\n## [v1.0.0](https://example.invalid/static) - 2026-01-01\n\n- b\n' > "$f"
+check "linked heading URL without its tag refused (no guessed rewrite)" 1 "$(roll "$f" 1.1.0)"
+
+# --- comment-only Unreleased is empty, not content ---------------------------
+f="$WORK/comment.md"
+printf '## [Unreleased]\n\n<!-- add entries here -->\n\n## [1.0.0] - 2026-01-01\n\n- old\n' > "$f"
+check "comment-only Unreleased refused (would ship a visually empty release)" 1 \
+    "$(roll "$f" 1.1.0)"
+
+# --- tilde fences hide lookalikes too ----------------------------------------
+f="$WORK/tilde.md"
+printf '## [Unreleased]\n\n- a\n\n~~~\n## [9.9.9] - 2099-01-01\n~~~\n\n## [1.0.0] - 2026-01-01\n\n- b\n' > "$f"
+check "~~~ fenced lookalike ignored" 0 "$(roll "$f" 1.1.0 --date 2026-08-13)"
+check "~~~ fenced example untouched" yes \
+    "$(grep -qx '## \[9.9.9\] - 2099-01-01' "$f" && echo yes || echo no)"
+
+# --- CRLF files keep their line endings --------------------------------------
+f="$WORK/crlf.md"
+printf '## [Unreleased]\r\n\r\n- change\r\n\r\n## [1.0.0] - 2026-01-01\r\n\r\n- old\r\n' > "$f"
+check "CRLF file rolls cleanly" 0 "$(roll "$f" 1.1.0 --date 2026-08-13)"
+check "CRLF line endings preserved (no wholesale LF rewrite)" 0 \
+    "$(grep -c $'[^\r]$' "$f")"
+
+# --- keep-a-changelog link-reference definitions are rolled too --------------
+f="$WORK/refs.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- change
+
+## [1.2.0] - 2026-01-01
+
+- old
+
+[Unreleased]: https://github.com/x/y/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/x/y/compare/v1.1.0...v1.2.0
+EOF
+check "ref-style defs: exits 0" 0 "$(roll "$f" 1.3.0 --date 2026-08-13)"
+check "ref-style defs: [Unreleased] range restarts at the new tag" yes \
+    "$(grep -qx '\[Unreleased\]: https://github.com/x/y/compare/v1.3.0...HEAD' "$f" && echo yes || echo no)"
+check "ref-style defs: the new release got its own definition" yes \
+    "$(grep -qx '\[1.3.0\]: https://github.com/x/y/compare/v1.2.0...v1.3.0' "$f" && echo yes || echo no)"
+f="$WORK/refs-odd.md"
+printf '## [Unreleased]\n\n- a\n\n## [1.0.0] - 2026-01-01\n\n- b\n\n[Unreleased]: https://example.invalid/branches\n' > "$f"
+check "ref-style defs in an unknown shape: roll succeeds with a warning" 0 \
+    "$(roll "$f" 1.1.0 --date 2026-08-13)"
+check "…and the warning names the manual follow-up" yes \
+    "$(grep -q 'WARNING: link-reference definitions' "$WORK/out.txt" && echo yes || echo no)"
+
+# --- dry run writes nothing --------------------------------------------------
+f="$WORK/dry.md"
+printf '## [Unreleased]\n\n- pending\n\n## [1.0.0] - 2026-01-01\n\n- old\n' > "$f"
+before=$(cat "$f")
+check "dry run exits 0" 0 "$(roll "$f" 1.1.0 --dry-run)"
+check "dry run leaves the file untouched" "$before" "$(cat "$f")"
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "All roll-changelog tests passed"
+else
+    echo "Some roll-changelog tests FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Ships the maintained fleet-release driver proposed in #218 for the public GitHub fleet: `survey` → `manifest` (hard human-approval stop) → `bump` → `finish`, on a host-neutral shared engine. Fleets on other hosts ship their own driver in their own (private) infrastructure, vendor the engine, and implement the documented `host_*` callbacks — host knowledge stays with the host.

Closes #218.

## Change

- `skills/skill-repo/scripts/fleet-release-github.sh` — driver for github.com/netresearch: gh-based survey call set (API error bodies never captured as data), auto-merge arming, completion-first check gate with plain merge only on `mergeStateStatus == CLEAN`, Release-with-assets verification.
- `skills/skill-repo/scripts/fleet-release-common.sh` — host-neutral engine: normalized survey schema, one classification implementation (BUMP, TAG-ONLY, FIRST-RELEASE, SKIP-CI-ONLY, SURVEY-INCOMPLETE, BEHIND-TAG, TAG-RELEASE-DIVERGED, OWN-PR-OPEN, NO-RELEASE-JOB, and the BLOCKED-* set incl. the foreign-PR author gate), plan validation (uniqueness, semver, monotonicity against the surveyed baseline), subshell-per-repo logging with the log-count invariant, parity read from refs, peeled-ref idempotent signed tagging on the PR's merge commit, remote-reality resume at every crash window, and `fr_tool` resolution so a vendored copy finds the installed skill-repo tooling.
- `skills/skill-repo/scripts/roll-changelog.py` — standalone shape-aware changelog roll: all five fleet heading shapes, fence-aware, refuses no-op and comment-only rolls, preserves CRLF, rolls keep-a-changelog link-reference definitions.
- `skills/skill-repo/scripts/fleet-repos-github.txt` — maintained default fleet list with a regeneration command; the survey dedupes rename redirects by resolved name, so stale entries degrade to DUPLICATE rows.
- `tests/fleet-release.sh` (91 assertions), `tests/roll-changelog.sh` (41 assertions) — every offline guard observed failing on a violating fixture; the header states the offline scope plainly.
- `skills/skill-repo/references/release-discipline.md` — new lead section pointing sweeps at the driver; `docs/ARCHITECTURE.md` — release-tooling enumeration. SKILL.md body untouched (at 499/500 words; the reference carries the pointer).

## Deliberately out of scope

Merging anyone else's PR/MR, unarchiving, cloning missing checkouts, writing CI files (a NO-RELEASE-JOB row points at adopting the shared release CI), inventing versions or PR bodies, and non-default-branch releases. Foreign-host fleet specifics (driver, repo list, CI conventions) live with that host, not here.

## Review

The design passed two adversarial pre-build reviews (spec coverage against release-discipline.md; over-engineering/operator-usability), and the implementation passed a 46-agent four-lens review with per-finding adversarial verification: 41 confirmed findings, all incorporated — among them gh error bodies captured as data on 404/403, an empty check rollup treated as green, tagging the live tip instead of the merge commit, and a missing version-monotonicity gate.

## Verification

`shellcheck -x -S error`, `ruff@0.16.0 check`/`format --check`, all eight `tests/*.sh` suites, and `validate-skill.sh` are green on the final tree. Live read-only survey+manifest runs classify known repos correctly: rename redirect deduped (agents-skill), archived flagged with measured red CI (claude-coach-skill), BUMP delta on this repo itself. The 404-body guard was proven empirically against a nonexistent release tag.

Pre-existing observation, not touched here: `skills/skill-repo/scripts/sync-plugin-manifest.sh` is committed non-executable (mode 100644), so `bump-version.sh`'s `-x` check silently takes the direct-write fallback instead of projecting the manifest.
