### PR TITLE
feat(evals): bind every A/B delta to the actor that produced it

### DIFF
--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -394,7 +394,13 @@ async function loadData() {
     // Result blocks are keyed by the model id recorded in provenance
     // (legacy entries: "opus"). Alias the single model key to `opus`
     // so the render code below has one canonical accessor.
-    DATA.skills.forEach(s => { if (s.results && !s.results.opus) s.results.opus = Object.values(s.results)[0]; });
+    DATA.skills.forEach(s => {
+      // Keep the model the entry was actually measured under before the alias
+      // below adds a second key; the provenance block is authoritative when
+      // present, and for older entries the result key is all there is.
+      s.modelKey = (s.provenance && s.provenance.model) || (s.results && Object.keys(s.results)[0]) || null;
+      if (s.results && !s.results.opus) s.results.opus = Object.values(s.results)[0];
+    });
   } catch (e) {
     document.body.innerHTML = '<p style="padding:2rem;color:red;">Failed to load data/results.json</p>';
     return;
@@ -421,6 +427,16 @@ const severityLabels = { critical: 'Would Cause Failures', quality: 'Quality Gap
 function ghUrl(s, path) { return `https://github.com/${s.repo}/blob/main/${path}`; }
 function repoUrl(s) { return `https://github.com/${s.repo}`; }
 function releaseUrl(s) { return `https://github.com/${s.repo}/releases/tag/v${s.version}`; }
+// A delta is not a property of a skill: it is what one skill version scored
+// under one model, one harness and one eval set. The number is only
+// interpretable next to that tuple, so every delta carries it.
+function measuredUnder(s) {
+  const p = s.provenance || {};
+  const evalSet = p.eval_set ? `${p.eval_set.count} evals @ ${String(p.eval_set.sha).slice(0, 8)}` : `${s.eval_count} evals`;
+  return `${s.name}@${s.version || 'unknown'} · ${p.harness || 'harness not recorded'}`
+    + ` · model ${s.modelKey || 'unknown'} · ${evalSet}`
+    + (p.run_date ? ` · ${p.run_date.split('T')[0]}` : '');
+}
 function skillUrl(s) { return ghUrl(s, s.skill_path || `skills/${s.name}/SKILL.md`); }
 function evalsUrl(s) { return ghUrl(s, s.evals_path || `skills/${s.name}/evals/evals.json`); }
 
@@ -434,10 +450,24 @@ let activeSeverity = 'all';
 // Header
 const totalEvals = skills.reduce((s, sk) => s + sk.eval_count, 0);
 const avgDelta = skills.reduce((s, sk) => s + sk.results.opus.delta, 0) / skills.length;
+// The actor tuple behind the aggregate. Where entries were measured under
+// different actors it says "mixed" rather than picking one and implying the
+// whole table shares it.
+function distinct(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+function tupleField(values, fallback) {
+  const seen = distinct(values);
+  if (seen.length === 0) return fallback;
+  return seen.length === 1 ? seen[0] : `mixed (${seen.length})`;
+}
 document.getElementById('headerMeta').innerHTML =
   `<span><span class="num">${skills.length}</span> skills</span>` +
   `<span><span class="num">${totalEvals}</span> evals</span>` +
   `<span><span class="num">+${(avgDelta * 100).toFixed(0)}%</span> avg delta</span>` +
+  `<span title="A delta is measured for one skill version under one harness, model and eval set — it is not a property of the skill. Hover a delta for the tuple behind it.">` +
+  `model ${tupleField(skills.map(s => s.modelKey), 'unknown')} · ` +
+  `${tupleField(skills.map(s => (s.provenance || {}).harness), 'harness not recorded')}</span>` +
   `<span>${DATA.generated.split('T')[0]}</span>`;
 
 // Nav
@@ -507,7 +537,7 @@ function renderTable() {
           <span class="bar-label">${wp}% / ${wip}%</span>
         </div>
       </td>
-      <td class="delta-cell ${deltaClass(o.delta)}"><a href="${repoUrl(s)}" target="_blank" title="View repository">+${(o.delta * 100).toFixed(0)}%</a></td>
+      <td class="delta-cell ${deltaClass(o.delta)}"><a href="${repoUrl(s)}" target="_blank" title="${measuredUnder(s)}">+${(o.delta * 100).toFixed(0)}%</a></td>
       <td><span class="category-badge cat-${s.category}">${s.category}</span></td>
       <td class="finding">${s.top_finding} <a href="${releaseUrl(s)}" target="_blank" title="Latest release" style="font-size:0.75em;opacity:0.6">v${s.version}</a></td>
     </tr>`;

--- a/scripts/merge-ab-results.py
+++ b/scripts/merge-ab-results.py
@@ -98,6 +98,14 @@ def main() -> int:
         }
     }
     entry["provenance"] = provenance
+    # A delta belongs to the actor tuple it was measured under, so the
+    # dashboard has to be able to render it next to the number. Older runs
+    # have no harness field; say so rather than implying the current one.
+    provenance.setdefault("harness", "unknown")
+    if "discriminating_checks" in ab:
+        entry["discriminating_checks"] = ab["discriminating_checks"]
+    if "evals_without_delta" in ab:
+        entry["evals_without_delta"] = ab["evals_without_delta"]
     if args.category:
         entry["category"] = args.category
     entry.setdefault("category", "other")
@@ -117,12 +125,19 @@ def main() -> int:
         json.dump(data, f, indent=2)
         f.write("\n")
 
+    version = entry.get("version", "unknown")
     print(
-        f"{args.name}: merged {checks} checks "
+        f"{args.name}@{version}: merged {checks} checks "
         f"(without={without_rate} with={with_rate} "
         f"delta={entry['results'][provenance['model']]['delta']}) "
-        f"model={provenance['model']}"
+        f"model={provenance['model']} harness={provenance['harness']}"
     )
+    no_delta = entry.get("evals_without_delta") or []
+    if no_delta:
+        print(
+            f"{args.name}: {len(no_delta)} eval(s) with no check the baseline "
+            f"fails: {', '.join(no_delta)}"
+        )
     return 0
 
 

--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 # run-ab-evals.sh - A/B test evals WITHOUT vs WITH skill context
-# Usage: ./scripts/run-ab-evals.sh [--no-llm] [concurrency]
+# Usage: ./scripts/run-ab-evals.sh [--no-llm] [--require-delta] [concurrency]
 # Default concurrency: 4 (parallel eval pairs)
 # --no-llm: Skip LLM-based grading of expectations (regex assertions only)
+# --require-delta: exit 1 if any eval has no discriminating assertion, i.e. no
+#   assertion that the no-skill baseline fails and the with-skill run passes.
+#   Such an eval measures boilerplate the model produces either way; it cannot
+#   support a claim that the skill changed anything.
+#
+# A delta is not a property of a skill. It is a function of skill version,
+# model, agent harness, eval set and tool environment, so every run records
+# that tuple in the provenance block of ab-results.json and prints it at the
+# end. Quote a number together with the tuple it was measured under, never on
+# its own: a stronger actor may derive the same content unaided, and then the
+# skill only costs context.
 
 set -euo pipefail
 
@@ -11,12 +22,14 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Parse flags and positional args
 NO_LLM=false
+REQUIRE_DELTA=false
 CONCURRENCY=4
 EVALS_FILE=""
 SKILL_FILE=""
 for arg in "$@"; do
     case "$arg" in
         --no-llm) NO_LLM=true ;;
+        --require-delta) REQUIRE_DELTA=true ;;
         --evals=*) EVALS_FILE="${arg#--evals=}" ;;
         --skill=*) SKILL_FILE="${arg#--skill=}" ;;
         [0-9]*) CONCURRENCY="$arg" ;;
@@ -32,6 +45,41 @@ RESULTS_DIR="${REPO_DIR}/scripts/ab-results"
 # provenance block of ab-results.json so published numbers stay reproducible.
 EVAL_MODEL="sonnet"
 GRADER_MODEL="haiku"
+
+# The rest of the actor tuple. The harness is the agent runtime that has to
+# discover and apply the skill -- a different one can be worse at that with an
+# unchanged skill -- and the skill version says which text was measured. Both
+# fall back to "unknown" rather than failing the run, because a missing
+# version is a weaker claim, not a broken measurement.
+HARNESS_VERSION="claude-code $(claude --version 2>/dev/null | head -1 | tr -d '\r\n' || true)"
+[[ "$HARNESS_VERSION" == "claude-code " ]] && HARNESS_VERSION="claude-code unknown"
+
+skill_version_of() {
+    # Nearest plugin.json above the SKILL.md, then composer.json; the skill
+    # repo convention keeps those in version parity.
+    local dir="$1" manifest
+    while [[ "$dir" != "/" && -n "$dir" ]]; do
+        for manifest in "$dir/.claude-plugin/plugin.json" "$dir/plugin.json" "$dir/composer.json"; do
+            if [[ -f "$manifest" ]]; then
+                local version
+                version=$(python3 -c "
+import json, sys
+try:
+    print(json.load(open(sys.argv[1])).get('version') or '')
+except Exception:
+    print('')
+" "$manifest")
+                if [[ -n "$version" ]]; then
+                    echo "$version"
+                    return
+                fi
+            fi
+        done
+        dir="$(dirname "$dir")"
+    done
+    echo "unknown"
+}
+SKILL_VERSION=$(skill_version_of "$(cd "$(dirname "$SKILL_FILE")" && pwd)")
 
 mkdir -p "$RESULTS_DIR"
 
@@ -168,6 +216,28 @@ Format: one line per expectation, e.g.:
         > "$grader_file" 2>/dev/null || true
 }
 
+# Expectations the with-skill run passes and the baseline does not. Same
+# anchor as count_expectation_passes below, so the two cannot disagree about
+# what a PASS line looks like.
+count_expectation_discriminating() {
+    python3 - "$1" "$2" <<'PYEOF'
+import re
+import sys
+
+
+def passing(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return set()
+    return {int(m.group(1)) for m in re.finditer(r"^(\d+)\.\s*PASS", text, re.M | re.I)}
+
+
+print(len(passing(sys.argv[2]) - passing(sys.argv[1])))
+PYEOF
+}
+
 # Count PASS lines in a grader output file
 count_expectation_passes() {
     local grader_file="$1"
@@ -240,9 +310,13 @@ TOTAL_CHECKS=0
 TOTAL_EXP_WITHOUT=0
 TOTAL_EXP_WITH=0
 TOTAL_EXPECTATIONS=0
+TOTAL_DISCRIMINATING=0
+EVALS_WITHOUT_DELTA=()
 
 for i in $(seq 0 $((EVAL_COUNT - 1))); do
     name=$(get_eval_name "$i")
+    eval_disc=0
+    eval_graded=0
 
     without_file="$RESULTS_DIR/${name}_without.txt"
     with_file="$RESULTS_DIR/${name}_with.txt"
@@ -255,14 +329,20 @@ evals = raw['evals'] if isinstance(raw, dict) and 'evals' in raw else raw
 print(len(evals[$i].get('assertions', [])))
 ")
     if [[ "$assertion_count" -gt 0 ]]; then
-        pass_w=0; pass_s=0; total=0
+        pass_w=0; pass_s=0; total=0; disc=0
         while IFS= read -r pattern; do
             [[ -z "$pattern" ]] && continue
             # Strip PCRE inline flags (e.g. (?i)) — grep -i already handles case
             pattern="${pattern#'(?i)'}"
             ((total++)) || true
-            grep -qiE "$pattern" "$without_file" 2>/dev/null && ((pass_w++)) || true
-            grep -qiE "$pattern" "$with_file" 2>/dev/null && ((pass_s++)) || true
+            hit_w=0; hit_s=0
+            grep -qiE "$pattern" "$without_file" 2>/dev/null && hit_w=1 || true
+            grep -qiE "$pattern" "$with_file" 2>/dev/null && hit_s=1 || true
+            ((pass_w += hit_w)) || true
+            ((pass_s += hit_s)) || true
+            # Discriminating: the baseline misses it and the skill run hits it.
+            # An assertion both runs pass measures boilerplate, not the skill.
+            if [[ "$hit_w" -eq 0 && "$hit_s" -eq 1 ]]; then ((disc++)) || true; fi
         done <<< "$(python3 -c "
 import json
 raw = json.load(open('$EVALS_FILE'))
@@ -278,8 +358,12 @@ for a in evals[$i].get('assertions', []):
         TOTAL_WITH=$((TOTAL_WITH + pass_s))
         TOTAL_CHECKS=$((TOTAL_CHECKS + total))
 
+        eval_disc=$((eval_disc + disc))
+        eval_graded=$((eval_graded + total))
+        TOTAL_DISCRIMINATING=$((TOTAL_DISCRIMINATING + disc))
+
         echo "| $((i+1)) | $name | regex | $pass_w/$total | $pass_s/$total | $ds |" >> "$SUMMARY_FILE"
-        echo "  $name [regex]: without=$pass_w/$total with=$pass_s/$total ($ds)"
+        echo "  $name [regex]: without=$pass_w/$total with=$pass_s/$total ($ds) discriminating=$disc/$total"
     fi
 
     # Check LLM-graded expectations
@@ -296,6 +380,9 @@ print(len(evals[$i].get('expectations', [])))
         else
             exp_pass_w=$(count_expectation_passes "$RESULTS_DIR/${name}_without_expectations.txt")
             exp_pass_s=$(count_expectation_passes "$RESULTS_DIR/${name}_with_expectations.txt")
+            exp_disc=$(count_expectation_discriminating \
+                "$RESULTS_DIR/${name}_without_expectations.txt" \
+                "$RESULTS_DIR/${name}_with_expectations.txt")
 
             exp_delta=$((exp_pass_s - exp_pass_w))
             [[ $exp_delta -gt 0 ]] && exp_ds="+$exp_delta" || exp_ds="$exp_delta"
@@ -303,10 +390,19 @@ print(len(evals[$i].get('expectations', [])))
             TOTAL_EXP_WITHOUT=$((TOTAL_EXP_WITHOUT + exp_pass_w))
             TOTAL_EXP_WITH=$((TOTAL_EXP_WITH + exp_pass_s))
             TOTAL_EXPECTATIONS=$((TOTAL_EXPECTATIONS + exp_count))
+            eval_disc=$((eval_disc + exp_disc))
+            eval_graded=$((eval_graded + exp_count))
+            TOTAL_DISCRIMINATING=$((TOTAL_DISCRIMINATING + exp_disc))
 
             echo "| $((i+1)) | $name | llm | $exp_pass_w/$exp_count | $exp_pass_s/$exp_count | $exp_ds |" >> "$SUMMARY_FILE"
-            echo "  $name [llm]: without=$exp_pass_w/$exp_count with=$exp_pass_s/$exp_count ($exp_ds)"
+            echo "  $name [llm]: without=$exp_pass_w/$exp_count with=$exp_pass_s/$exp_count ($exp_ds) discriminating=$exp_disc/$exp_count"
         fi
+    fi
+
+    # An eval nothing graded (only expectations, run with --no-llm) says
+    # nothing either way and is not reported as evidence-free.
+    if [[ "$eval_graded" -gt 0 && "$eval_disc" -eq 0 ]]; then
+        EVALS_WITHOUT_DELTA+=("$name")
     fi
 done
 
@@ -335,38 +431,103 @@ cat "$SUMMARY_FILE"
 SKILL_REPO_SHA=$(git -C "$(dirname "$SKILL_FILE")" rev-parse HEAD 2>/dev/null || echo "unknown")
 RUNNER_REPO_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
 RUNNER_SCRIPT_SHA=$(git hash-object "$0" 2>/dev/null || echo "unknown")
+# Content id of the eval set: two runs quoting the same delta must be able to
+# show they graded the same questions, and a path alone cannot.
+EVALS_SHA=$(git hash-object "$EVALS_FILE" 2>/dev/null || echo "unknown")
 RUN_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-python3 - "$RESULTS_DIR/ab-results.json" \
-    "$RUN_DATE" \
-    "$EVAL_MODEL" \
-    "$GRADER_MODEL" \
-    "$SKILL_REPO_SHA" \
-    "$RUNNER_REPO_SHA" \
-    "$RUNNER_SCRIPT_SHA" \
-    "$EVAL_COUNT" \
-    "$TOTAL_WITHOUT" "$TOTAL_WITH" "$TOTAL_CHECKS" \
-    "$TOTAL_EXP_WITHOUT" "$TOTAL_EXP_WITH" "$TOTAL_EXPECTATIONS" \
-    "$COMBINED_WITHOUT" "$COMBINED_WITH" "$COMBINED_TOTAL" <<'PYEOF'
-import json, sys
 
-with open(sys.argv[1], "w") as f:
+if [[ "$NO_LLM" == "true" ]]; then AB_GRADED_LLM_VALUE=false; else AB_GRADED_LLM_VALUE=true; fi
+AB_NO_DELTA_VALUE=$(printf '%s\n' "${EVALS_WITHOUT_DELTA[@]+"${EVALS_WITHOUT_DELTA[@]}"}")
+
+export AB_OUT="$RESULTS_DIR/ab-results.json" \
+    AB_RUN_DATE="$RUN_DATE" \
+    AB_MODEL="$EVAL_MODEL" \
+    AB_GRADER_MODEL="$GRADER_MODEL" \
+    AB_HARNESS="$HARNESS_VERSION" \
+    AB_SKILL_VERSION="$SKILL_VERSION" \
+    AB_SKILL_FILE="$SKILL_FILE" \
+    AB_SKILL_REPO_SHA="$SKILL_REPO_SHA" \
+    AB_RUNNER_REPO_SHA="$RUNNER_REPO_SHA" \
+    AB_RUNNER_SCRIPT_SHA="$RUNNER_SCRIPT_SHA" \
+    AB_EVALS_FILE="$EVALS_FILE" \
+    AB_EVALS_SHA="$EVALS_SHA" \
+    AB_EVAL_COUNT="$EVAL_COUNT" \
+    AB_GRADED_LLM="$AB_GRADED_LLM_VALUE" \
+    AB_REGEX_WITHOUT="$TOTAL_WITHOUT" AB_REGEX_WITH="$TOTAL_WITH" AB_REGEX_CHECKS="$TOTAL_CHECKS" \
+    AB_LLM_WITHOUT="$TOTAL_EXP_WITHOUT" AB_LLM_WITH="$TOTAL_EXP_WITH" AB_LLM_CHECKS="$TOTAL_EXPECTATIONS" \
+    AB_COMBINED_WITHOUT="$COMBINED_WITHOUT" AB_COMBINED_WITH="$COMBINED_WITH" AB_COMBINED_CHECKS="$COMBINED_TOTAL" \
+    AB_DISCRIMINATING="$TOTAL_DISCRIMINATING" \
+    AB_NO_DELTA="$AB_NO_DELTA_VALUE"
+
+python3 <<'PYEOF'
+import json
+import os
+
+no_delta = [line for line in os.environ["AB_NO_DELTA"].splitlines() if line]
+
+with open(os.environ["AB_OUT"], "w") as f:
     json.dump({
+        # The actor tuple a delta belongs to. Reporting a number without it
+        # states a property of the skill, which is not what was measured.
         "provenance": {
-            "run_date": sys.argv[2],
-            "model": sys.argv[3],
-            "grader_model": sys.argv[4],
-            "skill_repo_commit": sys.argv[5],
-            "runner_commit": sys.argv[6],
-            "runner_script_sha": sys.argv[7],
+            "run_date": os.environ["AB_RUN_DATE"],
+            "model": os.environ["AB_MODEL"],
+            "grader_model": os.environ["AB_GRADER_MODEL"],
+            "harness": os.environ["AB_HARNESS"],
+            "skill_version": os.environ["AB_SKILL_VERSION"],
+            "skill_file": os.environ["AB_SKILL_FILE"],
+            "skill_repo_commit": os.environ["AB_SKILL_REPO_SHA"],
+            "runner_commit": os.environ["AB_RUNNER_REPO_SHA"],
+            "runner_script_sha": os.environ["AB_RUNNER_SCRIPT_SHA"],
+            "eval_set": {
+                "path": os.environ["AB_EVALS_FILE"],
+                "sha": os.environ["AB_EVALS_SHA"],
+                "count": int(os.environ["AB_EVAL_COUNT"]),
+            },
+            "llm_grading": os.environ["AB_GRADED_LLM"] == "true",
         },
-        "eval_count": int(sys.argv[8]),
+        "eval_count": int(os.environ["AB_EVAL_COUNT"]),
         "totals": {
-            "regex": {"without": int(sys.argv[9]), "with": int(sys.argv[10]), "checks": int(sys.argv[11])},
-            "llm": {"without": int(sys.argv[12]), "with": int(sys.argv[13]), "checks": int(sys.argv[14])},
-            "combined": {"without": int(sys.argv[15]), "with": int(sys.argv[16]), "checks": int(sys.argv[17])},
+            "regex": {
+                "without": int(os.environ["AB_REGEX_WITHOUT"]),
+                "with": int(os.environ["AB_REGEX_WITH"]),
+                "checks": int(os.environ["AB_REGEX_CHECKS"]),
+            },
+            "llm": {
+                "without": int(os.environ["AB_LLM_WITHOUT"]),
+                "with": int(os.environ["AB_LLM_WITH"]),
+                "checks": int(os.environ["AB_LLM_CHECKS"]),
+            },
+            "combined": {
+                "without": int(os.environ["AB_COMBINED_WITHOUT"]),
+                "with": int(os.environ["AB_COMBINED_WITH"]),
+                "checks": int(os.environ["AB_COMBINED_CHECKS"]),
+            },
         },
+        # Checks the baseline fails and the skill run passes. An eval with
+        # none of them cannot support a claim that the skill changed anything.
+        "discriminating_checks": int(os.environ["AB_DISCRIMINATING"]),
+        "evals_without_delta": no_delta,
     }, f, indent=2)
     f.write("\n")
 PYEOF
+
+echo ""
+echo "Measured: $(basename "$(dirname "$SKILL_FILE")")@${SKILL_VERSION} · ${HARNESS_VERSION} · model ${EVAL_MODEL} (judge ${GRADER_MODEL}) · eval-set $(basename "$EVALS_FILE")@${EVALS_SHA:0:8} (${EVAL_COUNT} evals)"
+echo "Discriminating checks (baseline fails, skill passes): $TOTAL_DISCRIMINATING"
+echo "Quote the delta with that tuple, not on its own."
+
+if [[ ${#EVALS_WITHOUT_DELTA[@]} -gt 0 ]]; then
+    echo ""
+    echo "${#EVALS_WITHOUT_DELTA[@]} eval(s) with no discriminating check — the baseline"
+    echo "answered them as well as the skill run, so they are not evidence for the skill:"
+    printf '  - %s\n' "${EVALS_WITHOUT_DELTA[@]}"
+fi
+
 echo ""
 echo "Results JSON: $RESULTS_DIR/ab-results.json"
+
+if [[ "$REQUIRE_DELTA" == "true" && ${#EVALS_WITHOUT_DELTA[@]} -gt 0 ]]; then
+    echo "::error::--require-delta: ${#EVALS_WITHOUT_DELTA[@]} eval(s) have no assertion the no-skill baseline fails"
+    exit 1
+fi

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -156,9 +156,25 @@ or command shape a model can only produce by having read the skill (an internal 
 path, an exact risk multiplier, a non-obvious CLI invocation, a "do X not Y" correction
 of the model's default instinct).
 
+The runner computes this for you. It calls an assertion **discriminating** when the
+baseline fails it and the with-skill run passes it, prints
+`discriminating=<n>/<total>` on every eval line, and lists each eval that scored zero
+under a "no discriminating check" heading at the end. `ab-results.json` carries the same
+information as `discriminating_checks` and `evals_without_delta`. `--require-delta`
+turns that list into exit 1 — use it in a repo whose evals are already clean, so the
+next eval cannot arrive without evidence.
+
+Zero discriminating checks does not make an eval wrong: a regression guard both arms
+pass today is doing its job. It makes it unusable as evidence *for the skill*, which is
+a different claim and the one being made whenever skill content is defended.
+
 This verification is a **LOCAL/manual step, not CI** — `run-ab-evals.sh` calls out to
 `claude -p` per eval. It is referenced only by `.github/workflows/ab-evals-schedule.yml`,
 which is disabled by team decision, so it is not part of any active CI gate.
+
+**Report the delta with the actor it was measured under**, never as a bare percentage —
+see [`skill-quality.md`](skill-quality.md) ("A delta belongs to an actor, not to a
+skill"). The runner prints the tuple and stores it in the `provenance` block.
 
 ### `samples`: the part of that quality rule CI can decide
 

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -27,7 +27,49 @@ Size rules bound how MUCH a skill costs; this rubric bounds WHAT KIND of content
 Two protections when applying the rubric:
 
 - Categories 3 and 5 are **first-class even when they read as prose**. Reducing wrong or unnecessary inference counts as value although the model "knows" the underlying facts — a skill that surfaces the right rule at the right moment saves the retry tokens the guess would have cost. Do not cut a failure pattern or a never-guess rule because it "looks like advice".
-- A claimed activation/recall benefit ("the model knows this but forgets") is an eval claim: back it with an A/B delta (repo-root `scripts/run-ab-evals.sh`) rather than asserting it.
+- A claimed activation/recall benefit ("the model knows this but forgets") is an eval claim: back it with an A/B delta (repo-root `scripts/run-ab-evals.sh`) rather than asserting it. See "Eval evidence" below for what that delta does and does not say.
+
+## Eval evidence
+
+Whether an eval can carry evidence at all — every eval needs at least one
+assertion a no-skill baseline fails — is specified in
+[`materialization-contract.md`](materialization-contract.md) ("Quality rule:
+every eval needs a delta-discriminating assertion"), together with the
+`samples` self-check. What follows is the other half: how to report a number
+once you have one.
+
+### A delta belongs to an actor, not to a skill
+
+```text
+delta = f(skill version, model, agent harness, task, tool environment)
+```
+
+So `docker-development has +23%` is not a statement anyone can check. The
+reportable form names the tuple:
+
+```text
+docker-development@2.4.0 · claude-code 2.0.31 · model sonnet
+· eval-set evals.json@09cc52ef (24 evals) → +23% over the no-skill baseline
+```
+
+Every run prints that line and stores the same fields under `provenance` in
+`ab-results.json`, so a published number can be traced to the text, the actor
+and the questions that produced it. Quote them together — in a PR that
+justifies skill content, in the dashboard, in a release note.
+
+Two consequences worth stating, because they cut in opposite directions:
+
+- **A stronger actor can erase a delta.** If a later model derives the same
+  content unaided, the skill stops buying behaviour and only costs context.
+  That is a reason to re-measure on the current actor before defending a
+  passage, not a reason to keep the old number.
+- **A weaker delta is not always a weaker skill.** A harness that is bad at
+  skill discovery scores the skill poorly although the skill is fine. The
+  per-skill A/B eval assumes the skill is already loaded, so it cannot see
+  that failure at all — that is what the system-level evals in
+  [`netresearch/agent-system-evals`](https://github.com/netresearch/agent-system-evals)
+  measure, by giving the agent a realistic underspecified request that names
+  no skill, tool or method.
 
 ### Fact and trigger ownership
 
@@ -181,3 +223,4 @@ Pattern 2 detection is heuristic: a reference file counts as P2 when its stem ma
 - Anthropic published skills: <https://github.com/anthropics/skills>
 - Settings schema: `skillListingBudgetFraction`, `skillListingMaxDescChars` (Claude Code settings.json)
 - Den Odell, "The Great Agent Skills Land Grab": <https://denodell.com/blog/the-great-agent-skills-land-grab> — the generate-it-with-a-prompt test and the eval-evidence bar for activation/recall claims
+- Xiong et al., "How Memory Management Impacts LLM Agents: An Empirical Study of Experience-Following Behavior", ACL 2026: <https://aclanthology.org/2026.acl-long.27/> — inaccurate past experience compounds into later runs, and executions that look correct can still be misleading as experience; the paper's proposal is to use later task outcomes as quality labels, which is what `/retro outcome` does

--- a/tests/run-ab-evals.sh
+++ b/tests/run-ab-evals.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# tests/run-ab-evals.sh — the two things run-ab-evals.sh reports beyond a pass
+# rate:
+#
+#   * the actor tuple a delta belongs to (skill version, harness, model,
+#     eval-set content id), because a bare percentage is not a checkable claim
+#   * per-eval discriminating checks — assertions the no-skill baseline fails
+#     and the with-skill run passes — and `--require-delta`, which turns an
+#     eval without any of them into a non-zero exit
+#
+# The runner drives `claude -p` per eval, so the fixture puts a stub earlier on
+# PATH. The stub answers differently depending on whether the invocation
+# carries --append-system-prompt, which is exactly what separates the two arms,
+# and grades expectations by looking at the response embedded in the grading
+# prompt. No model is called.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$(cd "$HERE/.." && pwd)/scripts/run-ab-evals.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+check() { # check <name> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        fail=1
+    fi
+}
+contains() { # contains <name> <needle> <haystack>
+    case "$3" in
+        *"$2"*) echo "  ok   $1" ;;
+        *) echo "  FAIL $1: '$2' not found in output"; fail=1 ;;
+    esac
+}
+
+# --- Fixture -----------------------------------------------------------------
+mkdir -p "$WORK/bin" "$WORK/repo/scripts" "$WORK/repo/skills/demo/evals"
+cp "$RUNNER" "$WORK/repo/scripts/run-ab-evals.sh"
+
+cat > "$WORK/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+# Minimal claude stand-in. Without the skill the answer omits the gotcha; with
+# it, the answer contains it. Grading prompts are answered from the RESPONSE
+# section they carry.
+with_skill=""
+for arg in "$@"; do
+    [ "$arg" = "--version" ] && { echo "9.9.9 (Claude Code test stub)"; exit 0; }
+    [ "$arg" = "--append-system-prompt" ] && with_skill=1
+done
+prompt="${*: -1}"
+case "$prompt" in
+    *"You are grading"*)
+        case "$prompt" in
+            *"nonroot USER"*) printf '1. PASS - names the base image\n2. PASS - sets a non-root user\n' ;;
+            *) printf '1. PASS - names the base image\n2. FAIL - no non-root user\n' ;;
+        esac
+        ;;
+    *)
+        if [ -n "$with_skill" ]; then
+            echo "Use alpine and add a nonroot USER."
+        else
+            echo "Use alpine."
+        fi
+        ;;
+esac
+STUB
+chmod +x "$WORK/bin/claude"
+
+cat > "$WORK/repo/skills/demo/SKILL.md" <<'EOF'
+---
+name: demo
+description: "Use when demonstrating the A/B runner in a test fixture."
+---
+
+Always add a nonroot USER.
+EOF
+printf '{"name":"demo","version":"4.5.6"}\n' > "$WORK/repo/skills/demo/plugin.json"
+
+# One eval with a discriminating assertion (USER appears only with the skill)
+# and one whose assertions both arms satisfy.
+cat > "$WORK/repo/skills/demo/evals/mixed.json" <<'EOF'
+{"skill_name": "demo", "evals": [
+  {"name": "discriminates", "prompt": "Write a Dockerfile.",
+   "assertions": [{"type": "content", "pattern": "alpine"},
+                  {"type": "content", "pattern": "USER"}]},
+  {"name": "boilerplate_only", "prompt": "Write a Dockerfile.",
+   "assertions": [{"type": "content", "pattern": "alpine"},
+                  {"type": "content", "pattern": "Use"}]}
+]}
+EOF
+# Same file minus the evidence-free eval.
+cat > "$WORK/repo/skills/demo/evals/clean.json" <<'EOF'
+{"skill_name": "demo", "evals": [
+  {"name": "discriminates", "prompt": "Write a Dockerfile.",
+   "assertions": [{"type": "content", "pattern": "alpine"},
+                  {"type": "content", "pattern": "USER"}]}
+]}
+EOF
+# LLM-graded expectations: the grader passes the second one only for the
+# with-skill answer.
+cat > "$WORK/repo/skills/demo/evals/graded.json" <<'EOF'
+{"skill_name": "demo", "evals": [
+  {"name": "graded", "prompt": "Write a Dockerfile.",
+   "expectations": ["names the base image", "sets a non-root user"]}
+]}
+EOF
+
+run_runner() { # run_runner <evals-file> [extra-flags...]
+    local evals="$1"; shift
+    (
+        cd "$WORK/repo" || exit 99
+        PATH="$WORK/bin:$PATH" bash scripts/run-ab-evals.sh \
+            --evals="$WORK/repo/skills/demo/evals/$evals" \
+            --skill="$WORK/repo/skills/demo/SKILL.md" \
+            2 "$@" 2>&1
+    )
+}
+results_json() { python3 -c "
+import json, sys
+print(json.load(open('$WORK/repo/scripts/ab-results/ab-results.json'))$1)
+"; }
+
+# --- Regex arm ---------------------------------------------------------------
+out=$(run_runner mixed.json --no-llm)
+rc=$?
+check "a run over a well-formed eval set exits 0" 0 "$rc"
+contains "the discriminating eval reports 1 of 2 checks" \
+    "discriminates [regex]: without=1/2 with=2/2 (+1) discriminating=1/2" "$out"
+contains "the boilerplate eval reports none" \
+    "boilerplate_only [regex]: without=2/2 with=2/2 (0) discriminating=0/2" "$out"
+contains "the evidence-free eval is named in the summary" \
+    "- boilerplate_only" "$out"
+contains "the measured line carries version, harness, model and eval set" \
+    "Measured: demo@4.5.6 · claude-code 9.9.9 (Claude Code test stub) · model sonnet" "$out"
+
+check "provenance records the harness" \
+    "claude-code 9.9.9 (Claude Code test stub)" "$(results_json "['provenance']['harness']")"
+check "provenance records the skill version" "4.5.6" \
+    "$(results_json "['provenance']['skill_version']")"
+check "provenance records the eval-set size" "2" \
+    "$(results_json "['provenance']['eval_set']['count']")"
+check "provenance records an eval-set content id" "40" \
+    "$(results_json "['provenance']['eval_set']['sha']" | tr -d '\n' | wc -c)"
+check "the evidence-free eval is listed in the results file" "['boilerplate_only']" \
+    "$(results_json "['evals_without_delta']")"
+check "discriminating checks are counted" "1" \
+    "$(results_json "['discriminating_checks']")"
+
+# --- --require-delta --------------------------------------------------------
+run_runner mixed.json --no-llm --require-delta >/dev/null 2>&1
+check "--require-delta fails on an eval without a discriminating check" 1 "$?"
+
+run_runner clean.json --no-llm --require-delta >/dev/null 2>&1
+check "--require-delta passes when every eval discriminates" 0 "$?"
+
+# --- LLM-graded expectations ------------------------------------------------
+out=$(run_runner graded.json)
+contains "expectations are counted for discrimination too" \
+    "graded [llm]: without=1/2 with=2/2 (+1) discriminating=1/2" "$out"
+check "an LLM-only run is not reported as evidence-free" "[]" \
+    "$(results_json "['evals_without_delta']")"
+check "llm grading is recorded in provenance" "True" \
+    "$(results_json "['provenance']['llm_grading']")"
+
+echo ""
+if [ "$fail" -eq 0 ]; then
+    echo "All run-ab-evals tests passed"
+else
+    echo "run-ab-evals tests FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
Part of [#148](https://github.com/netresearch/skill-repo-skill/issues/148) — the rule and the instrument, not yet the per-repo backfill.

A delta is not a property of a skill:

```text
delta = f(skill version, model, agent harness, task, tool environment)
```

So `docker-development has +23%` is not a claim anyone can check, and a stronger future actor can erase the same delta while a discovery-weak harness can suppress it with the skill unchanged. Two things follow.

**1. Every run records and prints the actor tuple.** `provenance` gains `harness` (from `claude --version`), `skill_version` (nearest `plugin.json`/`composer.json` above the SKILL.md) and `eval_set` (path, content id, count) — so two runs quoting one number can show they graded the same questions. The run ends with:

```text
Measured: docker-development@2.4.0 · claude-code 2.0.31 · model sonnet (judge haiku) · eval-set evals.json@09cc52ef (24 evals)
Discriminating checks (baseline fails, skill passes): 14
Quote the delta with that tuple, not on its own.
```

`merge-ab-results.py` carries the fields into the dashboard entry, and the dashboard renders them: the actor beside the aggregate in the header, the whole tuple on every delta. The 25 existing entries have no provenance at all, so they read **"harness not recorded"** — accurate, and the point: those numbers were published without recording what produced them.

**2. The runner computes the A6 rule instead of only asking for it.** `materialization-contract.md` already requires every eval to have an assertion the no-skill baseline fails; nothing measured it. A *discriminating check* is now defined as one the baseline fails and the skill run passes, reported per eval as `discriminating=<n>/<total>`, with every zero-scoring eval listed by name and both facts in `ab-results.json` (`discriminating_checks`, `evals_without_delta`). `--require-delta` turns that list into exit 1 — for repos whose evals are already clean, which is what the backfill half of #148 has to produce first. Not wired into any CI job in this PR, deliberately.

Zero discriminating checks does not make an eval wrong — a regression guard both arms pass is doing its job — but it cannot be evidence *for the skill*, which is the claim being made whenever skill content is defended.

Docs follow ownership rather than duplicating: the rule stays canonical in `materialization-contract.md` (now with the tooling), and `skill-quality.md` owns the reporting side plus why the two eval levels answer different questions — the per-skill A/B assumes the skill is loaded and structurally cannot see a discovery failure, which is what [`netresearch/agent-system-evals`](https://github.com/netresearch/agent-system-evals) measures.

**Verified locally:**

- `tests/run-ab-evals.sh` — new, 16 assertions against a `claude` stub (no model calls): the tuple, per-eval counts in both the regex and the LLM-graded path, the named evidence-free eval, and both exit codes of `--require-delta`. It runs in CI via `tests-caller.yml` → `tests.yml` (`tests/**/*.sh`).
- Defect-injected: inverting the discrimination condition fails six assertions including both `--require-delta` directions, then restored byte-identical and green again.
- All 8 pre-existing `tests/*.sh` suites pass, `pre-commit run --files <changed>` green (`shellcheck`, `markdownlint`, `ruff`), `validate-skill.sh` and `validate-evals.sh` clean, `audit-skills.sh` unchanged verdicts.
- Dashboard driven in a real browser against the committed `results.json`: 25 rows, no page errors, header reads `model opus · harness not recorded`, delta tooltips read `netresearch-branding@2.6.0 · harness not recorded · model opus · 21 evals`.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
