### PR TITLE
feat(tests): run PHP test entrypoints, not only shell and Python

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,20 @@ on:
         required: false
         type: string
         default: "tests/**/*.py"
+      php_glob:
+        description: >-
+          Glob for PHP test entrypoints, relative to the repo root. Every match
+          is executed, so a repo keeping fixtures under tests/ narrows this to
+          the entrypoints (for example "tests/run.php") rather than letting the
+          default sweep tests/fixtures/ as well.
+        required: false
+        type: string
+        default: "tests/**/*.php"
+      php_version:
+        description: "PHP version used when PHP tests are present."
+        required: false
+        type: string
+        default: "8.3"
       require_tests:
         description: >-
           Fail when the repo ships scripts under skills/*/scripts/ but matches
@@ -101,6 +115,56 @@ jobs:
           done
           exit $rc
 
+      # PHP needs a toolchain, so the glob is resolved first and the setup runs
+      # only when there is something to run. Detection is pure bash and costs
+      # nothing on the repos that ship none.
+      - name: Detect PHP tests
+        id: detect_php
+        if: always()
+        env:
+          PHP_GLOB: ${{ inputs.php_glob }}
+        run: |
+          shopt -s nullglob globstar
+          # shellcheck disable=SC2206  # word splitting is the point: expand the glob
+          files=(${PHP_GLOB})
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No PHP tests matched ${PHP_GLOB}"
+          fi
+
+      - name: Set up PHP
+        if: always() && steps.detect_php.outputs.count != '0'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ inputs.php_version }}
+          coverage: none
+
+      # --no-plugins on purpose: a skill repo requires
+      # netresearch/composer-agent-skill-plugin, and a root install that has not
+      # declared it under config.allow-plugins aborts non-interactively. Running
+      # the tests never needs the plugin, so the gate stays independent of each
+      # repo's allow-plugins state and adoption cannot break on it.
+      - name: Install PHP dependencies
+        if: always() && steps.detect_php.outputs.count != '0' && hashFiles('composer.json') != ''
+        run: composer install --no-interaction --no-progress --no-plugins
+
+      - name: PHP tests
+        id: php
+        if: always() && steps.detect_php.outputs.count != '0'
+        env:
+          PHP_GLOB: ${{ inputs.php_glob }}
+        run: |
+          shopt -s nullglob globstar
+          # shellcheck disable=SC2206  # word splitting is the point: expand the glob
+          files=(${PHP_GLOB})
+          rc=0
+          for t in "${files[@]}"; do
+            echo "::group::$t"
+            php "$t" || { echo "::error file=$t::test failed"; rc=1; }
+            echo "::endgroup::"
+          done
+          exit $rc
+
       # A repo that ships executable surface and matched zero tests is the
       # state this workflow exists to surface. Reported always; fatal only when
       # the caller asks for it, so adoption is never a breaking change.
@@ -109,6 +173,7 @@ jobs:
         env:
           SHELL_COUNT: ${{ steps.shell.outputs.count }}
           PYTHON_COUNT: ${{ steps.python.outputs.count }}
+          PHP_COUNT: ${{ steps.detect_php.outputs.count }}
           REQUIRE_TESTS: ${{ inputs.require_tests }}
         run: |
           shopt -s nullglob globstar
@@ -116,7 +181,7 @@ jobs:
           # Defaulted because `if: always()` can reach this step while an
           # earlier one never wrote its `count=`. Bash reads an empty variable
           # as 0 here, so this is explicitness, not a crash guard.
-          total=$(( ${SHELL_COUNT:-0} + ${PYTHON_COUNT:-0} ))
+          total=$(( ${SHELL_COUNT:-0} + ${PYTHON_COUNT:-0} + ${PHP_COUNT:-0} ))
           echo "shipped scripts: ${#scripts[@]} | test files run: $total"
           if [ ${#scripts[@]} -gt 0 ] && [ "$total" -eq 0 ]; then
             msg="repo ships ${#scripts[@]} script(s) under skills/*/scripts/ but no test file was run"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,40 @@ jobs:
           # only exposes it to later steps and artifacts.
           persist-credentials: false
 
+      # PHP first: the toolchain and dependencies are installed before any leg
+      # runs, so a shell test that shells out to php finds them too. A shell
+      # wrapper around a PHP suite otherwise reports green while the suite
+      # skips itself for a missing vendor/ — observed on php-ast-edit-skill.
+      # Detection is pure bash and costs nothing on repos shipping no PHP.
+      - name: Detect PHP tests
+        id: detect_php
+        env:
+          PHP_GLOB: ${{ inputs.php_glob }}
+        run: |
+          shopt -s nullglob globstar
+          # shellcheck disable=SC2206  # word splitting is the point: expand the glob
+          files=(${PHP_GLOB})
+          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No PHP tests matched ${PHP_GLOB}"
+          fi
+
+      - name: Set up PHP
+        if: steps.detect_php.outputs.count != '0'
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ inputs.php_version }}
+          coverage: none
+
+      # --no-plugins on purpose: a skill repo requires
+      # netresearch/composer-agent-skill-plugin, and a root install that has not
+      # declared it under config.allow-plugins aborts non-interactively. Running
+      # the tests never needs the plugin, so the gate stays independent of each
+      # repo's allow-plugins state and adoption cannot break on it.
+      - name: Install PHP dependencies
+        if: steps.detect_php.outputs.count != '0' && hashFiles('composer.json') != ''
+        run: composer install --no-interaction --no-progress --no-plugins
+
       - name: Shell tests
         id: shell
         env:
