### PR TITLE
fix(evals): grade must_not assertions in the direction they state

### DIFF
--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -330,7 +330,10 @@ print(len(evals[$i].get('assertions', [])))
 ")
     if [[ "$assertion_count" -gt 0 ]]; then
         pass_w=0; pass_s=0; total=0; disc=0
-        while IFS= read -r pattern; do
+        # Each line is "<kind><TAB><pattern>", kind being must_not or positive.
+        # The kind is emitted first and is never empty, so IFS cannot collapse
+        # it into the pattern field.
+        while IFS=$'\t' read -r kind pattern; do
             [[ -z "$pattern" ]] && continue
             # Strip PCRE inline flags (e.g. (?i)) — grep -i already handles case
             pattern="${pattern#'(?i)'}"
@@ -338,17 +341,31 @@ print(len(evals[$i].get('assertions', [])))
             hit_w=0; hit_s=0
             grep -qiE "$pattern" "$without_file" 2>/dev/null && hit_w=1 || true
             grep -qiE "$pattern" "$with_file" 2>/dev/null && hit_s=1 || true
-            ((pass_w += hit_w)) || true
-            ((pass_s += hit_s)) || true
-            # Discriminating: the baseline misses it and the skill run hits it.
-            # An assertion both runs pass measures boilerplate, not the skill.
-            if [[ "$hit_w" -eq 0 && "$hit_s" -eq 1 ]]; then ((disc++)) || true; fi
+            # A must_not assertion passes when the pattern is ABSENT. Grading it
+            # like a positive one credits the arm that gives the forbidden
+            # answer, which is the opposite of what the eval states.
+            if [[ "$kind" == "must_not" ]]; then
+                ok_w=$((1 - hit_w)); ok_s=$((1 - hit_s))
+            else
+                ok_w="$hit_w"; ok_s="$hit_s"
+            fi
+            ((pass_w += ok_w)) || true
+            ((pass_s += ok_s)) || true
+            # Discriminating: the baseline fails the assertion and the skill run
+            # passes it. An assertion both arms pass measures boilerplate, not
+            # the skill.
+            if [[ "$ok_w" -eq 0 && "$ok_s" -eq 1 ]]; then ((disc++)) || true; fi
         done <<< "$(python3 -c "
 import json
 raw = json.load(open('$EVALS_FILE'))
 evals = raw['evals'] if isinstance(raw, dict) and 'evals' in raw else raw
 for a in evals[$i].get('assertions', []):
-    print(a.get('value') or a.get('pattern') or '')
+    if isinstance(a, dict):
+        pattern = a.get('value') or a.get('pattern') or ''
+        kind = 'must_not' if 'must_not' in str(a.get('type') or '') else 'positive'
+    else:
+        pattern, kind = str(a), 'positive'
+    print(kind + '\t' + pattern)
 ")"
 
         delta=$((pass_s - pass_w))

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -201,13 +201,20 @@ without the skill — a straw man that shares no vocabulary with a correct answe
 the check while proving nothing.
 
 **Matching uses the grader's instrument, not a similar one.** `run-ab-evals.sh` grades
-with `grep -qiE` after stripping a leading `(?i)`: case-insensitive POSIX ERE, with no
-type filter — it takes `value or pattern` from *every* assertion. The validator calls the
+with `grep -qiE` after stripping a leading `(?i)`: case-insensitive POSIX ERE, over
+`value or pattern` from *every* assertion whatever its type. The validator calls the
 same binary with the same flags, because Python's `re` disagrees with ERE in ways that
 decide real cases (`[^\n]` excludes the letter `n` in ERE, and `re` is case-sensitive),
 and a self-check measuring with a different engine certifies evals the grader would fail.
-For the same reason a pattern under `tool_use` or `content_regex` is validated too. An
-assertion typed `must_not` is checked inverted: it must NOT match `passing`.
+For the same reason a pattern under `tool_use` or `content_regex` is validated too.
+
+**A `must_not` assertion is inverted in both instruments.** The validator requires that it
+does NOT match `samples.passing`; the grader counts the arm in which the pattern is
+**absent** as the passing one, and a discriminating check accordingly means the baseline
+produced the forbidden answer and the skill run did not. Until August 2026 the grader
+ignored the type and credited whichever arm *contained* the pattern, so a negative
+expectation could not be stated as an assertion at all and had to live in
+`samples.failing`. Both directions are now pinned in `tests/run-ab-evals.sh`.
 
 Two things change for evals **without** a samples block: patterns are now checked to be
 parseable by `grep -E`, and an unparseable one fails — except under a `*_contains` type,

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -14,8 +14,8 @@
 # Patterns are checked with `grep -E` and matched with `grep -qiE`, the same
 # binary and flags run-ab-evals.sh grades with, so the check cannot certify an
 # eval the grader would fail. Every assertion carrying value/pattern counts,
-# whatever its type, because the grader has no type filter either; `must_not`
-# is checked inverted.
+# whatever its type, because the grader greps every one of them; `must_not` is
+# checked inverted here and graded inverted there.
 #
 # Usage: bash validate-evals.sh [path-to-evals.json] [--require-evals]
 #   If no path given, searches skills/*/evals/evals.json then evals/evals.json
@@ -308,10 +308,12 @@ for i, ev in enumerate(evals):
             # A pattern only had to be a non-empty string until now, so an
             # unbalanced group passed validation and first misbehaved wherever
             # the eval was actually graded. Which assertions count is decided by
