### PR TITLE
chore(release): v1.33.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "skill-repo",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.32.0"
+  version: "1.33.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Minor release: ships the fleet-release driver for the public GitHub fleet (#218, #219) plus release-discipline documentation on fleet-driver hazards, the unarchive-release-rearchive playbook, manifest-sync data loss, and API-quota budgeting (#217, #220).