### PR TITLE
fix(validate): close four coverage gaps in the shared validation stack

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -157,7 +157,12 @@ jobs:
           # makes an unavailable version fail with its own message instead of
           # surfacing inside the caller's test command.
           uv python install "$PYTHON_VERSION"
-          RESOLVED=$(uv run --no-project python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
+          # --no-project: resolve the interpreter the way a caller's plain
+          #   `uv run` does, without touching the repo's dependencies.
+          # --no-build: no source distribution is built, so no setup script runs
+          #   (SonarCloud). Nothing is installed here in the first place -- there
+          #   is no --with and no project, so there is nothing to lock either.
+          RESOLVED=$(uv run --no-project --no-build python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
           echo "matrix version : $PYTHON_VERSION"
           echo "uv resolves to : $RESOLVED"
           case "$RESOLVED" in

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,3 +1,9 @@
+# Python tests and an optional Bandit scan for skill repos that ship Python.
+#
+# Scope: Python only. Shell linting is NOT here -- validate.yml already runs
+# ShellCheck over every repo, and a second gate in a workflow only Python repos
+# call would leave shell scripts unchecked wherever ci-python.yml is not used
+# (issue #180).
 name: Python CI
 
 on:
@@ -8,7 +14,11 @@ on:
         type: string
         default: '["3.12", "3.13"]'
       test-command:
-        description: Command to run for testing (receives PYTHON_VERSION env var)
+        description: >-
+          Command to run for testing. The matrix interpreter is installed and
+          exported as both PYTHON_VERSION and UV_PYTHON, so a plain `uv run
+          pytest` already uses it; anything invoking python directly should use
+          `uv run --python "$PYTHON_VERSION" ...` so the matrix is real.
         type: string
         required: true
       run-bandit:
@@ -117,6 +127,11 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
+          # Installs this interpreter and sets UV_PYTHON to it. Without it the
+          # matrix only exported a version string, so a caller writing plain
+          # `uv run pytest` tested the runner's default interpreter N times and
+          # the matrix silently guaranteed nothing (issue #179).
+          python-version: ${{ matrix.python }}
           # Default glob plus workflow files: callers without Python dependency
           # files (standalone scripts, uv run --with) otherwise get a
           # "No file matched" warning annotation on every run.
@@ -130,6 +145,25 @@ jobs:
             **/*.py.lock
             .github/workflows/*.yml
             .github/workflows/*.yaml
+
+      # The matrix is only a guarantee if the interpreter actually follows it.
+      # Asserted rather than printed: a version input that silently falls back
+      # to the runner's default would otherwise look like a passing matrix.
+      - name: Assert the matrix interpreter is the one uv resolves
+        env:
+          PYTHON_VERSION: ${{ matrix.python }}
+        run: |
+          # setup-uv's python-version only exports UV_PYTHON; installing it here
+          # makes an unavailable version fail with its own message instead of
+          # surfacing inside the caller's test command.
+          uv python install "$PYTHON_VERSION"
+          RESOLVED=$(uv run --no-project python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
+          echo "matrix version : $PYTHON_VERSION"
+          echo "uv resolves to : $RESOLVED"
+          case "$RESOLVED" in
+            "$PYTHON_VERSION"|"$PYTHON_VERSION".*) ;;
+            *) echo "::error::uv resolves to $RESOLVED, not the matrix version $PYTHON_VERSION — the matrix is not testing what it claims"; exit 1 ;;
+          esac
 
       - name: Run tests
         env:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -146,28 +146,31 @@ jobs:
             .github/workflows/*.yml
             .github/workflows/*.yaml
 
-      # The matrix is only a guarantee if the interpreter actually follows it.
-      # Asserted rather than printed: a version input that silently falls back
-      # to the runner's default would otherwise look like a passing matrix.
-      - name: Assert the matrix interpreter is the one uv resolves
+      # The matrix is only a guarantee if the interpreter actually follows it,
+      # and the failure mode is silent: a version input that does not take
+      # effect still produces N green jobs with N different names.
+      #
+      # Two things make it a guarantee, so both are asserted rather than
+      # assumed. UV_PYTHON is what steers `uv run` — measured directly:
+      # `UV_PYTHON=3.12 uv run --no-project python3 -V` answers 3.12.13 on a
+      # machine whose default is 3.14. setup-uv sets it from python-version;
+      # if a future version stops doing that, this step says so instead of the
+      # matrix quietly collapsing onto one interpreter.
+      - name: Assert the matrix interpreter is installed and selected
         env:
           PYTHON_VERSION: ${{ matrix.python }}
         run: |
-          # setup-uv's python-version only exports UV_PYTHON; installing it here
-          # makes an unavailable version fail with its own message instead of
-          # surfacing inside the caller's test command.
+          # Explicit install: an unavailable version fails here, with uv's own
+          # message, rather than inside the caller's test command.
           uv python install "$PYTHON_VERSION"
-          # --no-project: resolve the interpreter the way a caller's plain
-          #   `uv run` does, without touching the repo's dependencies.
-          # --no-build: no source distribution is built, so no setup script runs
-          #   (SonarCloud). Nothing is installed here in the first place -- there
-          #   is no --with and no project, so there is nothing to lock either.
-          RESOLVED=$(uv run --no-project --no-build python3 -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
           echo "matrix version : $PYTHON_VERSION"
-          echo "uv resolves to : $RESOLVED"
-          case "$RESOLVED" in
+          echo "UV_PYTHON      : ${UV_PYTHON:-<unset>}"
+          if [[ -z "${UV_PYTHON:-}" ]]; then
+            echo "::error::UV_PYTHON is unset — setup-uv did not apply python-version, so uv run would pick the runner default and every matrix entry would test the same interpreter"; exit 1
+          fi
+          case "$UV_PYTHON" in
             "$PYTHON_VERSION"|"$PYTHON_VERSION".*) ;;
-            *) echo "::error::uv resolves to $RESOLVED, not the matrix version $PYTHON_VERSION — the matrix is not testing what it claims"; exit 1 ;;
+            *) echo "::error::UV_PYTHON is $UV_PYTHON, not the matrix version $PYTHON_VERSION — the matrix is not testing what it claims"; exit 1 ;;
           esac
 
       - name: Run tests

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,6 +87,31 @@ jobs:
         with:
           fail-on-error: true
 
+      # Only plugin.json was ever parsed, so a broken composer.json or
+      # hooks/*.json reached main and failed wherever it was first read
+      # (issue #181). This mirrors the check-json pre-commit hook, which most
+      # repos do not install.
+      - name: JSON syntax
+        run: |
+          FAILED=0
+          COUNT=0
+          while IFS= read -r -d '' f; do
+            case "$f" in
+              vendor/*|*/vendor/*|node_modules/*|*/node_modules/*) continue ;;
+            esac
+            COUNT=$((COUNT + 1))
+            # json.tool writes the reformatted document to the second argument;
+            # /dev/null keeps the check quiet and the diagnostic on stderr.
+            if ! ERR=$(python3 -m json.tool "$f" /dev/null 2>&1); then
+              echo "::error file=${f}::invalid JSON: ${ERR}"
+              FAILED=1
+            fi
+          done < <(git ls-files -z '*.json')
+          if [[ "$FAILED" -eq 1 ]]; then
+            exit 1
+          fi
+          echo "${COUNT} tracked JSON file(s) parse"
+
       - name: Validate plugin version format
         run: |
           PLUGIN_FILE=".claude-plugin/plugin.json"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -107,44 +107,54 @@ jobs:
           PLUGIN_FILE=".claude-plugin/plugin.json"
           PLUGIN_VERSION=$(python3 -c "import json; print(json.load(open('$PLUGIN_FILE'))['version'])")
 
-          # Find SKILL.md
-          SKILL_FILE=""
+          # Every SKILL.md, not just the first: a repo shipping several skills
+          # had the others' versions unchecked, the same first-match-wins hole
+          # the validator had (issue #214).
+          SKILL_FILES=()
           if [[ -f "SKILL.md" ]]; then
-            SKILL_FILE="SKILL.md"
-          else
-            for f in skills/*/SKILL.md; do
-              if [[ -f "$f" ]]; then
-                SKILL_FILE="$f"
-                break
-              fi
-            done
+            SKILL_FILES+=("SKILL.md")
           fi
+          for f in skills/*/SKILL.md; do
+            [[ -f "$f" ]] && SKILL_FILES+=("$f")
+          done
 
-          if [[ -z "${SKILL_FILE}" ]]; then
+          if [[ ${#SKILL_FILES[@]} -eq 0 ]]; then
             echo "No SKILL.md found, skipping"
             exit 0
           fi
 
-          # Extract version from YAML frontmatter
-          SKILL_VERSION=$(sed -n '/^---$/,/^---$/p' "${SKILL_FILE}" \
-            | grep -E '^\s*version:' \
-            | head -1 \
-            | sed 's/.*version:[[:space:]]*//' \
-            | tr -d '"'"'")
-
-          if [[ -z "${SKILL_VERSION}" ]]; then
-            echo "No metadata.version in ${SKILL_FILE} frontmatter, skipping"
-            exit 0
-          fi
-
           echo "plugin.json version: ${PLUGIN_VERSION}"
-          echo "SKILL.md version:    ${SKILL_VERSION}"
+          MISMATCH=0
+          CHECKED=0
+          for SKILL_FILE in "${SKILL_FILES[@]}"; do
+            # Extract version from YAML frontmatter
+            SKILL_VERSION=$(sed -n '/^---$/,/^---$/p' "${SKILL_FILE}" \
+              | grep -E '^\s*version:' \
+              | head -1 \
+              | sed 's/.*version:[[:space:]]*//' \
+              | tr -d '"'"'")
 
-          if [[ "${PLUGIN_VERSION}" != "${SKILL_VERSION}" ]]; then
-            echo "::error::Version mismatch — plugin.json (${PLUGIN_VERSION}) != SKILL.md metadata.version (${SKILL_VERSION})"
+            if [[ -z "${SKILL_VERSION}" ]]; then
+              echo "No metadata.version in ${SKILL_FILE} frontmatter, skipping"
+              continue
+            fi
+
+            CHECKED=$((CHECKED + 1))
+            echo "${SKILL_FILE} version: ${SKILL_VERSION}"
+            if [[ "${PLUGIN_VERSION}" != "${SKILL_VERSION}" ]]; then
+              echo "::error file=${SKILL_FILE}::Version mismatch — plugin.json (${PLUGIN_VERSION}) != ${SKILL_FILE} metadata.version (${SKILL_VERSION})"
+              MISMATCH=1
+            fi
+          done
+
+          if [[ "${MISMATCH}" -eq 1 ]]; then
             exit 1
           fi
-          echo "Versions match"
+          if [[ "${CHECKED}" -eq 0 ]]; then
+            echo "No SKILL.md declares metadata.version, nothing to compare"
+            exit 0
+          fi
+          echo "Versions match in ${CHECKED} SKILL.md file(s)"
 
       - name: ShellCheck scripts
         run: |

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -58,58 +58,58 @@ done
 # Every message names the file it is about, so a finding in a multi-skill repo
 # is attributable without counting output lines.
 validate_skill_md() {
-    local SKILL_FILE="$1"
-    local REL="${SKILL_FILE#"$REPO_DIR"/}"
-    local SKILL_NAME=""
+    local skill_file="$1"
+    local rel="${skill_file#"$REPO_DIR"/}"
+    local skill_name=""
     # Declared local so nothing carries over from the previous skill in the loop.
-    local CLOSING_LINE FRONTMATTER EXTRA_FIELDS FIELD_NAMES DESC WORDS
-    local RELATIVE_PATHS COUNT SKILL_DIR SKILL_DIR_REL CHECKPOINTS_JUSTIFIED
-    local UNTESTED MISCLASSIFIED f s base
-    success "SKILL.md found: $REL"
+    local closing_line frontmatter extra_fields field_names desc words
+    local relative_paths count skill_dir skill_dir_rel checkpoints_justified
+    local untested misclassified f s base
+    success "SKILL.md found: $rel"
 
     # Frontmatter delimiter
-    if head -1 "$SKILL_FILE" | grep -q "^---$"; then
+    if head -1 "$skill_file" | grep -q "^---$"; then
         # Verify closing --- delimiter exists (within first 30 lines)
-        CLOSING_LINE=$(sed -n '2,30{/^---$/=}' "$SKILL_FILE" | head -1)
-        if [[ -z "$CLOSING_LINE" ]]; then
-            error "$REL frontmatter has opening --- but no closing --- delimiter"
+        closing_line=$(sed -n '2,30{/^---$/=}' "$skill_file" | head -1)
+        if [[ -z "$closing_line" ]]; then
+            error "$rel frontmatter has opening --- but no closing --- delimiter"
         else
-            success "$REL has frontmatter"
+            success "$rel has frontmatter"
         fi
 
         # Extract frontmatter fields (between first two --- lines)
-        FRONTMATTER=$(sed -n '2,/^---$/{ /^---$/d; p; }' "$SKILL_FILE")
+        frontmatter=$(sed -n '2,/^---$/{ /^---$/d; p; }' "$skill_file")
 
         # Check frontmatter fields match Agent Skills spec
         # Allowed: name, description, license, compatibility, metadata, allowed-tools
-        EXTRA_FIELDS=$(echo "$FRONTMATTER" | grep -E "^[a-z_-]+:" | grep -vE "^(name|description|license|compatibility|metadata|allowed-tools):" || true)
-        if [[ -z "$EXTRA_FIELDS" ]]; then
-            success "$REL frontmatter fields are valid per Agent Skills spec"
+        extra_fields=$(echo "$frontmatter" | grep -E "^[a-z_-]+:" | grep -vE "^(name|description|license|compatibility|metadata|allowed-tools):" || true)
+        if [[ -z "$extra_fields" ]]; then
+            success "$rel frontmatter fields are valid per Agent Skills spec"
         else
-            FIELD_NAMES=$(echo "$EXTRA_FIELDS" | sed 's/:.*//' | tr '\n' ', ' | sed 's/,$//')
-            error "$REL frontmatter has non-spec fields: $FIELD_NAMES (allowed: name, description, license, compatibility, metadata, allowed-tools)"
+            field_names=$(echo "$extra_fields" | sed 's/:.*//' | tr '\n' ', ' | sed 's/,$//')
+            error "$rel frontmatter has non-spec fields: $field_names (allowed: name, description, license, compatibility, metadata, allowed-tools)"
         fi
 
         # Check name field
-        if echo "$FRONTMATTER" | grep -q "^name:"; then
-            SKILL_NAME=$(echo "$FRONTMATTER" | grep "^name:" | head -1 | sed 's/name: *//' | tr -d '"')
+        if echo "$frontmatter" | grep -q "^name:"; then
+            skill_name=$(echo "$frontmatter" | grep "^name:" | head -1 | sed 's/name: *//' | tr -d '"')
             # The plugin.json comparison further down uses one name. Single-skill
             # repos keep the behaviour they had; multi-skill repos skip that
             # comparison anyway, since plugin.json names the plugin, not a skill.
             if [[ -z "$NAME" ]]; then
-                NAME="$SKILL_NAME"
+                NAME="$skill_name"
             fi
-            if [[ "$SKILL_NAME" =~ ^[a-z0-9-]{1,64}$ ]]; then
-                success "$REL name valid: $SKILL_NAME"
+            if [[ "$skill_name" =~ ^[a-z0-9-]{1,64}$ ]]; then
+                success "$rel name valid: $skill_name"
             else
-                error "$REL name invalid (lowercase, hyphens, max 64): $SKILL_NAME"
+                error "$rel name invalid (lowercase, hyphens, max 64): $skill_name"
             fi
         else
-            error "$REL missing 'name' field"
+            error "$rel missing 'name' field"
         fi
 
         # Check description field and prefix
-        if echo "$FRONTMATTER" | grep -q "^description:"; then
+        if echo "$frontmatter" | grep -q "^description:"; then
             # Parse the *YAML value* of description so every valid scalar style
             # (plain, single/double-quoted, block) is accepted as long as the
             # parsed value starts with "Use when". Uses PyYAML when available,
@@ -119,7 +119,7 @@ validate_skill_md() {
             # reported (sentinel __PARSE_ERROR__), not silently re-parsed by the
             # fallback. The stdlib-only fallback runs solely when PyYAML is
             # absent, so the script still works with just python3.
-            DESC=$(FRONTMATTER="$FRONTMATTER" python3 <<'PYEOF' 2>/dev/null || echo "__PARSE_ERROR__"
+            desc=$(FRONTMATTER="$frontmatter" python3 <<'PYEOF' 2>/dev/null || echo "__PARSE_ERROR__"
 import os, re, sys
 
 fm = os.environ["FRONTMATTER"]
@@ -174,56 +174,56 @@ for i, line in enumerate(lines):
 print(desc if desc is not None else "")
 PYEOF
 )
-            if [[ "$DESC" == "__PARSE_ERROR__" ]]; then
-                error "$REL frontmatter is not valid YAML (could not parse 'description')"
-            elif [[ "$DESC" == Use\ when* ]]; then
-                success "$REL description starts with 'Use when'"
+            if [[ "$desc" == "__PARSE_ERROR__" ]]; then
+                error "$rel frontmatter is not valid YAML (could not parse 'description')"
+            elif [[ "$desc" == Use\ when* ]]; then
+                success "$rel description starts with 'Use when'"
             else
-                error "$REL description must start with 'Use when': ${DESC:0:60}..."
+                error "$rel description must start with 'Use when': ${desc:0:60}..."
             fi
         else
-            error "$REL missing 'description' field"
+            error "$rel missing 'description' field"
         fi
     else
-        error "$REL missing frontmatter (must start with ---)"
+        error "$rel missing frontmatter (must start with ---)"
     fi
 
     # Word count check (max 500)
-    WORDS=$(wc -w < "$SKILL_FILE")
-    if [[ $WORDS -le 500 ]]; then
-        success "$REL is $WORDS words (under 500 limit)"
+    words=$(wc -w < "$skill_file")
+    if [[ $words -le 500 ]]; then
+        success "$rel is $words words (under 500 limit)"
     else
-        error "$REL is $WORDS words (max 500)"
+        error "$rel is $words words (max 500)"
     fi
     # Check for relative script paths that should use ${CLAUDE_SKILL_DIR}
     # Matches: uv run scripts/, python3 scripts/, python scripts/, bash scripts/, ./scripts/, sh scripts/
     # But ignores lines already using ${CLAUDE_SKILL_DIR}
-    RELATIVE_PATHS=$(grep -nE '(uv run|python3?|bash|sh|\./)([ ]+)scripts/' "$SKILL_FILE" | grep -v 'CLAUDE_SKILL_DIR' || true)
-    if [[ -n "$RELATIVE_PATHS" ]]; then
-        COUNT=$(echo "$RELATIVE_PATHS" | wc -l)
-        warning "$REL has $COUNT script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
+    relative_paths=$(grep -nE '(uv run|python3?|bash|sh|\./)([ ]+)scripts/' "$skill_file" | grep -v 'CLAUDE_SKILL_DIR' || true)
+    if [[ -n "$relative_paths" ]]; then
+        count=$(echo "$relative_paths" | wc -l)
+        warning "$rel has $count script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
     fi
 
     # checkpoints.yaml presence (warning only — many skills legitimately lack
     # one; a documented justification marker suppresses the warning per
     # add-checkpoints' suitability criteria, e.g. purely conceptual skills)
-    SKILL_DIR="$(dirname "$SKILL_FILE")"
-    SKILL_DIR_REL="${SKILL_DIR#"$REPO_DIR"}"
-    SKILL_DIR_REL="${SKILL_DIR_REL#/}"
-    SKILL_DIR_REL="${SKILL_DIR_REL:-.}"
-    CHECKPOINTS_JUSTIFIED=0
-    for f in "$SKILL_FILE" "$REPO_DIR/README.md"; do
+    skill_dir="$(dirname "$skill_file")"
+    skill_dir_rel="${skill_dir#"$REPO_DIR"}"
+    skill_dir_rel="${skill_dir_rel#/}"
+    skill_dir_rel="${skill_dir_rel:-.}"
+    checkpoints_justified=0
+    for f in "$skill_file" "$REPO_DIR/README.md"; do
         if [[ -f "$f" ]] && grep -qiE "^[[:space:]]*([*-][[:space:]]+)?checkpoints:[[:space:]]*none[[:space:]]*\(justified" "$f"; then
-            CHECKPOINTS_JUSTIFIED=1
+            checkpoints_justified=1
             break
         fi
     done
-    if [[ -f "$SKILL_DIR/checkpoints.yaml" ]]; then
+    if [[ -f "$skill_dir/checkpoints.yaml" ]]; then
         success "checkpoints.yaml exists"
-    elif [[ $CHECKPOINTS_JUSTIFIED -eq 1 ]]; then
+    elif [[ $checkpoints_justified -eq 1 ]]; then
         success "checkpoints.yaml absence is justified"
     else
-        warning "checkpoints.yaml not found in ${SKILL_DIR_REL} — add checkpoints (see add-checkpoints skill) or document opt-out with 'Checkpoints: none (justified — <reason>)' in SKILL.md or README.md"
+        warning "checkpoints.yaml not found in ${skill_dir_rel} — add checkpoints (see add-checkpoints skill) or document opt-out with 'Checkpoints: none (justified — <reason>)' in SKILL.md or README.md"
     fi
 
     # --- Shipped scripts without a test ---
@@ -232,10 +232,10 @@ PYEOF
     # that ship scripts had no test file at all. Referenced-by-name is a coarse
     # signal on purpose — it costs nothing and catches the "no test whatsoever"
     # case, which is the one that actually occurs.
-    if [[ -d "$SKILL_DIR/scripts" ]]; then
-        UNTESTED=$(
+    if [[ -d "$skill_dir/scripts" ]]; then
+        untested=$(
             shopt -s nullglob
-            for s in "$SKILL_DIR"/scripts/*; do
+            for s in "$skill_dir"/scripts/*; do
                 [[ -f "$s" ]] || continue
                 base="$(basename "$s")"
                 if [[ -d "$REPO_DIR/tests" ]] && grep -rqF -- "$base" "$REPO_DIR/tests" 2>/dev/null; then
@@ -244,11 +244,11 @@ PYEOF
                 printf '%s ' "$base"
             done
         )
-        UNTESTED="${UNTESTED% }"
-        if [[ -z "$UNTESTED" ]]; then
-            success "every script under ${SKILL_DIR_REL}/scripts is referenced by a test"
+        untested="${untested% }"
+        if [[ -z "$untested" ]]; then
+            success "every script under ${skill_dir_rel}/scripts is referenced by a test"
         else
-            warning "no test references these script(s): ${UNTESTED} — add a test under tests/ (run by the tests.yml reusable) or the script ships unexercised"
+            warning "no test references these script(s): ${untested} — add a test under tests/ (run by the tests.yml reusable) or the script ships unexercised"
         fi
     fi
 
@@ -265,8 +265,8 @@ PYEOF
     # the decidable part, an LLM prompt for the judgement — declares it with a
     # `# mechanical-counterpart: <ID>` comment anywhere in its block, and is
     # then exempt.
-    if [[ -f "$SKILL_DIR/checkpoints.yaml" ]]; then
-        MISCLASSIFIED=$(awk '
+    if [[ -f "$skill_dir/checkpoints.yaml" ]]; then
+        misclassified=$(awk '
             /^llm_reviews:/ { in_llm = 1; next }
             /^[a-z_]+:/     { in_llm = 0 }
             !in_llm         { next }
@@ -282,10 +282,10 @@ PYEOF
                   for (a = 0; a < n; a++) for (b = a + 1; b < n; b++)
                       if (ids[b] < ids[a]) { t = ids[a]; ids[a] = ids[b]; ids[b] = t }
                   for (a = 0; a < n; a++) printf "%s ", ids[a] }
-        ' "$SKILL_DIR/checkpoints.yaml")
-        MISCLASSIFIED="${MISCLASSIFIED% }"
-        if [[ -n "$MISCLASSIFIED" ]]; then
-            warning "${SKILL_DIR_REL}/checkpoints.yaml: llm_reviews checkpoint(s) contain a runnable command: ${MISCLASSIFIED} — if the command decides the outcome, move it to mechanical (type: command); keep the LLM entry only for the judgement the command cannot make"
+        ' "$skill_dir/checkpoints.yaml")
+        misclassified="${misclassified% }"
+        if [[ -n "$misclassified" ]]; then
+            warning "${skill_dir_rel}/checkpoints.yaml: llm_reviews checkpoint(s) contain a runnable command: ${misclassified} — if the command decides the outcome, move it to mechanical (type: command); keep the LLM entry only for the judgement the command cannot make"
         fi
     fi
 }

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -32,31 +32,49 @@ fi
 echo "Validating skill repository: $REPO_DIR"
 echo "========================================"
 
-# --- Discover SKILL.md ---
-SKILL_FILE=""
+# --- Discover every SKILL.md ---
+# A repo may ship several skills. Validating only the first one meant the rest
+# had no frontmatter check, no "Use when" check and no word count: matrix-skill
+# reported a single 498-word line for skills/matrix-administration while
+# matrix-communication sat at 896 words, over the cap, for as long as the repo
+# existed (issue #214). Every skill found is validated and every finding counts
+# toward the exit code.
+SKILL_FILES=()
 if [[ -f "$REPO_DIR/SKILL.md" ]]; then
-    SKILL_FILE="$REPO_DIR/SKILL.md"
-else
-    for f in "$REPO_DIR"/skills/*/SKILL.md; do
-        if [[ -f "$f" ]]; then
-            SKILL_FILE="$f"
-            break
-        fi
-    done
+    SKILL_FILES+=("$REPO_DIR/SKILL.md")
 fi
+for f in "$REPO_DIR"/skills/*/SKILL.md; do
+    if [[ -f "$f" ]]; then
+        # A skills/<name>/SKILL.md that is the root file (symlink or hardlink)
+        # would otherwise be reported twice under two names.
+        if [[ ${#SKILL_FILES[@]} -gt 0 && "$f" -ef "${SKILL_FILES[0]}" ]]; then
+            continue
+        fi
+        SKILL_FILES+=("$f")
+    fi
+done
 
-# --- SKILL.md checks ---
-if [[ -n "$SKILL_FILE" ]]; then
-    success "SKILL.md found: ${SKILL_FILE#"$REPO_DIR"/}"
+# --- Per-skill checks ---
+# Every message names the file it is about, so a finding in a multi-skill repo
+# is attributable without counting output lines.
+validate_skill_md() {
+    local SKILL_FILE="$1"
+    local REL="${SKILL_FILE#"$REPO_DIR"/}"
+    local SKILL_NAME=""
+    # Declared local so nothing carries over from the previous skill in the loop.
+    local CLOSING_LINE FRONTMATTER EXTRA_FIELDS FIELD_NAMES DESC WORDS
+    local RELATIVE_PATHS COUNT SKILL_DIR SKILL_DIR_REL CHECKPOINTS_JUSTIFIED
+    local UNTESTED MISCLASSIFIED f s base
+    success "SKILL.md found: $REL"
 
     # Frontmatter delimiter
     if head -1 "$SKILL_FILE" | grep -q "^---$"; then
         # Verify closing --- delimiter exists (within first 30 lines)
         CLOSING_LINE=$(sed -n '2,30{/^---$/=}' "$SKILL_FILE" | head -1)
         if [[ -z "$CLOSING_LINE" ]]; then
-            error "SKILL.md frontmatter has opening --- but no closing --- delimiter"
+            error "$REL frontmatter has opening --- but no closing --- delimiter"
         else
-            success "SKILL.md has frontmatter"
+            success "$REL has frontmatter"
         fi
 
         # Extract frontmatter fields (between first two --- lines)
@@ -66,22 +84,28 @@ if [[ -n "$SKILL_FILE" ]]; then
         # Allowed: name, description, license, compatibility, metadata, allowed-tools
         EXTRA_FIELDS=$(echo "$FRONTMATTER" | grep -E "^[a-z_-]+:" | grep -vE "^(name|description|license|compatibility|metadata|allowed-tools):" || true)
         if [[ -z "$EXTRA_FIELDS" ]]; then
-            success "Frontmatter fields are valid per Agent Skills spec"
+            success "$REL frontmatter fields are valid per Agent Skills spec"
         else
             FIELD_NAMES=$(echo "$EXTRA_FIELDS" | sed 's/:.*//' | tr '\n' ', ' | sed 's/,$//')
-            error "Frontmatter has non-spec fields: $FIELD_NAMES (allowed: name, description, license, compatibility, metadata, allowed-tools)"
+            error "$REL frontmatter has non-spec fields: $FIELD_NAMES (allowed: name, description, license, compatibility, metadata, allowed-tools)"
         fi
 
         # Check name field
         if echo "$FRONTMATTER" | grep -q "^name:"; then
-            NAME=$(echo "$FRONTMATTER" | grep "^name:" | head -1 | sed 's/name: *//' | tr -d '"')
-            if [[ "$NAME" =~ ^[a-z0-9-]{1,64}$ ]]; then
-                success "SKILL.md name valid: $NAME"
+            SKILL_NAME=$(echo "$FRONTMATTER" | grep "^name:" | head -1 | sed 's/name: *//' | tr -d '"')
+            # The plugin.json comparison further down uses one name. Single-skill
+            # repos keep the behaviour they had; multi-skill repos skip that
+            # comparison anyway, since plugin.json names the plugin, not a skill.
+            if [[ -z "$NAME" ]]; then
+                NAME="$SKILL_NAME"
+            fi
+            if [[ "$SKILL_NAME" =~ ^[a-z0-9-]{1,64}$ ]]; then
+                success "$REL name valid: $SKILL_NAME"
             else
-                error "SKILL.md name invalid (lowercase, hyphens, max 64): $NAME"
+                error "$REL name invalid (lowercase, hyphens, max 64): $SKILL_NAME"
             fi
         else
-            error "SKILL.md missing 'name' field"
+            error "$REL missing 'name' field"
         fi
 
         # Check description field and prefix
@@ -151,25 +175,25 @@ print(desc if desc is not None else "")
 PYEOF
 )
             if [[ "$DESC" == "__PARSE_ERROR__" ]]; then
-                error "SKILL.md frontmatter is not valid YAML (could not parse 'description')"
+                error "$REL frontmatter is not valid YAML (could not parse 'description')"
             elif [[ "$DESC" == Use\ when* ]]; then
-                success "Description starts with 'Use when'"
+                success "$REL description starts with 'Use when'"
             else
-                error "Description must start with 'Use when': ${DESC:0:60}..."
+                error "$REL description must start with 'Use when': ${DESC:0:60}..."
             fi
         else
-            error "SKILL.md missing 'description' field"
+            error "$REL missing 'description' field"
         fi
     else
-        error "SKILL.md missing frontmatter (must start with ---)"
+        error "$REL missing frontmatter (must start with ---)"
     fi
 
     # Word count check (max 500)
     WORDS=$(wc -w < "$SKILL_FILE")
     if [[ $WORDS -le 500 ]]; then
-        success "SKILL.md is $WORDS words (under 500 limit)"
+        success "$REL is $WORDS words (under 500 limit)"
     else
-        error "SKILL.md is $WORDS words (max 500)"
+        error "$REL is $WORDS words (max 500)"
     fi
     # Check for relative script paths that should use ${CLAUDE_SKILL_DIR}
     # Matches: uv run scripts/, python3 scripts/, python scripts/, bash scripts/, ./scripts/, sh scripts/
@@ -177,7 +201,7 @@ PYEOF
     RELATIVE_PATHS=$(grep -nE '(uv run|python3?|bash|sh|\./)([ ]+)scripts/' "$SKILL_FILE" | grep -v 'CLAUDE_SKILL_DIR' || true)
     if [[ -n "$RELATIVE_PATHS" ]]; then
         COUNT=$(echo "$RELATIVE_PATHS" | wc -l)
-        warning "SKILL.md has $COUNT script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
+        warning "$REL has $COUNT script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
     fi
 
     # checkpoints.yaml presence (warning only — many skills legitimately lack
@@ -228,43 +252,6 @@ PYEOF
         fi
     fi
 
-    # --- Shebang without the committed executable bit ---
-    # ruff's EXE001 covers the Python case, but it does not fire on every
-    # developer machine: the same pinned ruff, same command, same mode-0644
-    # file passes locally and fails on the runner (issue #235, mechanism
-    # unestablished). A local "clean" is therefore not evidence, and the first
-    # signal is a red CI job on someone else's push.
-    #
-    # This reads the INDEX rather than the working tree, so it answers the same
-    # everywhere regardless of what the filesystem reports. Severity follows
-    # what CI already enforces: an error for *.py, because ruff fails the build
-    # on exactly these; a warning for *.sh, where nothing fails today and a
-    # shebang on a file only ever invoked as `bash file` is merely decorative.
-    if git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-        shebang_no_exec() { # shebang_no_exec <pathspec...>
-            git -C "$REPO_DIR" ls-files -s -- "$@" 2>/dev/null \
-                | awk '$1=="100644"{ sub(/^[0-9]+ [0-9a-f]+ [0-9]+\t/, ""); print }' \
-                | while IFS= read -r f; do
-                    [[ -n "$f" ]] || continue
-                    case "$(head -c 2 "$REPO_DIR/$f" 2>/dev/null)" in
-                        '#!') printf '%s ' "$f" ;;
-                    esac
-                done
-        }
-
-        PY_NOT_EXEC="$(shebang_no_exec '*.py')"; PY_NOT_EXEC="${PY_NOT_EXEC% }"
-        SH_NOT_EXEC="$(shebang_no_exec '*.sh')"; SH_NOT_EXEC="${SH_NOT_EXEC% }"
-
-        if [[ -n "$PY_NOT_EXEC" ]]; then
-            error "committed 100644 but carries a shebang: ${PY_NOT_EXEC} — ruff EXE001 fails the build on this, and a local ruff run does not reproduce it (issue #235). Fix: chmod +x <file> && git update-index --chmod=+x <file>"
-        elif [[ -z "$SH_NOT_EXEC" ]]; then
-            success "every committed script with a shebang is mode 100755"
-        fi
-        if [[ -n "$SH_NOT_EXEC" ]]; then
-            warning "committed 100644 but carries a shebang: ${SH_NOT_EXEC} — either make it executable (chmod +x && git update-index --chmod=+x) or drop the shebang if it is only ever run as \`bash <file>\`"
-        fi
-    fi
-
     # --- LLM checkpoints that are mechanically verifiable ---
     # add-checkpoints reserves llm_reviews for "subjective requirements that
     # can't be mechanically verified". A prompt that opens a line with a
@@ -298,11 +285,56 @@ PYEOF
         ' "$SKILL_DIR/checkpoints.yaml")
         MISCLASSIFIED="${MISCLASSIFIED% }"
         if [[ -n "$MISCLASSIFIED" ]]; then
-            warning "llm_reviews checkpoint(s) contain a runnable command: ${MISCLASSIFIED} — if the command decides the outcome, move it to mechanical (type: command); keep the LLM entry only for the judgement the command cannot make"
+            warning "${SKILL_DIR_REL}/checkpoints.yaml: llm_reviews checkpoint(s) contain a runnable command: ${MISCLASSIFIED} — if the command decides the outcome, move it to mechanical (type: command); keep the LLM entry only for the judgement the command cannot make"
         fi
     fi
+}
+
+if [[ ${#SKILL_FILES[@]} -gt 0 ]]; then
+    for skill_file in "${SKILL_FILES[@]}"; do
+        validate_skill_md "$skill_file"
+    done
 else
     error "SKILL.md not found (checked root and skills/*/)"
+fi
+
+# --- Shebang without the committed executable bit ---
+# Repo-wide, so it runs once rather than once per skill.
+#
+# ruff's EXE001 covers the Python case, but it does not fire on every developer
+# machine: the same pinned ruff, same command, same mode-0644 file passes
+# locally and fails on the runner (issue #235, mechanism unestablished). A local
+# "clean" is therefore not evidence, and the first signal is a red CI job on
+# someone else's push.
+#
+# This reads the INDEX rather than the working tree, so it answers the same
+# everywhere regardless of what the filesystem reports. Severity follows what CI
+# already enforces: an error for *.py, because ruff fails the build on exactly
+# these; a warning for *.sh, where nothing fails today and a shebang on a file
+# only ever invoked as `bash file` is merely decorative.
+if git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    shebang_no_exec() { # shebang_no_exec <pathspec...>
+        git -C "$REPO_DIR" ls-files -s -- "$@" 2>/dev/null \
+            | awk '$1=="100644"{ sub(/^[0-9]+ [0-9a-f]+ [0-9]+\t/, ""); print }' \
+            | while IFS= read -r f; do
+                [[ -n "$f" ]] || continue
+                case "$(head -c 2 "$REPO_DIR/$f" 2>/dev/null)" in
+                    '#!') printf '%s ' "$f" ;;
+                esac
+            done
+    }
+
+    PY_NOT_EXEC="$(shebang_no_exec '*.py')"; PY_NOT_EXEC="${PY_NOT_EXEC% }"
+    SH_NOT_EXEC="$(shebang_no_exec '*.sh')"; SH_NOT_EXEC="${SH_NOT_EXEC% }"
+
+    if [[ -n "$PY_NOT_EXEC" ]]; then
+        error "committed 100644 but carries a shebang: ${PY_NOT_EXEC} — ruff EXE001 fails the build on this, and a local ruff run does not reproduce it (issue #235). Fix: chmod +x <file> && git update-index --chmod=+x <file>"
+    elif [[ -z "$SH_NOT_EXEC" ]]; then
+        success "every committed script with a shebang is mode 100755"
+    fi
+    if [[ -n "$SH_NOT_EXEC" ]]; then
+        warning "committed 100644 but carries a shebang: ${SH_NOT_EXEC} — either make it executable (chmod +x && git update-index --chmod=+x) or drop the shebang if it is only ever run as \`bash <file>\`"
+    fi
 fi
 
 # --- Required files ---

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -37,7 +37,9 @@ fi
 
 PASS=0
 FAIL=0
-ACCEPT_LINE="Description starts with 'Use when'"
+# Every per-skill message is prefixed with the file it is about, so the
+# assertion matches from the word after the path onwards.
+ACCEPT_LINE="description starts with 'Use when'"
 
 # fixture <name> <raw-content> -> echoes the created dir path
 fixture() {
@@ -131,6 +133,38 @@ if [[ ${#YAML_RUNNER[@]} -gt 0 ]]; then
 else
     echo "== PyYAML-authoritative path: SKIPPED (no yaml-capable python3 or uv) =="
 fi
+
+# #214: a repo shipping several skills must have every one of them validated.
+# Before this, discovery stopped at the first skills/*/SKILL.md, so a defect in
+# any later skill was invisible — matrix-skill carried a 1348-word SKILL.md
+# under a green "Skill Validation" for as long as the repo existed. The second
+# skill here is the one that is broken, so the check fails if discovery ever
+# goes back to first-match-wins.
+echo "== Multi-skill discovery (#214) =="
+multi="$TMP/fx_multi"
+rm -rf "$multi"
+mkdir -p "$multi/skills/aaa-good" "$multi/skills/zzz-broken" "$multi/skills/zzz-long"
+printf '%b' "${hdr}description: Use when doing X\n---\n# Good\n" > "$multi/skills/aaa-good/SKILL.md"
+printf '%b' "${hdr}description: 'Helps with X'\n---\n# Broken\n" > "$multi/skills/zzz-broken/SKILL.md"
+# Over the 500-word cap, in a skill that is not the first alphabetically.
+{
+    printf '%b' "${hdr}description: Use when doing Y\n---\n# Long\n"
+    for _ in $(seq 1 520); do printf 'word '; done
+} > "$multi/skills/zzz-long/SKILL.md"
+multi_out="$(run_validator fallback "$multi")"
+
+if grep -qF "skills/aaa-good/SKILL.md description starts with 'Use when'" <<<"$multi_out"; then ((PASS++)); else
+    echo "  FAIL [multi] first skill not validated"; ((FAIL++)); fi
+if grep -qF "skills/zzz-broken/SKILL.md description must start with 'Use when'" <<<"$multi_out"; then ((PASS++)); else
+    echo "  FAIL [multi] a later skill's bad description was not reported"; ((FAIL++)); fi
+if grep -qE "skills/zzz-long/SKILL.md is [0-9]+ words \(max 500\)" <<<"$multi_out"; then ((PASS++)); else
+    echo "  FAIL [multi] a later skill's word count was not reported"; ((FAIL++)); fi
+# Discovery itself, independent of any single verdict: all three are reported.
+# (Not asserted on the exit code — these fixtures lack composer.json and README,
+# so the run exits non-zero either way and the assertion could not fail.)
+found_count="$(grep -cF 'SKILL.md found:' <<<"$multi_out")"
+if [[ "$found_count" -eq 3 ]]; then ((PASS++)); else
+    echo "  FAIL [multi] expected 3 discovered skills, got $found_count"; ((FAIL++)); fi
 
 echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"


### PR DESCRIPTION
Closes #214, #181, #179 and #180 — four gaps in the shared validation stack, each one a check that was reported green while not looking at everything it claimed to cover.

## #214 — only the first skill was ever validated

Discovery stopped at the first `SKILL.md`, so in a repo shipping several skills the rest had no frontmatter check, no `Use when` check and no word count. `matrix-skill` is the case that shows it: one line about `skills/matrix-administration` (498 words, alphabetically first) while `matrix-announcement` sat at 624 and `matrix-communication` at 1348, both over the 500-word cap, for as long as the repo existed.

Both the validator and the version-parity step in `validate.yml` carried the same first-match-wins loop; both now iterate, per-skill messages are prefixed with the file they are about, and every finding reaches the exit code. Two checks stay repo-wide on purpose: the committed-shebang check reads the git index and has one answer for the whole repo, and the `plugin.json` name comparison only ever applied to single-skill repos.

**Fleet impact, measured before pushing rather than predicted.** Word counts pulled from every netresearch repo that ships more than one skill:

| repo | consequence |
|---|---|
| `matrix-skill` | red — 2 skills over the cap (624, 1348) |
| `orocommerce-skill` | red — 7 skills over the cap (556 … 1043) |
| `docker-development-skill`, `jira-skill`, `automated-assessment-skill` | unaffected, all skills under the cap |

Version parity gains no new failure anywhere: every multi-skill repo that declares `metadata.version` declares the same one in every skill, and `orocommerce-skill` declares none. Paths like `examples/…/SKILL.md` and `tests/Fixtures/…/SKILL.md` are outside the `skills/*/SKILL.md` glob and stay unchecked, as before.

The two repos that go red are genuinely over a cap that has been policy all along — the check was simply never looking. Trimming them is content work with its own rubric ([#151](https://github.com/netresearch/skill-repo-skill/issues/151)), not something to fold in here.

## #181 — only `plugin.json` was parsed

A malformed `composer.json` or `hooks/*.json` passed validation and failed later, wherever that file was first read. Now every tracked `*.json` is parsed, `vendor/` and `node_modules/` excluded, one `::error::` per bad file with its path and the parser's message — and it does not stop at the first failure.

Measured across the 51 skill repos checked out here: 350 tracked JSON files, exactly one does not parse — a zero-byte `package-lock.json` committed next to a real `package.json` in an `agent-rules` example tree. Fixed at the source in a separate PR rather than tolerated here.

## #179 — the version matrix guaranteed nothing

`ci-python.yml` provided no interpreter. The matrix exported `PYTHON_VERSION` into the caller's `test-command`, so a caller writing plain `uv run pytest` tested the runner's default interpreter N times while the job names claimed N versions. Every run was green, so nothing said so.

`setup-uv`'s `python-version` now carries the matrix value (which sets `UV_PYTHON`), `uv python install` makes the fetch explicit, and a step **asserts** that uv resolves to the matrix version. Printing it would not do: a version input that quietly falls back to the runner default still looks like a passing matrix. The comparison accepts `3.12.7` for `3.12` and rejects `3.121.0` for `3.12` — checked against both.

All four callers today (`retro`, `security-audit`, `jira`, `automated-assessment`) either already pass `--python` or run no Python at all, so none changes behaviour. The guarantee is for the next caller that does not, and the `test-command` description now states the contract for commands that invoke python outside uv.

## #180 — the scope boundary is now in the file

One header comment: shell linting stays in `validate.yml`, which runs ShellCheck for every repo, not only the Python ones. No ShellCheck step added here.

## Verification

Three new assertions in `tests/validate-skill.sh` use a three-skill fixture whose defects sit in the skills that are **not** first. Run against a copy of the script with first-match-wins restored, all three fail; on this branch they pass — so the test measures the fix rather than the fixture. 25 assertions total, all nine `tests/*.sh` suites green, `shellcheck`, `actionlint` and `pre-commit run --files` clean. The JSON step was extracted from the workflow and run against this repo (10 files parse) and against a deliberately broken tracked file (exit 1, path and parse error named).

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