-            # the grader, not by a type name: run-ab-evals.sh takes
-            # `value or pattern` from EVERY assertion with no type filter, so a
-            # broken pattern under type "tool_use", "content_regex" or any other
-            # label is graded and must be validated the same way.
+            # the grader, not by a type name: run-ab-evals.sh greps
+            # `value or pattern` from EVERY assertion, so a broken pattern under
+            # type "tool_use", "content_regex" or any other label is graded and
+            # must be validated the same way. The type decides only the
+            # DIRECTION of the verdict -- `must_not` passes when the pattern is
+            # absent -- not whether the assertion is graded at all.
             patterns = []
             for j, a in enumerate(assertions):
                 if not isinstance(a, dict):

--- a/tests/run-ab-evals.sh
+++ b/tests/run-ab-evals.sh
@@ -100,6 +100,17 @@ cat > "$WORK/repo/skills/demo/evals/clean.json" <<'EOF'
                   {"type": "content", "pattern": "USER"}]}
 ]}
 EOF
+# A negative expectation. The baseline answer says "Use alpine." and the
+# with-skill answer adds the USER line, so a must_not on `USER` must FAIL the
+# with-skill arm and PASS the baseline — the mirror image of a positive
+# assertion, and the case that was graded backwards until the type was read.
+cat > "$WORK/repo/skills/demo/evals/negative.json" <<'EOF'
+{"skill_name": "demo", "evals": [
+  {"name": "forbids_user_line", "prompt": "Write a Dockerfile.",
+   "assertions": [{"type": "content", "pattern": "alpine"},
+                  {"type": "must_not", "pattern": "USER"}]}
+]}
+EOF
 # LLM-graded expectations: the grader passes the second one only for the
 # with-skill answer.
 cat > "$WORK/repo/skills/demo/evals/graded.json" <<'EOF'
@@ -156,6 +167,15 @@ check "--require-delta fails on an eval without a discriminating check" 1 "$?"
 
 run_runner clean.json --no-llm --require-delta >/dev/null 2>&1
 check "--require-delta passes when every eval discriminates" 0 "$?"
+
+# --- must_not is graded inverted --------------------------------------------
+out=$(run_runner negative.json --no-llm)
+contains "a must_not assertion passes the arm that lacks the pattern" \
+    "forbids_user_line [regex]: without=2/2 with=1/2 (-1) discriminating=0/2" "$out"
+check "an eval whose only movement is a must_not violation is not counted as evidence" \
+    "['forbids_user_line']" "$(results_json "['evals_without_delta']")"
+check "no discriminating check is credited when the skill run violates the must_not" "0" \
+    "$(results_json "['discriminating_checks']")"
 
 # --- LLM-graded expectations ------------------------------------------------
 out=$(run_runner graded.json)

--- a/tests/validate-evals.sh
+++ b/tests/validate-evals.sh
@@ -171,8 +171,9 @@ bash "$SCRIPT" "$WORK/samples-case.json" >/dev/null 2>&1
 check "case-insensitive like the grader" 0 "$?"
 
 # --- every graded assertion is validated, whatever its type is ---------------
-# The grader takes value-or-pattern from EVERY assertion with no type filter,
-# so a broken pattern under tool_use is graded and must be caught.
+# The grader greps value-or-pattern from EVERY assertion, whatever its type,
+# so a broken pattern under tool_use is graded and must be caught. (The type
+# decides the direction of the verdict, not whether it is graded.)
 suite "$WORK/tooluse-pattern.json" <<'EOF'
 { "name": "broken_pattern_under_tool_use", "prompt": "Anything.",
   "assertions": [{"type": "tool_use", "tool": "Bash", "pattern": "(unclosed group"},


### PR DESCRIPTION
Closes #230.

The grading loop emitted only `value or pattern`, so the assertion type never reached the comparison and everything was scored as "pattern present = pass". For `must_not` that is backwards: the arm giving the forbidden answer got the point, the baseline rate rose, the delta shrank, and the discriminating count added in #229 inherited the same inversion. A negative expectation could not be stated as an assertion at all — in [docker-development-skill#62](https://github.com/netresearch/docker-development-skill/pull/62) it had to move into `samples.failing`.

**The fix** reads kind and pattern as a two-field line — kind first and never empty, so `IFS` cannot collapse it into the pattern field — and inverts the verdict for `must_not`. Passing means the pattern is **absent**; a discriminating check means the baseline produced the forbidden answer and the skill run did not.

**Blast radius, measured rather than assumed.** 58 `must_not` assertions in two repos:

| repo | assertions | published delta |
|---|---|---|
| german-technical-writing-skill | 35 | none |
| github-release-skill | 23 | none |

Neither appears in `docs/dashboard/data/results.json`, so no published number was computed in the wrong direction and nothing has to be retracted. Both want a run before their first publish — which is [#232](https://github.com/netresearch/skill-repo-skill/issues/232)'s job anyway, and #230 was its stated blocker.

**Docs corrected.** Three places stated "no type filter" as settled behaviour: the validator header, the validator's inline justification for checking every pattern, and `materialization-contract.md`. They now separate the two questions — every assertion is graded whatever its type, and the type decides the *direction* of the verdict.

**Verified:**

- `tests/run-ab-evals.sh` gains the mirror case, and I ran it against the **unfixed** grader first: three assertions fail, including "an eval whose only movement is a `must_not` violation is not counted as evidence" (it was credited with a discriminating check before).
- All 9 `tests/*.sh` suites pass; `pre-commit run --files <changed>` green; `shellcheck` clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
