### PR TITLE
docs(release-discipline): budget the shared API quota before a fleet sweep

### DIFF
--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -24,6 +24,20 @@ shared release CI first), and non-default-branch releases — the
 something the driver lacks, extend it in a PR; a session-local driver script
 is how the next incident starts.
 
+**Budget the API before a sweep: the survey costs ~10 calls per repo, and
+each GitHub quota pool (REST 5,000/h, GraphQL 5,000 points/h — separate
+pools) is shared across every tool, watcher and agent in the session.** A
+40-repo survey plus check-watchers plus a merge-gate poll can exhaust them
+mid-sweep — the GraphQL pool usually dies first because `gh pr merge`,
+`gh pr view --json` and pr-status.sh all draw from it, while plain REST
+still answers apart from short burst limits (2026-08-13: a sweep session hit
+exactly this between "all gates verified" and "merge"). Practice: act on a verified, unchanged head
+with ONE call instead of re-running preflight batteries — the REST merge
+takes an `sha` pin (`gh api -X PUT .../pulls/N/merge -f merge_method=merge
+-f sha=$(git rev-parse HEAD)`) whose 409 IS the freshness check — prefer one
+`--watch` over repeated status reads, and stop any watcher whose answer is
+already known.
+
 ## Canonical Order: Bump PR Merged → Tag Pushed
 
 **Tag a version only after the version-bump PR is merged to the default branch.** Tagging first causes the Release workflow to run against the old code, fail CI, and produce an immutable GitHub release locked to a bad tag.


### PR DESCRIPTION
Retro finding from the 2026-08-13 driver-implementation session ([#218](https://github.com/netresearch/skill-repo-skill/issues/218), [#219](https://github.com/netresearch/skill-repo-skill/pull/219)): the sweep session exhausted the shared 5,000/h GitHub quota between gate verification and merge — the survey's ~10 calls/repo plus check-watchers plus preflight batteries add up, and the GraphQL secondary quota died first, taking `gh pr merge` and pr-status.sh with it while plain REST still answered. Adds one paragraph to the fleet-sweeps lead section: budget the quota, act on a verified unchanged head with one SHA-pinned REST call instead of re-running preflights, prefer `--watch` over repeated reads, stop known-answer watchers.