### PR TITLE
fix: add apt timeouts and job timeout to prevent indefinite hangs (#245)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,7 @@ jobs:
   validate:
     name: Skill Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -192,7 +193,13 @@ jobs:
           fi
           COUNT=$(echo "$SCRIPTS" | wc -l)
           echo "Found $COUNT shell script(s)"
-          sudo apt-get update -qq > /dev/null 2>&1 && sudo apt-get install -y -qq shellcheck > /dev/null 2>&1
+          # Set apt timeouts to prevent indefinite hangs on slow mirrors
+          sudo mkdir -p /etc/apt/apt.conf.d
+          echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/99-timeouts > /dev/null
+          echo 'Acquire::http::Timeout "15";' | sudo tee -a /etc/apt/apt.conf.d/99-timeouts > /dev/null
+          echo 'Acquire::https::Timeout "15";' | sudo tee -a /etc/apt/apt.conf.d/99-timeouts > /dev/null
+          timeout 60 sudo apt-get update -qq 2>&1 | tail -5 || echo "apt-get update completed or timed out"
+          timeout 60 sudo apt-get install -y -qq shellcheck 2>&1 | tail -5 || { echo "::error::Failed to install shellcheck within timeout"; exit 1; }
           FAILED=0
           while IFS= read -r script; do
             [[ -z "$script" ]] && continue


### PR DESCRIPTION
## Summary
Adds apt acquisition timeouts and a job-level timeout to prevent `validate.yml` from hanging indefinitely when a mirror is slow or unresponsive.

## Changes
- **APT timeouts**: Writes `/etc/apt/apt.conf.d/99-timeouts` with `Acquire::Retries 3`, `Acquire::http::Timeout 15`, `Acquire::https::Timeout 15` before apt-get update/install
- **Install timeout**: Wraps both `apt-get update` and `apt-get install` in `timeout 60` so the step fails instead of hanging
- **Job timeout**: Adds `timeout-minutes: 15` to the validate job to cap total runner time
- **Visible output**: Removes `> /dev/null 2>&1` from apt commands so stalls are diagnosable from logs

## Why
Without these bounds, a mirror that accepts the connection and then stops responding blocks the step forever. The `-qq` plus `> /dev/null 2>&1` discards all output, making a stalled fetch invisible. On 2026-08-19 this stalled a step for 37 minutes until cancelled by hand. This reusable is called by every skill repo in the fleet, so a bad apt day stalls validation everywhere.

Closes #245