### PR TITLE
fix(validate-evals): validate every evals.json, not the first one found

### DIFF
--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -110,12 +110,33 @@ for arg in "$@"; do
 done
 
 if [[ -z "$EVALS_FILE" ]]; then
+  # Every candidate, not the first: a repo shipping several skills ships several
+  # evals.json, and stopping at the first left the rest unchecked — six repos in
+  # the fleet carry more than one, matrix-skill three. Same hole the skill
+  # validator had (issue #214).
+  EVALS_FILES=()
   for candidate in skills/*/evals/evals.json evals/evals.json; do
-    if [[ -f "$candidate" ]]; then
-      EVALS_FILE="$candidate"
-      break
-    fi
+    [[ -f "$candidate" ]] && EVALS_FILES+=("$candidate")
   done
+
+  if [[ ${#EVALS_FILES[@]} -gt 1 ]]; then
+    # One run per file so each gets its own counters and summary, with the exit
+    # code covering all of them.
+    MULTI_RC=0
+    for candidate in "${EVALS_FILES[@]}"; do
+      echo "=============================================="
+      bash "$0" "$candidate" || MULTI_RC=1
+      echo ""
+    done
+    if [[ "$MULTI_RC" -ne 0 ]]; then
+      echo "::error::at least one evals.json failed validation"
+    else
+      echo "All ${#EVALS_FILES[@]} evals.json files validate"
+    fi
+    exit "$MULTI_RC"
+  fi
+
+  EVALS_FILE="${EVALS_FILES[0]:-}"
 fi
 
 if [[ -z "$EVALS_FILE" ]] || [[ ! -f "$EVALS_FILE" ]]; then

--- a/tests/validate-evals.sh
+++ b/tests/validate-evals.sh
@@ -211,6 +211,34 @@ EOF
 bash "$SCRIPT" "$WORK/no-samples.json" >/dev/null 2>&1
 check "an eval without samples still passes" 0 "$?"
 
+# --- every evals.json is validated, not the first one found (#214 class) -----
+# A repo shipping several skills ships several evals.json; discovery used to
+# stop at the first, so a defect in any later one was invisible. The good file
+# sorts FIRST and is padded to pass on its own, so the run can only fail because
+# the later, broken one was reached.
+MULTI="$WORK/multi"
+rm -rf "$MULTI"
+mkdir -p "$MULTI/skills/aaa-good/evals" "$MULTI/skills/zzz-broken/evals"
+suite "$MULTI/skills/aaa-good/evals/evals.json" <<'EOF'
+{ "name": "good", "prompt": "Anything.",
+  "assertions": [{"type": "content", "pattern": "(?i)anything"},
+                 {"type": "content", "pattern": "(?i)thing"}] }
+EOF
+suite "$MULTI/skills/zzz-broken/evals/evals.json" <<'EOF'
+{ "name": "no-grading", "prompt": "Anything." }
+EOF
+
+# The good one alone must pass, or the check below would fail for the wrong reason.
+bash "$SCRIPT" "$MULTI/skills/aaa-good/evals/evals.json" >/dev/null 2>&1
+check "the padded good fixture passes on its own" 0 "$?"
+
+out="$(cd "$MULTI" && bash "$SCRIPT" 2>&1)"; rc=$?
+check "a defect in a later evals.json fails the run" 1 "$rc"
+case "$out" in
+    *aaa-good*zzz-broken*) check "both files are reported, in order" 0 0 ;;
+    *) check "both files are reported, in order" 0 1 ;;
+esac
+
 echo
 if [ "$fail" -eq 0 ]; then
     echo "All validate-evals tests passed"


### PR DESCRIPTION
`validate-evals.sh` had the same first-match-wins hole the skill validator had in #214: discovery stopped at the first `skills/*/evals/evals.json`, then `evals/evals.json`. A repo shipping several skills ships several eval files, and the rest were never checked.

**Measured across the 51 skill repos checked out locally — six carry more than one:**

| repo | eval files | validated before |
|---|---|---|
| `matrix-skill` | 3 | 1 (`matrix-administration`) |
| `agent-rules-skill` | 2 | 1 |
| `git-workflow-skill` | 2 | 1 |
| `go-development-skill` | 2 | 1 |
| `automated-assessment-skill` | 2 | 1 |
| `it-account-lifecycle-skill` | 2 | 1 |

All of them happen to be valid today — I ran each file individually to confirm — so nothing was silently broken. The **coverage** was, and that is the thing that fails quietly: the next defect in a non-first file would have shipped.

With more than one candidate the script now runs once per file, so each keeps its own counters and summary, and the exit code covers all of them. A single candidate, or an explicit path argument, behaves exactly as before.

## The test, and the first version of it that was worthless

Two assertions plus one guarding them:

1. the padded good fixture passes on its own,
2. a defect in a *later* file fails the run,
3. both files appear in the output, in order.

Assertion 1 exists because the first version of this test did not have it and was passing for the wrong reason: my "good" fixture failed the unified-format rules on its own (fewer than 10 evals, non-integer id, one assertion), so the run went red no matter which file was reached. Padding it through the existing `suite()` helper fixed that.

Verified against a copy of the script with first-match-wins restored: there the run goes **green with a broken second file**, and assertions 2 and 3 both fail. On this branch all three pass.

All nine `tests/*.sh` suites green, `shellcheck` and `pre-commit run --files` clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
