### PR TITLE
fix(validate): exclude the vendored tools checkout from ruff

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -183,11 +183,13 @@ jobs:
           COUNT=$(echo "$PYFILES" | wc -l)
           echo "Found $COUNT Python file(s)"
           echo "=== ruff check ==="
+          # --extend-exclude: the vendored tools checkout must not be linted
+          # under the CONSUMER repo's ruff config (find above prunes it too)
           # renovate: datasource=pypi depName=ruff
-          uvx --no-build ruff@0.16.0 check .
+          uvx --no-build ruff@0.16.0 check --extend-exclude .skill-repo-tools .
           echo "=== ruff format ==="
           # renovate: datasource=pypi depName=ruff
-          uvx --no-build ruff@0.16.0 format --check .
+          uvx --no-build ruff@0.16.0 format --check --extend-exclude .skill-repo-tools .
 
       - name: Validate checkpoint schemas
         run: |


### PR DESCRIPTION
The Python lint step's `find` already prunes `./.skill-repo-tools`, but the ruff invocations run over the whole tree, so the vendored `roll-changelog.py` is format-checked under the CONSUMER repo's ruff config. Any consumer with a different line-length goes red on a file it does not own — [netresearch/jira-skill main is red](https://github.com/netresearch/jira-skill/actions/runs/31751193667) on exactly this (jira-skill pins line-length 120, the vendored script is formatted at the fleet default). `--extend-exclude` is used rather than `--exclude` so a consumer's own exclude setting is not overridden. Found during the 2026-08-14 fleet release sweep; the fix propagates to all consumers immediately because callers reference this reusable workflow @main.