### PR TITLE
feat(evals): decide every assertion by majority over repeated samples

### DIFF
--- a/.github/workflows/ab-evals-caller.yml
+++ b/.github/workflows/ab-evals-caller.yml
@@ -38,6 +38,13 @@ on:
         description: "Run the full catalog instead of the rotation subset (several hours)"
         type: boolean
         default: false
+      samples:
+        description: >-
+          Completions per arm (default 3). A verdict from one completion flips
+          between runs on unchanged evals, so 3 is the number the per-eval
+          results are quoted from; the run costs 2xN completions per eval.
+        type: number
+        default: 3
 
 permissions: {}
 
@@ -56,5 +63,6 @@ jobs:
     with:
       skills: ${{ inputs.skills || '' }}
       full: ${{ inputs.full || false }}
+      samples: ${{ inputs.samples || 3 }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ab-evals-schedule.yml
+++ b/.github/workflows/ab-evals-schedule.yml
@@ -32,6 +32,16 @@ on:
         required: false
         type: string
         default: ""
+      samples:
+        description: >-
+          Completions per arm. 3 is the default because a verdict from a single
+          completion flips between runs on unchanged evals (issue #236); the run
+          costs 2xN completions per eval, so 3 triples the token bill against
+          the old behaviour. Lower it to 1 only for a cheap indicative run whose
+          per-eval verdicts must not be quoted.
+        required: false
+        type: number
+        default: 3
       full:
         description: "Run the full catalog instead of the rotation subset (several hours)"
         required: false
@@ -151,6 +161,7 @@ jobs:
       - name: Run A/B evals per skill (fail-soft)
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          SAMPLES_PER_ARM: ${{ inputs.samples }}
         run: |
           mkdir -p /tmp/ab-out
           : > /tmp/ab-out/pr-lines.md
@@ -181,7 +192,8 @@ jobs:
               failed+=("$name"); echo "::endgroup::"; continue
             fi
             rm -rf scripts/ab-results
-            if ! bash scripts/run-ab-evals.sh --evals="$evals" --skill="$skill" < /dev/null; then
+            if ! bash scripts/run-ab-evals.sh --evals="$evals" --skill="$skill" \
+                 --samples="${SAMPLES_PER_ARM}" < /dev/null; then
               echo "::warning::${name}: eval run failed, skipping"
               failed+=("$name"); echo "::endgroup::"; continue
             fi
@@ -240,6 +252,7 @@ jobs:
       - name: Open PR with refreshed dashboard data
         env:
           GH_TOKEN: ${{ github.token }}
+          SAMPLES_PER_ARM: ${{ inputs.samples }}
         run: |
           if git diff --quiet -- docs/dashboard/data/results.json; then
             echo "No changes to dashboard data; skipping PR."
@@ -262,6 +275,8 @@ jobs:
             echo ""
             if [[ -s /tmp/ab-out/no-delta.md ]]; then
               echo "## Evals with no discriminating check"
+              echo ""
+              echo "Verdicts are a majority over ${SAMPLES_PER_ARM} completions per arm."
               echo ""
               echo "The baseline answered these as well as the skill run, so they are not"
               echo "evidence for the skill. That does not make them wrong — a regression"

--- a/docs/dashboard/index.html
+++ b/docs/dashboard/index.html
@@ -433,8 +433,14 @@ function releaseUrl(s) { return `https://github.com/${s.repo}/releases/tag/v${s.
 function measuredUnder(s) {
   const p = s.provenance || {};
   const evalSet = p.eval_set ? `${p.eval_set.count} evals @ ${String(p.eval_set.sha).slice(0, 8)}` : `${s.eval_count} evals`;
+  // How many completions each arm got. A number from one sample per arm is a
+  // coin flip per eval, so the tuple has to say which it is rather than let
+  // the reader assume the firmer one.
+  const samples = p.samples_per_arm
+    ? `${p.samples_per_arm} sample${p.samples_per_arm === 1 ? '' : 's'}/arm`
+    : 'sample count not recorded';
   return `${s.name}@${s.version || 'unknown'} · ${p.harness || 'harness not recorded'}`
-    + ` · model ${s.modelKey || 'unknown'} · ${evalSet}`
+    + ` · model ${s.modelKey || 'unknown'} · ${evalSet} · ${samples}`
     + (p.run_date ? ` · ${p.run_date.split('T')[0]}` : '');
 }
 function skillUrl(s) { return ghUrl(s, s.skill_path || `skills/${s.name}/SKILL.md`); }
@@ -465,7 +471,7 @@ document.getElementById('headerMeta').innerHTML =
   `<span><span class="num">${skills.length}</span> skills</span>` +
   `<span><span class="num">${totalEvals}</span> evals</span>` +
   `<span><span class="num">+${(avgDelta * 100).toFixed(0)}%</span> avg delta</span>` +
-  `<span title="A delta is measured for one skill version under one harness, model and eval set — it is not a property of the skill. Hover a delta for the tuple behind it.">` +
+  `<span title="A delta is measured for one skill version under one harness, model, eval set and sample count — it is not a property of the skill. Hover a delta for the tuple behind it.">` +
   `model ${tupleField(skills.map(s => s.modelKey), 'unknown')} · ` +
   `${tupleField(skills.map(s => (s.provenance || {}).harness), 'harness not recorded')}</span>` +
   `<span>${DATA.generated.split('T')[0]}</span>`;

--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # run-ab-evals.sh - A/B test evals WITHOUT vs WITH skill context
-# Usage: ./scripts/run-ab-evals.sh [--no-llm] [--require-delta] [concurrency]
+# Usage: ./scripts/run-ab-evals.sh [--no-llm] [--samples=N] [--require-delta] [concurrency]
 # Default concurrency: 4 (parallel eval pairs)
 # --no-llm: Skip LLM-based grading of expectations (regex assertions only)
+# --samples=N: completions per arm (default 1). Every per-assertion verdict is
+#   then a majority over the samples. --require-delta demands N>=2, because a
+#   verdict from a single completion flips between runs on unchanged evals.
 # --require-delta: exit 1 if any eval has no discriminating assertion, i.e. no
 #   assertion that the no-skill baseline fails and the with-skill run passes.
 #   Such an eval measures boilerplate the model produces either way; it cannot
@@ -23,6 +26,10 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Parse flags and positional args
 NO_LLM=false
 REQUIRE_DELTA=false
+# Completions per arm. One is the historical behaviour and the cheapest run,
+# but a single sample cannot support a gate: unchanged evals were measured
+# flipping between discriminating and not on consecutive runs (issue #236).
+SAMPLES=1
 CONCURRENCY=4
 EVALS_FILE=""
 SKILL_FILE=""
@@ -30,6 +37,7 @@ for arg in "$@"; do
     case "$arg" in
         --no-llm) NO_LLM=true ;;
         --require-delta) REQUIRE_DELTA=true ;;
+        --samples=*) SAMPLES="${arg#--samples=}" ;;
         --evals=*) EVALS_FILE="${arg#--evals=}" ;;
         --skill=*) SKILL_FILE="${arg#--skill=}" ;;
         [0-9]*) CONCURRENCY="$arg" ;;
@@ -37,6 +45,15 @@ for arg in "$@"; do
 done
 
 # Defaults if not provided
+if ! [[ "$SAMPLES" =~ ^[1-9][0-9]*$ ]]; then
+    echo "--samples must be a positive integer, got '$SAMPLES'" >&2
+    exit 2
+fi
+if [[ "$REQUIRE_DELTA" == "true" && "$SAMPLES" -lt 2 ]]; then
+    echo "::error::--require-delta needs --samples=2 or more: a verdict from a single completion per arm flips between runs on unchanged evals, which is the configuration issue #236 rejected" >&2
+    exit 2
+fi
+
 EVALS_FILE="${EVALS_FILE:-$REPO_DIR/skills/skill-repo/evals/evals.json}"
 SKILL_FILE="${SKILL_FILE:-$REPO_DIR/skills/skill-repo/SKILL.md}"
 RESULTS_DIR="${REPO_DIR}/scripts/ab-results"
@@ -120,14 +137,25 @@ print(evals[$1].get('$2', ''))
 "
 }
 
+# Answer file for one sample. Sample 1 keeps the historical name so existing
+# tooling and eyeballs still find it; further samples get a suffix.
+sample_file() { # sample_file <name> <mode> <sample-index>
+    if [[ "$3" -le 1 ]]; then
+        echo "$RESULTS_DIR/${1}_${2}.txt"
+    else
+        echo "$RESULTS_DIR/${1}_${2}_s${3}.txt"
+    fi
+}
+
 run_single() {
     local idx="$1"
     local mode="$2"
+    local sample="${3:-1}"
     local name prompt output_file
 
     name=$(get_eval_name "$idx")
     prompt=$(get_eval_field "$idx" "prompt")
-    output_file="$RESULTS_DIR/${name}_${mode}.txt"
+    output_file="$(sample_file "$name" "$mode" "$sample")"
 
     # Two isolation steps, both added after a run showed the arms differing in
     # something other than the skill:
@@ -166,28 +194,40 @@ $NO_TOOLS_NOTE"
 
 run_pair() {
     local idx="$1"
-    local name
+    local name sample
+    local -a pids=()
     name=$(get_eval_name "$idx")
-    echo "  Starting eval $idx: $name"
-    run_single "$idx" "without" &
-    local pid1=$!
-    run_single "$idx" "with" &
-    local pid2=$!
-    wait "$pid1" "$pid2" 2>/dev/null || true
+    echo "  Starting eval $idx: $name ($SAMPLES sample(s) per arm)"
+    for ((sample = 1; sample <= SAMPLES; sample++)); do
+        run_single "$idx" "without" "$sample" &
+        pids+=("$!")
+        run_single "$idx" "with" "$sample" &
+        pids+=("$!")
+    done
+    wait "${pids[@]}" 2>/dev/null || true
     echo "  Finished eval $idx: $name"
 }
 
 # Grade expectations via LLM judge
 # Writes results to $RESULTS_DIR/${name}_${mode}_expectations.txt
+grader_file_for() { # grader_file_for <name> <mode> <sample-index>
+    if [[ "$3" -le 1 ]]; then
+        echo "$RESULTS_DIR/${1}_${2}_expectations.txt"
+    else
+        echo "$RESULTS_DIR/${1}_${2}_s${3}_expectations.txt"
+    fi
+}
+
 grade_expectations() {
     local idx="$1"
     local mode="$2"
+    local sample="${3:-1}"
     local name prompt output_file expectations_count grader_file
 
     name=$(get_eval_name "$idx")
     prompt=$(get_eval_field "$idx" "prompt")
-    output_file="$RESULTS_DIR/${name}_${mode}.txt"
-    grader_file="$RESULTS_DIR/${name}_${mode}_expectations.txt"
+    output_file="$(sample_file "$name" "$mode" "$sample")"
+    grader_file="$(grader_file_for "$name" "$mode" "$sample")"
 
     # Get expectations as numbered list
     expectations_count=$(python3 -c "
@@ -251,11 +291,32 @@ is_non_answer() {
     return 1
 }
 
-# Expectations the with-skill run passes and the baseline does not. Same
-# anchor as count_expectation_passes below, so the two cannot disagree about
-# what a PASS line looks like.
-count_expectation_discriminating() {
-    python3 - "$1" "$2" <<'PYEOF'
+# Does an assertion pass in MORE THAN HALF the usable samples of one arm?
+# A single completion is not a verdict -- unchanged evals were measured
+# flipping between runs -- so every per-assertion decision is a majority over
+# the samples, and `must_not` inverts each sample before the vote.
+majority_pass() { # majority_pass <kind> <pattern> <file...>
+    local kind="$1" pattern="$2"
+    shift 2
+    local hits=0 total=0 hit file
+    for file in "$@"; do
+        total=$((total + 1))
+        if grep -qiE "$pattern" "$file" 2>/dev/null; then hit=1; else hit=0; fi
+        [[ "$kind" == "must_not" ]] && hit=$((1 - hit))
+        hits=$((hits + hit))
+    done
+    [[ $((hits * 2)) -gt "$total" ]]
+}
+
+# Majority verdict over LLM-graded expectations, the counterpart of
+# majority_pass for the assertion path. Prints three numbers:
+#   <expectations the baseline passes> <the skill run passes> <discriminating>
+# An expectation counts as passed in an arm when more than half that arm's
+# usable grader files mark it PASS. Grader files that are missing or empty --
+# a sample whose completion never happened -- are dropped rather than counted
+# as failures, for the same reason a non-answer is not a refutation.
+expectation_majority() { # expectation_majority <n-without> <without...> <with...>
+    python3 - "$@" <<'PYEOF'
 import re
 import sys
 
@@ -265,22 +326,32 @@ def passing(path):
         with open(path, encoding="utf-8", errors="replace") as f:
             text = f.read()
     except OSError:
-        return set()
+        return None
+    if not text.strip():
+        return None
     return {int(m.group(1)) for m in re.finditer(r"^(\d+)\.\s*PASS", text, re.M | re.I)}
 
 
-print(len(passing(sys.argv[2]) - passing(sys.argv[1])))
-PYEOF
-}
+n_without = int(sys.argv[1])
+files = sys.argv[2:]
+arms = [
+    [s for s in (passing(p) for p in files[:n_without]) if s is not None],
+    [s for s in (passing(p) for p in files[n_without:]) if s is not None],
+]
 
-# Count PASS lines in a grader output file
-count_expectation_passes() {
-    local grader_file="$1"
-    if [[ ! -f "$grader_file" ]]; then
-        echo 0
-        return
-    fi
-    grep -ciE '^[0-9]+\.\s*PASS' "$grader_file" 2>/dev/null || echo 0
+
+def majority(samples, number):
+    if not samples:
+        return False
+    return sum(1 for s in samples if number in s) * 2 > len(samples)
+
+
+numbers = sorted({n for arm in arms for s in arm for n in s})
+pass_w = sum(1 for n in numbers if majority(arms[0], n))
+pass_s = sum(1 for n in numbers if majority(arms[1], n))
+disc = sum(1 for n in numbers if majority(arms[1], n) and not majority(arms[0], n))
+print(f"{pass_w} {pass_s} {disc}")
+PYEOF
 }
 
 # Run evals in batches
@@ -319,8 +390,10 @@ evals = raw['evals'] if isinstance(raw, dict) and 'evals' in raw else raw
 print(len(evals[$i].get('expectations', [])))
 ")
                 if [[ "$exp_count" -gt 0 ]]; then
-                    grade_expectations "$i" "without" &
-                    grade_expectations "$i" "with" &
+                    for ((sample = 1; sample <= SAMPLES; sample++)); do
+                        grade_expectations "$i" "without" "$sample" &
+                        grade_expectations "$i" "with" "$sample" &
+                    done
                 fi
             done
             wait
@@ -354,15 +427,25 @@ for i in $(seq 0 $((EVAL_COUNT - 1))); do
     eval_disc=0
     eval_graded=0
 
-    if is_non_answer "$RESULTS_DIR/${name}_without.txt" || is_non_answer "$RESULTS_DIR/${name}_with.txt"; then
+    # Drop samples that carry no answer; an arm with none left leaves the eval
+    # unmeasured rather than counted as evidence-free.
+    usable_w=(); usable_s=(); sample=0
+    for ((sample = 1; sample <= SAMPLES; sample++)); do
+        f=$(sample_file "$name" "without" "$sample")
+        is_non_answer "$f" || usable_w+=("$f")
+        f=$(sample_file "$name" "with" "$sample")
+        is_non_answer "$f" || usable_s+=("$f")
+    done
+    if [[ ${#usable_w[@]} -eq 0 || ${#usable_s[@]} -eq 0 ]]; then
         EVALS_UNMEASURED+=("$name")
-        echo "  $name: NOT MEASURED — an arm carries no answer (limit, API error or empty response)" >&2
+        echo "  $name: NOT MEASURED — an arm carries no answer in any sample (limit, API error or empty response)" >&2
         echo "| $((i+1)) | $name | — | not measured | not measured | -- |" >> "$SUMMARY_FILE"
         continue
     fi
-
-    without_file="$RESULTS_DIR/${name}_without.txt"
-    with_file="$RESULTS_DIR/${name}_with.txt"
+    dropped=$(( (SAMPLES - ${#usable_w[@]}) + (SAMPLES - ${#usable_s[@]}) ))
+    if [[ "$dropped" -gt 0 ]]; then
+        echo "  $name: $dropped of $((SAMPLES * 2)) samples carried no answer and were dropped" >&2
+    fi
 
     # Check regex assertions
     assertion_count=$(python3 -c "
@@ -381,17 +464,11 @@ print(len(evals[$i].get('assertions', [])))
             # Strip PCRE inline flags (e.g. (?i)) — grep -i already handles case
             pattern="${pattern#'(?i)'}"
             ((total++)) || true
-            hit_w=0; hit_s=0
-            grep -qiE "$pattern" "$without_file" 2>/dev/null && hit_w=1 || true
-            grep -qiE "$pattern" "$with_file" 2>/dev/null && hit_s=1 || true
-            # A must_not assertion passes when the pattern is ABSENT. Grading it
-            # like a positive one credits the arm that gives the forbidden
-            # answer, which is the opposite of what the eval states.
-            if [[ "$kind" == "must_not" ]]; then
-                ok_w=$((1 - hit_w)); ok_s=$((1 - hit_s))
-            else
-                ok_w="$hit_w"; ok_s="$hit_s"
-            fi
+            # A must_not assertion passes when the pattern is ABSENT; the
+            # inversion happens per sample inside majority_pass, before the vote.
+            ok_w=0; ok_s=0
+            majority_pass "$kind" "$pattern" "${usable_w[@]}" && ok_w=1
+            majority_pass "$kind" "$pattern" "${usable_s[@]}" && ok_s=1
             ((pass_w += ok_w)) || true
             ((pass_s += ok_s)) || true
             # Discriminating: the baseline fails the assertion and the skill run
@@ -438,11 +515,14 @@ print(len(evals[$i].get('expectations', [])))
             echo "| $((i+1)) | $name | llm | skipped | skipped | -- |" >> "$SUMMARY_FILE"
             echo "  $name [llm]: skipped (--no-llm)"
         else
-            exp_pass_w=$(count_expectation_passes "$RESULTS_DIR/${name}_without_expectations.txt")
-            exp_pass_s=$(count_expectation_passes "$RESULTS_DIR/${name}_with_expectations.txt")
-            exp_disc=$(count_expectation_discriminating \
-                "$RESULTS_DIR/${name}_without_expectations.txt" \
-                "$RESULTS_DIR/${name}_with_expectations.txt")
+            graders_w=(); graders_s=()
+            for ((sample = 1; sample <= SAMPLES; sample++)); do
+                graders_w+=("$(grader_file_for "$name" "without" "$sample")")
+                graders_s+=("$(grader_file_for "$name" "with" "$sample")")
+            done
+            read -r exp_pass_w exp_pass_s exp_disc < <(
+                expectation_majority "${#graders_w[@]}" "${graders_w[@]}" "${graders_s[@]}"
+            )
 
             exp_delta=$((exp_pass_s - exp_pass_w))
             [[ $exp_delta -gt 0 ]] && exp_ds="+$exp_delta" || exp_ds="$exp_delta"
@@ -513,6 +593,7 @@ export AB_OUT="$RESULTS_DIR/ab-results.json" \
     AB_EVALS_FILE="$EVALS_FILE" \
     AB_EVALS_SHA="$EVALS_SHA" \
     AB_EVAL_COUNT="$EVAL_COUNT" \
+    AB_SAMPLES="$SAMPLES" \
     AB_GRADED_LLM="$AB_GRADED_LLM_VALUE" \
     AB_REGEX_WITHOUT="$TOTAL_WITHOUT" AB_REGEX_WITH="$TOTAL_WITH" AB_REGEX_CHECKS="$TOTAL_CHECKS" \
     AB_LLM_WITHOUT="$TOTAL_EXP_WITHOUT" AB_LLM_WITH="$TOTAL_EXP_WITH" AB_LLM_CHECKS="$TOTAL_EXPECTATIONS" \
@@ -548,6 +629,9 @@ with open(os.environ["AB_OUT"], "w") as f:
                 "count": int(os.environ["AB_EVAL_COUNT"]),
             },
             "llm_grading": os.environ["AB_GRADED_LLM"] == "true",
+            # Completions per arm. A verdict from one sample flips between
+            # runs on unchanged evals, so the number belongs next to the delta.
+            "samples_per_arm": int(os.environ["AB_SAMPLES"]),
         },
         "eval_count": int(os.environ["AB_EVAL_COUNT"]),
         "totals": {
@@ -579,7 +663,7 @@ with open(os.environ["AB_OUT"], "w") as f:
 PYEOF
 
 echo ""
-echo "Measured: $(basename "$(dirname "$SKILL_FILE")")@${SKILL_VERSION} · ${HARNESS_VERSION} · model ${EVAL_MODEL} (judge ${GRADER_MODEL}) · eval-set $(basename "$EVALS_FILE")@${EVALS_SHA:0:8} (${EVAL_COUNT} evals)"
+echo "Measured: $(basename "$(dirname "$SKILL_FILE")")@${SKILL_VERSION} · ${HARNESS_VERSION} · model ${EVAL_MODEL} (judge ${GRADER_MODEL}) · eval-set $(basename "$EVALS_FILE")@${EVALS_SHA:0:8} (${EVAL_COUNT} evals, ${SAMPLES} sample(s)/arm)"
 echo "Discriminating checks (baseline fails, skill passes): $TOTAL_DISCRIMINATING"
 echo "Quote the delta with that tuple, not on its own."
 

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -162,7 +162,8 @@ baseline fails it and the with-skill run passes it, prints
 under a "no discriminating check" heading at the end. `ab-results.json` carries the same
 information as `discriminating_checks` and `evals_without_delta`. `--require-delta`
 turns that list into exit 1 — use it in a repo whose evals are already clean, so the
-next eval cannot arrive without evidence.
+next eval cannot arrive without evidence. Note the cost: `2 × N` completions per eval,
+so a sampled run over a 20-eval suite is 120 model calls.
 
 Zero discriminating checks does not make an eval wrong: a regression guard both arms
 pass today is doing its job. It makes it unusable as evidence *for the skill*, which is

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -73,10 +73,11 @@ Two consequences worth stating, because they cut in opposite directions:
 
 ### Where the gate lives, and where it must not
 
-`run-ab-evals.sh --require-delta` is a **local, pre-merge** instrument: run it
-in the repo you are editing, before opening the PR that adds the eval. It calls
-the model twice per eval, so it cannot run on every pull request, and it is
-deliberately **not** wired into the scheduled sweep either. The sweep's job is
+`run-ab-evals.sh --samples=3 --require-delta` is a **local, pre-merge**
+instrument: run it in the repo you are editing, before opening the PR that adds
+the eval. It calls the model `2 × N` times per eval, so it cannot run on every
+pull request, and it is deliberately **not** wired into the scheduled sweep
+either. The sweep's job is
 to publish numbers; a gate there would abort a skill's merge step, and a skill
 with one weak eval would quietly stop being refreshed on the dashboard while
 looking merely unchanged. The sweep therefore *reports* the evidence-free evals
@@ -87,25 +88,31 @@ the assertions accept a correct answer and reject a wrong one, which is the
 mechanical half of "this eval discriminates". Prefer adding `samples` over
 adding a CI job that spends tokens.
 
-### One sample per arm: a signal, not a verdict
+### Sample each arm more than once
 
-Each arm is a single completion, so per-eval discrimination is noisy. Measured
-on this repo's own suite, two consecutive runs of the *same* eval text:
+A single completion per arm is not a verdict. Measured on this repo's own
+suite, two consecutive runs of the *same* eval text:
 
 | eval | run 1 | run 2 |
 |---|---|---|
 | `migrate_single_license` | 2 discriminating checks | 0 |
 | `release_workflow_setup` | 1 | 0 |
 
-Nothing about those evals changed between the runs. `--require-delta` would
-have failed them on one day and passed them on the other, which is why it is
-an opt-in local signal — read the list, look at the two arms, decide — and not
-a hard gate. Making it a gate would need repeated sampling per arm, at a
-multiple of the token cost, and that is a budget decision rather than a flag.
+Nothing about those evals changed between the runs. `--samples=N` therefore
+runs N completions per arm and decides every assertion by **majority over the
+samples**; `must_not` inverts each sample before the vote, and samples that
+carry no answer are dropped rather than counted as failures. The sweep uses
+3 by default, and `ab-results.json` records `samples_per_arm` so a quoted
+number always says how firm it is.
 
-What survives the noise is the aggregate and the pattern: a suite where half
-the evals never discriminate is telling you something real even if the exact
-membership of the list moves.
+`--require-delta` refuses to run below `--samples=2` — gating on a coin flip
+is the failure mode the flag exists to prevent, one level up.
+
+The cost is linear and real: `2 × N` completions per eval, so the default
+triples what a single-sample sweep costs. Use `--samples=1` for a cheap
+indicative run whose *aggregate* is still informative — a suite where half the
+evals never discriminate is telling you something either way — but do not
+quote a per-eval verdict from it.
 
 ### Read the arms before believing the delta
 

--- a/tests/run-ab-evals.sh
+++ b/tests/run-ab-evals.sh
@@ -73,6 +73,25 @@ prompt="${*: -1}"
 # STUB_LIMIT=1 makes the stub answer like a CLI that hit its session limit:
 # the refusal goes to stdout and thus into the answer file, exactly as the real
 # one does.
+# STUB_FLAKY=1 models the run-to-run variance that motivated sampling: exactly
+# ONE with-arm sample misses the second assertion. Which of the parallel calls
+# draws it is arbitrary, but that exactly one does is not -- the index comes
+# from an atomic mkdir ticket, so the test asserts a property rather than a
+# race. One sample is then a coin flip; three samples are a majority.
+# Ticket dispenser for STUB_FLAKY, drawn ONLY by the with-skill arm -- a ticket
+# consumed by the baseline call would shift which sample draws number 1 and
+# make the test depend on scheduling.
+draw_flaky_ticket() {
+    flaky_ticket=0
+    [ -n "${STUB_FLAKY:-}" ] && [ -n "${STUB_TICKET_DIR:-}" ] || return 0
+    mkdir -p "$STUB_TICKET_DIR" 2>/dev/null
+    i=1
+    while [ "$i" -le 99 ]; do
+        if mkdir "$STUB_TICKET_DIR/t$i" 2>/dev/null; then flaky_ticket=$i; return 0; fi
+        i=$((i + 1))
+    done
+}
+
 if [ -n "${STUB_LIMIT:-}" ]; then
     case "$prompt" in
         *"You are grading"*) ;;
@@ -89,7 +108,12 @@ case "$prompt" in
         ;;
     *)
         if [ -n "$with_skill" ]; then
-            echo "Use alpine and add a nonroot USER."
+            draw_flaky_ticket
+            if [ "${flaky_ticket:-0}" = "1" ]; then
+                echo "Use alpine."      # the one sample that misses the USER line
+            else
+                echo "Use alpine and add a nonroot USER."
+            fi
         else
             echo "Use alpine."
         fi
@@ -153,7 +177,8 @@ run_runner() { # run_runner <evals-file> [extra-flags...]
     (
         cd "$WORK/repo" || exit 99
         PATH="$WORK/bin:$PATH" STUB_CALL_LOG="$WORK/calls.log" \
-        STUB_LIMIT="${STUB_LIMIT:-}" bash scripts/run-ab-evals.sh \
+        STUB_LIMIT="${STUB_LIMIT:-}" STUB_FLAKY="${STUB_FLAKY:-}" \
+        STUB_TICKET_DIR="$WORK/tickets" bash scripts/run-ab-evals.sh \
             --evals="$WORK/repo/skills/demo/evals/$evals" \
             --skill="$WORK/repo/skills/demo/SKILL.md" \
             2 "$@" 2>&1
@@ -192,10 +217,10 @@ check "discriminating checks are counted" "1" \
     "$(results_json "['discriminating_checks']")"
 
 # --- --require-delta --------------------------------------------------------
-run_runner mixed.json --no-llm --require-delta >/dev/null 2>&1
+run_runner mixed.json --no-llm --require-delta --samples=2 >/dev/null 2>&1
 check "--require-delta fails on an eval without a discriminating check" 1 "$?"
 
-run_runner clean.json --no-llm --require-delta >/dev/null 2>&1
+run_runner clean.json --no-llm --require-delta --samples=2 >/dev/null 2>&1
 check "--require-delta passes when every eval discriminates" 0 "$?"
 
 # --- The measurement is isolated from the operator's environment -------------
@@ -239,8 +264,44 @@ check "it is kept out of the evidence-free list" "[]" \
 check "its checks are kept out of the totals" "0" \
     "$(results_json "['totals']['combined']['checks']")"
 
-STUB_LIMIT=1 run_runner clean.json --no-llm --require-delta >/dev/null 2>&1
+STUB_LIMIT=1 run_runner clean.json --no-llm --require-delta --samples=3 >/dev/null 2>&1
 check "--require-delta fails when nothing could be measured" 1 "$?"
+
+# --- Sampling ----------------------------------------------------------------
+# The reason this exists: with one completion per arm a flaky answer decides the
+# verdict. With three, the majority does. The stub alternates the with-arm
+# answer, so a single sample is a coin flip and three samples are not.
+out=$(run_runner clean.json --no-llm --samples=3)
+contains "each arm is sampled the requested number of times" \
+    "3 sample(s) per arm" "$out"
+check "the sample count is recorded in provenance" "3" \
+    "$(results_json "['provenance']['samples_per_arm']")"
+check "per-arm samples are written to their own files" "yes" \
+    "$([[ -f "$WORK/repo/scripts/ab-results/discriminates_with_s3.txt" ]] && echo yes || echo no)"
+check "the first sample keeps the historical filename" "yes" \
+    "$([[ -f "$WORK/repo/scripts/ab-results/discriminates_with.txt" ]] && echo yes || echo no)"
+
+# One flaky sample decides the verdict at N=1 ...
+rm -rf "$WORK/tickets"
+STUB_FLAKY=1 run_runner clean.json --no-llm >/dev/null 2>&1
+check "a single sample lets one flaky answer decide the verdict" "['discriminates']" \
+    "$(results_json "$NO_DELTA_PATH")"
+
+# ... and does not at N=3, which is the whole point of the flag.
+rm -rf "$WORK/tickets"
+out=$(STUB_FLAKY=1 run_runner clean.json --no-llm --samples=3)
+contains "a majority over three samples outvotes the flaky one" \
+    "discriminating=1/2" "$out"
+check "the flaky eval counts as evidence when sampled" "[]" \
+    "$(results_json "$NO_DELTA_PATH")"
+
+# --- The gate refuses to run on a single sample ------------------------------
+run_runner clean.json --no-llm --require-delta >/dev/null 2>&1
+check "--require-delta refuses --samples=1" 2 "$?"
+run_runner clean.json --no-llm --require-delta --samples=3 >/dev/null 2>&1
+check "--require-delta accepts a sampled run" 0 "$?"
+run_runner mixed.json --no-llm --require-delta --samples=3 >/dev/null 2>&1
+check "--require-delta still fails on an evidence-free eval when sampled" 1 "$?"
 
 echo ""
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
Closes #236, answered yes: pay the multiplier, get a verdict that holds still.

## What changes

`--samples=N` runs N completions per arm and decides **each assertion by majority over them**. `must_not` inverts each sample before the vote, so validator and grader still agree on direction. Samples whose answer never arrived — session limit, API error, empty body — are dropped rather than counted as failures, and an arm left with none still makes the eval *unmeasured*. The LLM-graded path votes the same way, per expectation number.

`--require-delta` refuses to run below `--samples=2`. Gating on a single completion is the configuration #236 rejected; leaving it reachable would have kept that failure mode one flag away.

The sweep passes **3** by default and states it in the PR body it opens, so a reader knows how firm the per-eval verdicts are.

## The cost, stated plainly

`2 × N` completions per eval. For this repo's 21 evals that is **126 instead of 42**; across the weekly rotation it triples the sweep's bill. The number is in the workflow input description rather than in a comment, because it is the entire content of the decision this PR implements.

`--samples=1` remains available for a cheap indicative run — the aggregate still says something — but `skill-quality.md` now says not to quote a per-eval verdict from it.

## How the property is tested, not just the plumbing

The test stub makes exactly **one** with-arm sample miss an assertion, and the index is drawn through an atomic `mkdir` ticket, so it is deterministic without depending on how the parallel calls happen to be scheduled. Then:

| | verdict |
|---|---|
| `--samples=1` | the eval lands in `evals_without_delta` — one flaky answer decided it |
| `--samples=3` | the majority outvotes the flaky sample and it counts as evidence |

That is the flip from #236 reproduced in a fixture, and it is what the two new assertions pin. 36 assertions total, stable across three consecutive runs of the suite.

## Detail

Sample 1 keeps the historical filename; further samples get an `_sN` suffix, so existing eyeballs and tooling still find the first answer. `samples_per_arm` is recorded in `provenance` and printed in the `Measured:` line. Two helpers that only ever read a single grader file are removed, superseded by the majority function.

**Verified so far:** all 9 `tests/*.sh` suites pass, `shellcheck` and `actionlint` clean, `pre-commit run --files <changed>` green. A real 3-sample run against this repo's own suite is in flight; I will post its numbers here, in particular whether `migrate_single_license` and `release_workflow_setup` — the two evals that flipped between single-sample runs — now hold still.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_

---

## First sampled run against this repo's own suite

`skill-repo@1.35.0 · claude-code 2.1.235 · sonnet · 21 evals · 3 samples/arm` — 126 completions, 0 unmeasured:

| | single sample (previous run) | 3 samples |
|---|---|---|
| baseline | 44/80 | 43/80 |
| with skill | 60/80 | 65/80 |
| discriminating checks | 23 | 24 |
| evidence-free evals | 9 | 8 |

The two evals that motivated the issue:

| eval | run A (n=1) | run B (n=1) | sampled (n=3) |
|---|---|---|---|
| `migrate_single_license` | 2 | 0 | **2** |
| `release_workflow_setup` | 1 | 0 | **1** |

Both report the value they had in the run where they discriminated, which is what a majority should do with one outlying sample.

**That is one sampled run, so it does not yet establish stability** — a single measurement claiming "this is now stable" would repeat the error this PR exists to fix. A second sampled run is in flight; I will post the comparison, and if the per-eval verdicts differ between two sampled runs, that is a finding against `--samples=3` being enough and belongs here rather than in a later surprise.
