### PR TITLE
feat: compile assertion patterns and let evals self-check with samples

### DIFF
--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -179,13 +179,24 @@ decides it mechanically, with no model call:
 }
 ```
 
-Every `content` assertion must match `passing`, and each entry in `failing` must be
-rejected by at least one assertion. The block is optional and evals without it validate
-exactly as before, so adopting it never breaks a repo on day one. Write the `failing`
-samples from the answer a model actually gives without the skill — a straw man that
-shares no vocabulary with a correct answer passes the check while proving nothing.
-`content` assertion patterns are now compiled during validation as well, whether or not
-samples are present.
+Every assertion must match `passing`, and each entry in `failing` must be rejected by at
+least one assertion. Write the `failing` samples from the answer a model actually gives
+without the skill — a straw man that shares no vocabulary with a correct answer passes
+the check while proving nothing.
+
+**Matching uses the grader's instrument, not a similar one.** `run-ab-evals.sh` grades
+with `grep -qiE` after stripping a leading `(?i)`: case-insensitive POSIX ERE, with no
+type filter — it takes `value or pattern` from *every* assertion. The validator calls the
+same binary with the same flags, because Python's `re` disagrees with ERE in ways that
+decide real cases (`[^\n]` excludes the letter `n` in ERE, and `re` is case-sensitive),
+and a self-check measuring with a different engine certifies evals the grader would fail.
+For the same reason a pattern under `tool_use` or `content_regex` is validated too. An
+assertion typed `must_not` is checked inverted: it must NOT match `passing`.
+
+Two things change for evals **without** a samples block: patterns are now checked to be
+parseable by `grep -E`, and an unparseable one fails — except under a `*_contains` type,
+where the value is usually a literal and the mismatch is the grader's, so it only warns.
+Nothing else about validation changed, and no evals.json in the fleet changes verdict.
 
 ## Rule 8: Per-private-repo confirmation
 

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -160,6 +160,33 @@ This verification is a **LOCAL/manual step, not CI** — `run-ab-evals.sh` calls
 `claude -p` per eval. It is referenced only by `.github/workflows/ab-evals-schedule.yml`,
 which is disabled by team decision, so it is not part of any active CI gate.
 
+### `samples`: the part of that quality rule CI can decide
+
+An assertion is only a non-empty string as far as structural validation used to be
+concerned, so an inverted one — demanding a word the intended answer never uses — read
+exactly like a discriminating one. Add an optional `samples` block and the validator
+decides it mechanically, with no model call:
+
+```json
+{
+  "name": "worktree_cleanup_spares_the_primary_directory",
+  "prompt": "…",
+  "assertions": [{ "type": "content", "pattern": "(?i)\\bswitch\\b[^\\n]{0,30}\\b(main|master)" }],
+  "samples": {
+    "passing": "Do not remove it — run git -C project/main switch main instead.",
+    "failing": ["Remove every merged worktree, including project/main."]
+  }
+}
+```
+
+Every `content` assertion must match `passing`, and each entry in `failing` must be
+rejected by at least one assertion. The block is optional and evals without it validate
+exactly as before, so adopting it never breaks a repo on day one. Write the `failing`
+samples from the answer a model actually gives without the skill — a straw man that
+shares no vocabulary with a correct answer passes the check while proving nothing.
+`content` assertion patterns are now compiled during validation as well, whether or not
+samples are present.
+
 ## Rule 8: Per-private-repo confirmation
 
 Before pushing to a private host (`git.netresearch.de`, `gitlab.com/<private-org>`, etc.), prompt the user. Decision is remembered per `(session, repo-url)` for the duration of the active retro-skill session; not persisted across sessions.

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -11,8 +11,11 @@
 # Any eval may carry an optional self-check:
 #   "samples": {"passing": "<answer every assertion must match>",
 #               "failing": ["<answer at least one assertion must reject>"]}
-# Content assertion patterns are compiled; with samples present they are also
-# run, which is what separates a discriminating assertion from an inverted one.
+# Patterns are checked with `grep -E` and matched with `grep -qiE`, the same
+# binary and flags run-ab-evals.sh grades with, so the check cannot certify an
+# eval the grader would fail. Every assertion carrying value/pattern counts,
+# whatever its type, because the grader has no type filter either; `must_not`
+# is checked inverted.
 #
 # Usage: bash validate-evals.sh [path-to-evals.json] [--require-evals]
 #   If no path given, searches skills/*/evals/evals.json then evals/evals.json
@@ -140,8 +143,38 @@ pass "Valid JSON"
 # --- Run all structural checks via Python ---
 RESULT=$(python3 - "$EVALS_FILE" <<'PYEOF'
 import json
-import re
+import subprocess
 import sys
+
+# Assertions are graded by run-ab-evals.sh with `grep -qiE` after stripping a
+# leading (?i) — case-insensitive POSIX ERE, not Python's re. Validating them
+# with a different engine measures a different thing: `[^\n]` means one thing
+# in Python and another in ERE, and case-sensitive matching rejects patterns
+# the grader accepts. So the checks below call the same binary with the same
+# flags rather than approximating it.
+def _grep(args, text):
+    try:
+        return subprocess.run(
+            ["grep", *args], input=text, text=True,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        ).returncode
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _ere(pattern):
+    return pattern[4:] if pattern.startswith("(?i)") else pattern
+
+
+def pattern_compiles(pattern):
+    # grep exits 2 on a pattern it cannot parse and 1 on "no match".
+    rc = _grep(["-qE", "--", _ere(pattern)], "")
+    return rc is None or rc != 2
+
+
+def grader_matches(pattern, text):
+    return _grep(["-qiE", "--", _ere(pattern)], text) == 0
+
 
 with open(sys.argv[1]) as f:
     raw = json.load(f)
@@ -274,42 +307,95 @@ for i, ev in enumerate(evals):
 
             # A pattern only had to be a non-empty string until now, so an
             # unbalanced group passed validation and first misbehaved wherever
-            # the eval was actually graded.
+            # the eval was actually graded. Which assertions count is decided by
+            # the grader, not by a type name: run-ab-evals.sh takes
+            # `value or pattern` from EVERY assertion with no type filter, so a
+            # broken pattern under type "tool_use", "content_regex" or any other
+            # label is graded and must be validated the same way.
             patterns = []
             for j, a in enumerate(assertions):
                 if not isinstance(a, dict):
                     continue
-                pat = a.get("pattern") or a.get("value") or ""
-                if a.get("type") not in (None, "content") or not str(pat).strip():
+                pat = str(a.get("pattern") or a.get("value") or "")
+                if not pat.strip():
                     continue
-                try:
-                    patterns.append((j, re.compile(str(pat))))
-                except re.error as exc:
-                    invalid_assertions += 1
-                    print(f"FAIL|{label} ({name}): assertion[{j}] is not a valid regex: {exc}")
+                if not pattern_compiles(pat):
+                    # A *_contains assertion states a literal, and the value is
+                    # usually not meant as a regex at all — `((` in a Concourse
+                    # eval, `public function __construct(` in a PHP one. The
+                    # grader still greps it as an ERE, so it never matches, but
+                    # the defect is the grader's literal handling rather than
+                    # the eval's, and failing here would turn CI red in repos
+                    # this change does not fix. It warns instead.
+                    literal = "contains" in str(a.get("type") or "")
+                    if literal:
+                        print(
+                            f"WARN|{label} ({name}): assertion[{j}] is not a valid POSIX ERE. "
+                            "run-ab-evals.sh greps every assertion with -qiE, including this "
+                            "one, so it can never match — escape the value or make it a regex"
+                        )
+                    else:
+                        invalid_assertions += 1
+                        print(
+                            f"FAIL|{label} ({name}): assertion[{j}] is not a valid POSIX ERE "
+                            "— grep rejects it, so the grader scores it as never matching"
+                        )
+                    continue
+                patterns.append((j, pat, a.get("type") == "must_not"))
 
             # Optional self-check. Without it nothing distinguishes an assertion
             # that discriminates from one that is inverted or vacuous: both look
             # like a non-empty string. With it, the eval carries one answer that
             # must satisfy every assertion and answers that must not.
             samples = ev.get("samples")
-            if isinstance(samples, dict) and patterns:
+            if samples is not None and not isinstance(samples, dict):
+                invalid_assertions += 1
+                print(f"FAIL|{label} ({name}): samples must be an object, got {type(samples).__name__}")
+            elif isinstance(samples, dict):
+                unknown = sorted(set(samples) - {"passing", "failing"})
+                if unknown:
+                    invalid_assertions += 1
+                    print(
+                        f"FAIL|{label} ({name}): samples has unknown key(s) {', '.join(unknown)} "
+                        "— only 'passing' and 'failing' are read, so a typo would check nothing"
+                    )
+                if not patterns:
+                    invalid_assertions += 1
+                    print(
+                        f"FAIL|{label} ({name}): samples present but no assertion carries a "
+                        "pattern — the self-check would verify nothing"
+                    )
                 passing = samples.get("passing")
-                if isinstance(passing, str) and passing.strip():
-                    for j, rx in patterns:
-                        if not rx.search(passing):
-                            invalid_assertions += 1
-                            print(
-                                f"FAIL|{label} ({name}): assertion[{j}] does not match its own "
-                                "passing sample — the eval would reject a correct answer"
+                if passing is not None and (not isinstance(passing, str) or not passing.strip()):
+                    invalid_assertions += 1
+                    print(f"FAIL|{label} ({name}): samples.passing must be a non-empty string")
+                elif isinstance(passing, str) and passing.strip():
+                    for j, pat, negated in patterns:
+                        hit = grader_matches(pat, passing)
+                        if hit == negated:
+                            problem = (
+                                "matches its own passing sample although it is a must_not "
+                                "assertion" if negated else
+                                "does not match its own passing sample — the eval would "
+                                "reject a correct answer"
                             )
+                            invalid_assertions += 1
+                            print(f"FAIL|{label} ({name}): assertion[{j}] {problem}")
                 failing = samples.get("failing")
                 if isinstance(failing, str):
                     failing = [failing]
+                if failing is not None and not isinstance(failing, list):
+                    invalid_assertions += 1
+                    print(f"FAIL|{label} ({name}): samples.failing must be a string or an array")
+                    failing = []
                 for k, bad in enumerate(failing or []):
                     if not isinstance(bad, str) or not bad.strip():
+                        invalid_assertions += 1
+                        print(f"FAIL|{label} ({name}): samples.failing[{k}] must be a non-empty string")
                         continue
-                    if all(rx.search(bad) for _, rx in patterns):
+                    if patterns and all(
+                        grader_matches(pat, bad) != negated for _, pat, negated in patterns
+                    ):
                         invalid_assertions += 1
                         print(
                             f"FAIL|{label} ({name}): failing sample[{k}] satisfies every "

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -8,6 +8,12 @@
 #   Legacy A: {"skill_name": "...", "evals": [{id, eval_name, prompt, assertions: [...]}]}
 #   Legacy B: [{name, prompt, assertions: [{type, value/pattern, description?}]}]
 #
+# Any eval may carry an optional self-check:
+#   "samples": {"passing": "<answer every assertion must match>",
+#               "failing": ["<answer at least one assertion must reject>"]}
+# Content assertion patterns are compiled; with samples present they are also
+# run, which is what separates a discriminating assertion from an inverted one.
+#
 # Usage: bash validate-evals.sh [path-to-evals.json] [--require-evals]
 #   If no path given, searches skills/*/evals/evals.json then evals/evals.json
 #
@@ -134,6 +140,7 @@ pass "Valid JSON"
 # --- Run all structural checks via Python ---
 RESULT=$(python3 - "$EVALS_FILE" <<'PYEOF'
 import json
+import re
 import sys
 
 with open(sys.argv[1]) as f:
@@ -264,6 +271,50 @@ for i, ev in enumerate(evals):
                 else:
                     invalid_assertions += 1
                     print(f"FAIL|{label} ({name}): assertion[{j}] invalid type (not string or object)")
+
+            # A pattern only had to be a non-empty string until now, so an
+            # unbalanced group passed validation and first misbehaved wherever
+            # the eval was actually graded.
+            patterns = []
+            for j, a in enumerate(assertions):
+                if not isinstance(a, dict):
+                    continue
+                pat = a.get("pattern") or a.get("value") or ""
+                if a.get("type") not in (None, "content") or not str(pat).strip():
+                    continue
+                try:
+                    patterns.append((j, re.compile(str(pat))))
+                except re.error as exc:
+                    invalid_assertions += 1
+                    print(f"FAIL|{label} ({name}): assertion[{j}] is not a valid regex: {exc}")
+
+            # Optional self-check. Without it nothing distinguishes an assertion
+            # that discriminates from one that is inverted or vacuous: both look
+            # like a non-empty string. With it, the eval carries one answer that
+            # must satisfy every assertion and answers that must not.
+            samples = ev.get("samples")
+            if isinstance(samples, dict) and patterns:
+                passing = samples.get("passing")
+                if isinstance(passing, str) and passing.strip():
+                    for j, rx in patterns:
+                        if not rx.search(passing):
+                            invalid_assertions += 1
+                            print(
+                                f"FAIL|{label} ({name}): assertion[{j}] does not match its own "
+                                "passing sample — the eval would reject a correct answer"
+                            )
+                failing = samples.get("failing")
+                if isinstance(failing, str):
+                    failing = [failing]
+                for k, bad in enumerate(failing or []):
+                    if not isinstance(bad, str) or not bad.strip():
+                        continue
+                    if all(rx.search(bad) for _, rx in patterns):
+                        invalid_assertions += 1
+                        print(
+                            f"FAIL|{label} ({name}): failing sample[{k}] satisfies every "
+                            "assertion — the eval would accept an answer it calls wrong"
+                        )
 
             if invalid_assertions == 0:
                 has_assertions = True

--- a/tests/validate-evals.sh
+++ b/tests/validate-evals.sh
@@ -53,6 +53,110 @@ check "names the ungraded eval" yes "$(grep -q 'no_grading' <<<"$out" && echo ye
 bash "$SCRIPT" "$WORK/does-not-exist.json" >/dev/null 2>&1
 check "rejects a missing file" 1 "$?"
 
+# The validator also enforces a minimum eval count and a minimum number of
+# assertions per eval. A fixture holding only the eval under test therefore
+# fails for those reasons instead, and every "must fail" assertion below would
+# pass without ever exercising the check it names. suite() pads the file with
+# valid evals so the eval under test is the only thing that can fail.
+suite() { # suite <target-file> <<< <json of the eval under test>
+    # The subject travels through the environment: python's own heredoc owns
+    # stdin here, so sys.stdin would hand back this script instead.
+    local subject
+    subject="$(cat)"
+    SUBJECT="$subject" python3 - "$1" <<'PYEOF'
+import json, os, sys
+subject = json.loads(os.environ["SUBJECT"])
+evals = [
+    {"name": f"filler_{i}", "prompt": f"Filler prompt {i}.",
+     "assertions": [{"type": "content", "pattern": "(?i)filler"},
+                    {"type": "content", "pattern": r"\d"}]}
+    for i in range(12)
+]
+json.dump(evals + [subject], open(sys.argv[1], "w"), indent=2)
+PYEOF
+}
+
+# The padding itself must validate, or every case below is measuring the padding.
+suite "$WORK/padding-only.json" <<'EOF'
+{ "name": "subject_ok", "prompt": "A prompt.",
+  "assertions": [{"type": "content", "pattern": "(?i)alpha"},
+                 {"type": "content", "pattern": "(?i)beta"}] }
+EOF
+bash "$SCRIPT" "$WORK/padding-only.json" >/dev/null 2>&1
+check "the padded fixture validates on its own" 0 "$?"
+
+# --- a pattern that is not a regex must fail ---------------------------------
+# Until now a pattern only had to be a non-empty string, so an unbalanced group
+# shipped and first misbehaved wherever the eval was actually graded.
+suite "$WORK/uncompilable.json" <<'EOF'
+{ "name": "broken_pattern", "prompt": "Anything.",
+  "assertions": [{"type": "content", "pattern": "(unclosed group"},
+                 {"type": "content", "pattern": "(?i)fine"}] }
+EOF
+out=$(bash "$SCRIPT" "$WORK/uncompilable.json" 2>&1)
+check "rejects an assertion pattern that does not compile" 1 "$?"
+check "names the uncompilable eval" yes "$(grep -q 'broken_pattern' <<<"$out" && echo yes || echo no)"
+
+# --- samples: the self-check that tells a discriminating eval from a vacuous one
+suite "$WORK/samples-good.json" <<'EOF'
+{ "name": "discriminating",
+  "prompt": "How do you clean up a merged worktree that is the primary directory?",
+  "assertions": [
+    {"type": "content", "pattern": "(?i)\\bswitch\\b[^\\n]{0,30}\\b(main|master)"},
+    {"type": "content", "pattern": "(?i)primary|instead"}
+  ],
+  "samples": {
+    "passing": "Do not remove the primary one. Run git -C project/main switch main instead.",
+    "failing": ["Remove every merged worktree, including project/main."]
+  } }
+EOF
+bash "$SCRIPT" "$WORK/samples-good.json" >/dev/null 2>&1
+check "accepts samples whose assertions discriminate" 0 "$?"
+
+# --- an assertion that misses its own passing sample is inverted -------------
+# The case that motivated this check: an assertion demanded the literal word
+# "remove", while the answer it was written for says "never-removable".
+suite "$WORK/samples-inverted.json" <<'EOF'
+{ "name": "misses_its_own_answer",
+  "prompt": "How do you clean up a merged worktree that is the primary directory?",
+  "assertions": [
+    {"type": "content", "pattern": "(not|never) .{0,40}(remove|delete)"},
+    {"type": "content", "pattern": "(?i)worktree"}
+  ],
+  "samples": {
+    "passing": "Treat the primary worktree as never-removable; switch it back instead.",
+    "failing": ["Delete every merged worktree, do not keep any."]
+  } }
+EOF
+out=$(bash "$SCRIPT" "$WORK/samples-inverted.json" 2>&1)
+check "rejects an assertion that misses its own passing sample" 1 "$?"
+check "names the assertion index" yes "$(grep -q 'assertion\[0\]' <<<"$out" && echo yes || echo no)"
+
+# --- a failing sample that satisfies every assertion proves nothing ----------
+suite "$WORK/samples-vacuous.json" <<'EOF'
+{ "name": "accepts_the_wrong_answer",
+  "prompt": "How do you clean up a merged worktree that is the primary directory?",
+  "assertions": [
+    {"type": "content", "pattern": "(?i)worktree"},
+    {"type": "content", "pattern": "(?i)merged"}
+  ],
+  "samples": {
+    "passing": "Switch the primary worktree back to main; the merged ones can go.",
+    "failing": ["Remove every merged worktree, including the primary one."]
+  } }
+EOF
+out=$(bash "$SCRIPT" "$WORK/samples-vacuous.json" 2>&1)
+check "rejects a failing sample that no assertion rejects" 1 "$?"
+
+# --- evals without samples keep validating exactly as before -----------------
+suite "$WORK/no-samples.json" <<'EOF'
+{ "name": "unchanged", "prompt": "Anything.",
+  "assertions": [{"type": "content", "pattern": "(?i)anything"},
+                 {"type": "content", "pattern": "(?i)thing"}] }
+EOF
+bash "$SCRIPT" "$WORK/no-samples.json" >/dev/null 2>&1
+check "an eval without samples still passes" 0 "$?"
+
 echo
 if [ "$fail" -eq 0 ]; then
     echo "All validate-evals tests passed"

--- a/tests/validate-evals.sh
+++ b/tests/validate-evals.sh
@@ -95,7 +95,10 @@ suite "$WORK/uncompilable.json" <<'EOF'
 EOF
 out=$(bash "$SCRIPT" "$WORK/uncompilable.json" 2>&1)
 check "rejects an assertion pattern that does not compile" 1 "$?"
-check "names the uncompilable eval" yes "$(grep -q 'broken_pattern' <<<"$out" && echo yes || echo no)"
+# The eval name appears in the ordinary PASS output too, so asserting on the
+# name alone is green against an implementation that never checks anything.
+check "names the uncompilable eval in the FAIL line" yes \
+    "$(grep -qE 'FAIL.*broken_pattern.*(valid|ERE|regex)' <<<"$out" && echo yes || echo no)"
 
 # --- samples: the self-check that tells a discriminating eval from a vacuous one
 suite "$WORK/samples-good.json" <<'EOF'
@@ -147,6 +150,56 @@ suite "$WORK/samples-vacuous.json" <<'EOF'
 EOF
 out=$(bash "$SCRIPT" "$WORK/samples-vacuous.json" 2>&1)
 check "rejects a failing sample that no assertion rejects" 1 "$?"
+
+# --- the self-check must match the way the grader matches --------------------
+# run-ab-evals.sh grades with `grep -qiE`. Validating with a case-sensitive
+# engine rejects evals the grader accepts, and accepts vacuous ones it would
+# have caught.
+suite "$WORK/samples-case.json" <<'EOF'
+{ "name": "case_differs_from_the_sample",
+  "prompt": "Which licence file?",
+  "assertions": [
+    {"type": "content", "pattern": "Netresearch DTT GmbH"},
+    {"type": "content", "pattern": "LICENSE-MIT"}
+  ],
+  "samples": {
+    "passing": "Add license-mit and set the holder to netresearch dtt gmbh.",
+    "failing": ["Leave the licence alone."]
+  } }
+EOF
+bash "$SCRIPT" "$WORK/samples-case.json" >/dev/null 2>&1
+check "case-insensitive like the grader" 0 "$?"
+
+# --- every graded assertion is validated, whatever its type is ---------------
+# The grader takes value-or-pattern from EVERY assertion with no type filter,
+# so a broken pattern under tool_use is graded and must be caught.
+suite "$WORK/tooluse-pattern.json" <<'EOF'
+{ "name": "broken_pattern_under_tool_use", "prompt": "Anything.",
+  "assertions": [{"type": "tool_use", "tool": "Bash", "pattern": "(unclosed group"},
+                 {"type": "content", "pattern": "fine"}] }
+EOF
+bash "$SCRIPT" "$WORK/tooluse-pattern.json" >/dev/null 2>&1
+check "an unparseable tool_use pattern is rejected too" 1 "$?"
+
+# --- a misconfigured samples block must not be a silent no-op ---------------
+suite "$WORK/samples-typo.json" <<'EOF'
+{ "name": "typo_in_the_samples_key", "prompt": "Anything.",
+  "assertions": [{"type": "content", "pattern": "alpha"},
+                 {"type": "content", "pattern": "beta"}],
+  "samples": {"passes": "alpha beta", "failing": ["nothing here"]} }
+EOF
+out=$(bash "$SCRIPT" "$WORK/samples-typo.json" 2>&1)
+check "an unknown samples key is an error, not a no-op" 1 "$?"
+check "names the unknown key" yes "$(grep -q 'passes' <<<"$out" && echo yes || echo no)"
+
+suite "$WORK/samples-shape.json" <<'EOF'
+{ "name": "failing_is_a_number", "prompt": "Anything.",
+  "assertions": [{"type": "content", "pattern": "alpha"},
+                 {"type": "content", "pattern": "beta"}],
+  "samples": {"passing": "alpha beta", "failing": 42} }
+EOF
+bash "$SCRIPT" "$WORK/samples-shape.json" >/dev/null 2>&1
+check "a non-list failing value is rejected, not a traceback" 1 "$?"
 
 # --- evals without samples keep validating exactly as before -----------------
 suite "$WORK/no-samples.json" <<'EOF'


### PR DESCRIPTION
Structural validation accepted any non-empty string as an assertion pattern, so two defects passed it unseen: a pattern that is not parseable at all, and a pattern that is parseable but inverted — one demanding a word the intended answer never contains.

The second is not hypothetical; it shipped in git-workflow-skill. An assertion there required the literal `remove` or `delete`, while the reference answer says "never-removable" and "not a removal". A correct answer failed the eval and a wrong one could pass it, and CI could not see any of it, because assertions were never executed against anything.

**Matching uses the grader's own instrument.** `run-ab-evals.sh` grades with `grep -qiE` after stripping a leading `(?i)`. The first version of this branch validated with Python's `re`, which disagrees in ways that decide real cases: `re` is case-sensitive, so an eval whose passing sample differs only in case was rejected although the grader accepts it, and in ERE `[^\n]` excludes the letter `n`, so this branch's own showcase pattern matched in one engine and not the other. Both checks now call `grep` with the grader's flags. For the same reason every assertion carrying `value` or `pattern` is covered, whatever its type — the grader has no type filter either, so a broken pattern under `tool_use` or `content_regex` is graded and was being skipped. A `must_not` assertion is checked inverted.

An eval may carry an optional `samples` block: one `passing` answer that every assertion has to match, and `failing` answers that at least one assertion has to reject. Deterministic, no model call — it decides mechanically the part of the documented quality rule ("every eval needs a delta-discriminating assertion") that is decidable without an A/B run. A block that is malformed, misspelled, or attached to an eval with no pattern used to be a silent no-op; each is now an error naming the wrong key.

**Blast radius, measured against `main` file by file across all 37 `evals.json` in the local fleet: zero changed verdicts.** Three assertions in two consumer repos are not parseable as ERE — `((`, `((.:var`, `public function __construct(` — and the grader can therefore never match them. Those are real defects, but they predate this change and sit under a `*_contains` type where the value is meant as a literal, so they warn and name the cause rather than turning a foreign repo's CI red.

One note on the tests, because the first version of them was green for the wrong reason: the validator enforces a minimum of 10 evals and 2 assertions per eval, so a fixture holding only the eval under test fails on those minimums instead of the defect being tested, and every "must fail" assertion passes vacuously. `suite()` pads each fixture, a separate case asserts the padding validates on its own, and the assertion that a broken pattern is *named* now matches the FAIL line rather than the eval name, which appears in the PASS output too.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_012NiLDH3iWw8CVdAnimJbF8)_
