### PR TITLE
feat(evals): gate on the evidence ratio, which holds still between runs

### DIFF
--- a/scripts/run-ab-evals.sh
+++ b/scripts/run-ab-evals.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 # run-ab-evals.sh - A/B test evals WITHOUT vs WITH skill context
-# Usage: ./scripts/run-ab-evals.sh [--no-llm] [--samples=N] [--require-delta] [concurrency]
+# Usage: ./scripts/run-ab-evals.sh [--no-llm] [--samples=N]
+#            [--min-evidence-ratio=P] [--require-delta] [concurrency]
 # Default concurrency: 4 (parallel eval pairs)
 # --no-llm: Skip LLM-based grading of expectations (regex assertions only)
 # --samples=N: completions per arm (default 1). Every per-assertion verdict is
 #   then a majority over the samples. --require-delta demands N>=2, because a
 #   verdict from a single completion flips between runs on unchanged evals.
+# --min-evidence-ratio=P: exit 1 unless at least P percent of the MEASURED evals
+#   carry a discriminating check. This is the gate the measurements support: at
+#   --samples=3 the per-eval membership still moves between runs, the ratio does
+#   not. Prefer it over --require-delta for anything that blocks a merge.
 # --require-delta: exit 1 if any eval has no discriminating assertion, i.e. no
 #   assertion that the no-skill baseline fails and the with-skill run passes.
 #   Such an eval measures boilerplate the model produces either way; it cannot
@@ -30,6 +35,11 @@ REQUIRE_DELTA=false
 # but a single sample cannot support a gate: unchanged evals were measured
 # flipping between discriminating and not on consecutive runs (issue #236).
 SAMPLES=1
+# Fraction of measured evals that must contribute at least one discriminating
+# check, as a percentage. Empty = not enforced. This is the gate that survives
+# the noise: per-eval membership moves between runs even at --samples=3, while
+# the ratio does not (issue #238).
+MIN_EVIDENCE_RATIO=""
 CONCURRENCY=4
 EVALS_FILE=""
 SKILL_FILE=""
@@ -38,6 +48,7 @@ for arg in "$@"; do
         --no-llm) NO_LLM=true ;;
         --require-delta) REQUIRE_DELTA=true ;;
         --samples=*) SAMPLES="${arg#--samples=}" ;;
+        --min-evidence-ratio=*) MIN_EVIDENCE_RATIO="${arg#--min-evidence-ratio=}" ;;
         --evals=*) EVALS_FILE="${arg#--evals=}" ;;
         --skill=*) SKILL_FILE="${arg#--skill=}" ;;
         [0-9]*) CONCURRENCY="$arg" ;;
@@ -47,6 +58,10 @@ done
 # Defaults if not provided
 if ! [[ "$SAMPLES" =~ ^[1-9][0-9]*$ ]]; then
     echo "--samples must be a positive integer, got '$SAMPLES'" >&2
+    exit 2
+fi
+if [[ -n "$MIN_EVIDENCE_RATIO" ]] && ! [[ "$MIN_EVIDENCE_RATIO" =~ ^[0-9]+$ ]]; then
+    echo "--min-evidence-ratio must be a whole percentage, got '$MIN_EVIDENCE_RATIO'" >&2
     exit 2
 fi
 if [[ "$REQUIRE_DELTA" == "true" && "$SAMPLES" -lt 2 ]]; then
@@ -654,6 +669,17 @@ with open(os.environ["AB_OUT"], "w") as f:
         # Checks the baseline fails and the skill run passes. An eval with
         # none of them cannot support a claim that the skill changed anything.
         "discriminating_checks": int(os.environ["AB_DISCRIMINATING"]),
+        # Share of measured evals carrying at least one discriminating check.
+        # Stable across runs where the per-eval membership is not, so this is
+        # the number to gate on and to quote.
+        "evidence_ratio": (
+            round(
+                (int(os.environ["AB_EVAL_COUNT"]) - len(unmeasured) - len(no_delta))
+                * 100.0
+                / max(1, int(os.environ["AB_EVAL_COUNT"]) - len(unmeasured)),
+                1,
+            )
+        ),
         "evals_without_delta": no_delta,
         # Pairs where at least one arm carried no answer at all. Unknown, not
         # evidence-free: excluded from the totals and from --require-delta.
@@ -684,6 +710,25 @@ fi
 
 echo ""
 echo "Results JSON: $RESULTS_DIR/ab-results.json"