@@ -114,39 +148,6 @@ jobs:
             echo "::endgroup::"
           done
           exit $rc
-
-      # PHP needs a toolchain, so the glob is resolved first and the setup runs
-      # only when there is something to run. Detection is pure bash and costs
-      # nothing on the repos that ship none.
-      - name: Detect PHP tests
-        id: detect_php
-        if: always()
-        env:
-          PHP_GLOB: ${{ inputs.php_glob }}
-        run: |
-          shopt -s nullglob globstar
-          # shellcheck disable=SC2206  # word splitting is the point: expand the glob
-          files=(${PHP_GLOB})
-          echo "count=${#files[@]}" >> "$GITHUB_OUTPUT"
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No PHP tests matched ${PHP_GLOB}"
-          fi
-
-      - name: Set up PHP
-        if: always() && steps.detect_php.outputs.count != '0'
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-        with:
-          php-version: ${{ inputs.php_version }}
-          coverage: none
-
-      # --no-plugins on purpose: a skill repo requires
-      # netresearch/composer-agent-skill-plugin, and a root install that has not
-      # declared it under config.allow-plugins aborts non-interactively. Running
-      # the tests never needs the plugin, so the gate stays independent of each
-      # repo's allow-plugins state and adoption cannot break on it.
-      - name: Install PHP dependencies
-        if: always() && steps.detect_php.outputs.count != '0' && hashFiles('composer.json') != ''
-        run: composer install --no-interaction --no-progress --no-plugins
 
       - name: PHP tests
         id: php

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,8 +102,11 @@ jobs:
         if: steps.detect_php.outputs.count != '0' && hashFiles('composer.json') != ''
         run: composer install --no-interaction --no-progress --no-plugins
 
+      # always(), like the legs below: the PHP setup now runs first, and a failed
+      # composer install must not hide which shell tests pass.
       - name: Shell tests
         id: shell
+        if: always()
         env:
           SHELL_GLOB: ${{ inputs.shell_glob }}
         run: |
@@ -150,7 +153,6 @@ jobs:
           exit $rc
 
       - name: PHP tests
-        id: php
         if: always() && steps.detect_php.outputs.count != '0'
         env:
           PHP_GLOB: ${{ inputs.php_glob }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,6 +23,7 @@ Located in `.github/workflows/`, these are called by other skill repos via `uses
 - **`dependency-audit.yml`** -- Composer audit, SAST, dependency review.
 - **`npm-pack-smoke.yml`** -- Verifies the npm tarball ships the right files.
 - **`ci-python.yml`** -- Reusable Python lint/test pipeline.
+- **`tests.yml`** -- Runs a skill repo's own suite under `tests/`: shell, Python, and PHP (PHP toolchain and `composer install` only when the PHP glob matches). Reports whether a repo shipping `skills/*/scripts/` ran any test at all; fatal only when the caller sets `require_tests`.
 
 Auto-merge for Dependabot/Renovate PRs is delegated to `netresearch/.github/.github/workflows/auto-merge-deps.yml@main` via the local caller `auto-merge-deps-caller.yml`; it is **not** hosted in this repo.
 


### PR DESCRIPTION
Closes #242.

`repository-quality-rules.md` names this workflow as the thing that turns "every script under `scripts/` is referenced by a test" into a gate rather than a convention. The workflow globbed `tests/**/*.sh` and `tests/**/*.py` only, so a skill repo whose tests are PHP satisfied the rule on paper while no pipeline ever executed them.

That is not hypothetical: [php-ast-edit-skill](https://github.com/netresearch/php-ast-edit-skill) is the first skill repo that is also a runnable PHP package, and it currently bridges the gap with a `tests/run.sh` wrapper whose only job is to give the shell glob something to find, plus a repo-local matrix workflow. Once this lands it can call the reusable directly.

## What the leg does

A detection step resolves `php_glob` in plain bash, and `shivammathur/setup-php` plus `composer install` run only when it matched something — a repo shipping no PHP pays a few milliseconds of globbing and nothing else. `php_version` defaults to 8.3 and is an input; a repo wanting a real matrix keeps that in its own workflow, since a reusable running one version is a gate, not a compatibility matrix.

`composer install` runs with `--no-plugins`, deliberately. Every skill repo requires `netresearch/composer-agent-skill-plugin`, and a root install that has not declared it under `config.allow-plugins` aborts non-interactively — the trap documented in `composer-setup.md` since #231. Running tests never needs that plugin, so the gate stays independent of each repo's allow-plugins state and adoption cannot break on it.

The coverage tally at the end now counts PHP files too, otherwise a PHP-only repo would still be reported as shipping scripts with no tests.

`php_glob` matches are all executed, so its description says plainly that a repo keeping fixtures under `tests/` narrows the glob to its entrypoints. php-ast-edit-skill would pass `tests/run.php`, not the default, because the default would also execute `tests/fixtures/sample.php`.

## Also in this diff

`docs/ARCHITECTURE.md` was missing `tests.yml` from the reusable inventory entirely — pre-existing drift, not something this change introduced. Since the AGENTS.md rule binds those documents as a set and this PR modifies the workflow, the entry is added here rather than left for a follow-up.

## Verification

`actionlint` and the repo's pre-commit suite pass; `validate-skill.sh` reports 0 errors, 0 warnings. What that does not show is the leg actually running, because no repo calls it yet. An end-to-end run against php-ast-edit-skill is the real proof and is linked in a comment below once it exists.