+
+# The gate the two-run comparison actually supports. Per-eval membership moved
+# between two identical --samples=3 runs (24 vs 26 discriminating checks, but
+# four evals swapped sides); the RATIO of evals carrying evidence did not.
+if [[ -n "$MIN_EVIDENCE_RATIO" ]]; then
+    measured_evals=$((EVAL_COUNT - ${#EVALS_UNMEASURED[@]}))
+    if [[ "$measured_evals" -le 0 ]]; then
+        echo "::error::--min-evidence-ratio: nothing was measured — every eval pair carried a non-answer" >&2
+        exit 1
+    fi
+    with_evidence=$((measured_evals - ${#EVALS_WITHOUT_DELTA[@]}))
+    ratio=$(( with_evidence * 100 / measured_evals ))
+    echo ""
+    echo "Evidence ratio: ${with_evidence}/${measured_evals} measured evals carry a discriminating check (${ratio}%), floor ${MIN_EVIDENCE_RATIO}%"
+    if [[ "$ratio" -lt "$MIN_EVIDENCE_RATIO" ]]; then
+        echo "::error::--min-evidence-ratio: ${ratio}% of measured evals carry a discriminating check, below the ${MIN_EVIDENCE_RATIO}% floor" >&2
+        exit 1
+    fi
+fi
 
 if [[ "$REQUIRE_DELTA" == "true" ]]; then
     # A run that measured nothing must not pass the gate: without this floor an

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -113,11 +113,19 @@ three-sample runs of this repo's own suite, nothing changed in between, still
 disagreed about four evals — all of them at the 0↔1 boundary, where a single
 marginal assertion decides the verdict. The aggregate held (24 vs 26
 discriminating checks, 8 vs 6 evidence-free); the membership of the list did
-not. So read a `--require-delta` failure as *"these evals were marginal in
-this run"*, not as *"these evals carry no evidence"*, and do not gate a merge
-on it yet. Tracked in
-[#238](https://github.com/netresearch/skill-repo-skill/issues/238), which
-weighs gating on the aggregate instead.
+not.
+
+So the two flags have different jobs:
+
+| flag | what it is for |
+|---|---|
+| `--require-delta` | a **reading** signal. Read a failure as "these evals were marginal in this run", open the two arms, decide. Do not block a merge on it. |
+| `--min-evidence-ratio=P` | the **gate**. Fails unless at least P percent of the *measured* evals carry a discriminating check — the quantity that held still across both runs. |
+
+Pick the floor from a measurement of the suite rather than from taste, and
+leave headroom for the boundary cases: this suite measured 62% and 71% on two
+consecutive runs, so a floor of 50% holds while a floor of 70% would fail
+every other time — which would be the same coin flip one level up.
 
 The cost is linear and real: `2 × N` completions per eval, so the default
 triples what a single-sample sweep costs. Use `--samples=1` for a cheap

--- a/tests/run-ab-evals.sh
+++ b/tests/run-ab-evals.sh
@@ -303,6 +303,30 @@ check "--require-delta accepts a sampled run" 0 "$?"
 run_runner mixed.json --no-llm --require-delta --samples=3 >/dev/null 2>&1
 check "--require-delta still fails on an evidence-free eval when sampled" 1 "$?"
 
+# --- The aggregate gate ------------------------------------------------------
+# mixed.json holds one discriminating eval and one evidence-free one, so the
+# ratio is exactly 50%. That makes both sides of the floor testable without
+# depending on which evals happen to be marginal.
+out=$(run_runner mixed.json --no-llm --min-evidence-ratio=50)
+rc=$?
+check "a ratio at the floor passes" 0 "$rc"
+contains "the ratio is reported with its floor" \
+    "Evidence ratio: 1/2 measured evals carry a discriminating check (50%), floor 50%" "$out"
+check "the ratio lands in the results file" "50.0" \
+    "$(results_json "['evidence_ratio']")"
+
+run_runner mixed.json --no-llm --min-evidence-ratio=60 >/dev/null 2>&1
+check "a ratio below the floor fails" 1 "$?"
+
+run_runner clean.json --no-llm --min-evidence-ratio=100 >/dev/null 2>&1
+check "a suite where every eval discriminates clears a 100% floor" 0 "$?"
+
+STUB_LIMIT=1 run_runner clean.json --no-llm --min-evidence-ratio=50 >/dev/null 2>&1
+check "the ratio gate fails when nothing could be measured" 1 "$?"
+
+run_runner mixed.json --no-llm --min-evidence-ratio=abc >/dev/null 2>&1
+check "a non-numeric floor is rejected before any model call" 2 "$?"
+
 echo ""
 if [ "$fail" -eq 0 ]; then
     echo "All run-ab-evals tests passed"


### PR DESCRIPTION
Closes #238, taking its option 1 — gate on the aggregate — because that is the option the measurements support.

**What #238 measured.** Two consecutive `--samples=3` runs of this repo's own suite, nothing changed in between, disagreed about four evals (all at the 0↔1 boundary, where one marginal assertion decides the verdict). What held still was the aggregate: 24 vs 26 discriminating checks, 8 vs 6 evidence-free out of 21.

**`--min-evidence-ratio=P`** fails the run unless at least P percent of the **measured** evals carry a discriminating check. Unmeasured pairs are excluded from both sides of the fraction, so a limit-blocked sample cannot make a suite look worse than it is, and a run that measured nothing fails outright rather than dividing by zero.

That gives the two flags different jobs, which is now written down:

| flag | job |
|---|---|
| `--require-delta` | a **reading** signal — "these evals were marginal in this run"; open the two arms and decide. Not for blocking a merge. |
| `--min-evidence-ratio` | the **gate**, on the quantity that survives the noise. |

`evidence_ratio` also lands in `ab-results.json`, so the sweep and the dashboard can quote the stable number instead of a membership list that moves.

**Picking the floor is itself a measurement.** The docs say so explicitly: this suite came out at 62% and 71% on consecutive runs, so a 50% floor holds where 70% would fail every other time — the same coin flip one level up, which is exactly what this change exists to avoid.

**Verified:** the `mixed` fixture has a ratio of exactly 50% by construction, so both sides of the floor are testable without depending on which evals happen to be marginal — at the floor passes, below it fails, a clean suite clears a 100% floor, a fully blocked run fails, and a non-numeric floor is rejected before any model call. All 9 `tests/*.sh` suites pass; `shellcheck` and `pre-commit run --files <changed>` clean.

**Not done here, deliberately:** nothing is wired to enforce the new flag yet. The sweep still reports rather than gates, and picking a floor per repo needs a measurement per repo — that is a decision with numbers attached, not a default I should choose for 25 repos in this PR.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
