### PR TITLE
fix(ci): make the shellcheck hook and CI the same check

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -43,3 +43,16 @@ jobs:
 
       - name: Version parity
         run: bash skills/skill-repo/scripts/check-version-parity.sh
+
+  # The shellcheck step lives in validate.yml, and lint.yml calls that file from
+  # `main` — so a change to it is not gated by the PR that makes it. Calling the
+  # PR's own copy closes that hole, and pins this repo to the severity its
+  # pre-commit hook already enforces: all 21 scripts here are clean at `style`,
+  # so hook and CI agree by construction instead of by claim.
+  validate-self:
+    name: Skill Validation (this PR's validator)
+    uses: ./.github/workflows/validate.yml
+    permissions:
+      contents: read
+    with:
+      shellcheck-severity: style

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -221,7 +221,11 @@ jobs:
           # the same file, which is the divergence this input exists to end.
           # It also removes the apt stall that #245 had to bound: a pinned
           # tarball with a checksum cannot hang for 37 minutes on a mirror.
-          curl -fsSL --max-time 120 -o /tmp/shellcheck.tar.xz \
+          # --proto/--proto-redir pin the scheme for the request AND for the
+          # redirect GitHub answers with, so -L cannot be walked onto http
+          # (githubactions:S6506).
+          curl --proto '=https' --proto-redir '=https' --tlsv1.2 \
+            -fsSL --max-time 120 -o /tmp/shellcheck.tar.xz \
             "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
           echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c
           tar -xJf /tmp/shellcheck.tar.xz -C /tmp "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,21 @@ name: Validate Skill
 
 on:
   workflow_call:
+    inputs:
+      shellcheck-severity:
+        description: >-
+          Minimum shellcheck severity that fails the job: error (default),
+          warning, info or style. It exists so a repository can hold its
+          pre-commit hook and this job to the SAME level — the hook runs
+          shellcheck at its own default (style) unless given `args`, and a
+          repository whose scripts are clean at that level should say so here
+          rather than let the two gates disagree. Raise it only once the tree
+          passes: a repository carrying a vendored script it does not own
+          (a TYPO3 Core runTests.sh, say) stays on `error` and pins the same
+          value in its hook's `args`.
+        required: false
+        type: string
+        default: error
 
 permissions:
   contents: read
@@ -183,6 +198,8 @@ jobs:
           echo "Versions match in ${CHECKED} SKILL.md file(s)"
 
       - name: ShellCheck scripts
+        env:
+          SEVERITY: ${{ inputs.shellcheck-severity }}
         run: |
           # Auto-discover shell scripts in skill directories and root scripts/
           SCRIPTS=$(find . -path './.skill-repo-tools' -prune -o -path './.git' -prune -o \
@@ -219,7 +236,7 @@ jobs:
           while IFS= read -r script; do
             [[ -z "$script" ]] && continue
             echo "Checking: $script"
-            if ! shellcheck -x -S error "$script"; then
+            if ! shellcheck -x -S "$SEVERITY" "$script"; then
               FAILED=1
             fi
           done <<< "$SCRIPTS"
@@ -227,7 +244,7 @@ jobs:
             echo "::error::ShellCheck found errors"
             exit 1
           fi
-          echo "All $COUNT scripts passed ShellCheck"
+          echo "All $COUNT scripts passed ShellCheck at severity $SEVERITY"
 
       - name: Python lint
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -200,6 +200,9 @@ jobs:
       - name: ShellCheck scripts
         env:
           SEVERITY: ${{ inputs.shellcheck-severity }}
+          # renovate: datasource=github-releases depName=koalaman/shellcheck
+          SHELLCHECK_VERSION: '0.11.0'
+          SHELLCHECK_SHA256: '8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198'
         run: |
           # Auto-discover shell scripts in skill directories and root scripts/
           SCRIPTS=$(find . -path './.skill-repo-tools' -prune -o -path './.git' -prune -o \
@@ -210,28 +213,20 @@ jobs:
           fi
           COUNT=$(echo "$SCRIPTS" | wc -l)
           echo "Found $COUNT shell script(s)"
-          # apt applies no timeout to package acquisition, so a mirror that accepts the
-          # connection and then stops responding blocks forever instead of failing. That
-          # stalled this step for 37 minutes on 2026-08-19 (#245). The bound goes into
-          # apt's own config so any child process inherits it.
-          sudo tee /etc/apt/apt.conf.d/99-ci-timeouts >/dev/null <<'CONF'
-          Acquire::Retries "3";
-          Acquire::http::Timeout "30";
-          Acquire::https::Timeout "30";
-          CONF
-          # Output is deliberately not discarded: a stalled fetch is
-          # indistinguishable from a step doing nothing once -qq and
-          # >/dev/null have swallowed it.
-          for attempt in 1 2 3; do
-            if timeout 180 sudo apt-get update && timeout 180 sudo apt-get install -y shellcheck; then
-              break
-            fi
-            if [[ $attempt -eq 3 ]]; then
-              echo "::error::apt could not install shellcheck in three attempts"
-              exit 1
-            fi
-            echo "::warning::apt attempt ${attempt} did not complete within 180s"
-          done
+          # The binary comes from its own release, pinned, NOT from apt: the
+          # pre-commit hook pins shellcheck-py 0.11.0.x while Ubuntu 24.04
+          # ships 0.9.0, and the two disagree — 0.9.0 reports SC2317 on code
+          # 0.11 accepts. At `-S error` that difference was invisible; at any
+          # stricter severity it makes hook and CI contradict each other over
+          # the same file, which is the divergence this input exists to end.
+          # It also removes the apt stall that #245 had to bound: a pinned
+          # tarball with a checksum cannot hang for 37 minutes on a mirror.
+          curl -fsSL --max-time 120 -o /tmp/shellcheck.tar.xz \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          sudo install -m 0755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+          shellcheck --version
           FAILED=0
           while IFS= read -r script; do
             [[ -z "$script" ]] && continue

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,14 @@
 # a small drift window between a Renovate bump in CI and the local config
 # catching up; this is the standard pre-commit pattern.
 #
-# "Also runs in CI" means the same check, not merely the same tool: where a
-# hook takes `args`, they mirror CI's invocation. shellcheck is the one that
-# drifted — the hook ran at its default severity while CI passed `-S error`,
-# so a file CI accepted could not be committed, and the answer was to bypass
-# the hook. Both sides are now `-x` at `style` (see the shellcheck block and
-# validate.yml's `shellcheck-severity` input).
+# "Also runs in CI" means the same check, not merely the same tool: same
+# flags AND same version. shellcheck is the one that drifted on all three —
+# the hook ran at its default severity without `-x` while CI passed
+# `-S error -x`, and CI's binary came from apt (Ubuntu 24.04 ships 0.9.0)
+# while the hook pins 0.11.0.x. A file CI accepted could therefore be
+# uncommittable, and 0.9.0 reports findings 0.11 does not. Both sides now run
+# 0.11.0 with `-x` at `style` (see the shellcheck block below and
+# validate.yml's pinned download plus its `shellcheck-severity` input).
 #
 # This repo dogfoods its own hooks (validate-skill, check-version-parity from
 # skill-repo-skill itself).
@@ -72,9 +74,11 @@ repos:
     hooks:
       # `-x` mirrors CI, which passes it: without it a `source`d file is not
       # followed, so the two gates would analyse the same script differently
-      # even at equal severity. The severity itself is shellcheck's default
-      # (style) here, and validate.yml is called with `shellcheck-severity:
-      # style` to match. A repo whose tree is not clean at that level pins the
-      # SAME lower value on both sides rather than only on one.
+      # even at equal severity and version. The severity itself is
+      # shellcheck's default (style) here, and validate.yml is called with
+      # `shellcheck-severity: style` to match. The `rev` below and the version
+      # validate.yml downloads are one pair — bump them together, or CI starts
+      # reporting what the hook does not. A repo whose tree is not clean at
+      # `style` pins the SAME lower severity on both sides, not on one.
       - id: shellcheck
         args: [-x]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,13 @@
 # a small drift window between a Renovate bump in CI and the local config
 # catching up; this is the standard pre-commit pattern.
 #
+# "Also runs in CI" means the same check, not merely the same tool: where a
+# hook takes `args`, they mirror CI's invocation. shellcheck is the one that
+# drifted — the hook ran at its default severity while CI passed `-S error`,
+# so a file CI accepted could not be committed, and the answer was to bypass
+# the hook. Both sides are now `-x` at `style` (see the shellcheck block and
+# validate.yml's `shellcheck-severity` input).
+#
 # This repo dogfoods its own hooks (validate-skill, check-version-parity from
 # skill-repo-skill itself).
 #
@@ -63,4 +70,11 @@ repos:
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:
+      # `-x` mirrors CI, which passes it: without it a `source`d file is not
+      # followed, so the two gates would analyse the same script differently
+      # even at equal severity. The severity itself is shellcheck's default
+      # (style) here, and validate.yml is called with `shellcheck-severity:
+      # style` to match. A repo whose tree is not clean at that level pins the
+      # SAME lower value on both sides rather than only on one.
       - id: shellcheck
+        args: [-x]


### PR DESCRIPTION
Closes #248.

The config header promises "every hook below ALSO runs in CI". For shellcheck it did not:

| | hook | `validate.yml` |
|---|---|---|
| severity | shellcheck's default (`style`) | `-S error` |
| `-x` (follow `source`d files) | no | yes |

So a script CI accepted could be uncommittable, and the only way past it was `SKIP=shellcheck` — in a config that explicitly warns "if you need this often, the hook is wrong; don't tolerate the bypass".

## Not lowering one side blindly

The obvious fix — give the hook `-S error` — weakens a gate that most repositories pass today. Measured: all 21 shell scripts in this repository are clean at `style`. So the severity becomes an **input** instead, defaulting to `error`, which leaves all 23 consumers of `validate.yml` exactly where they are:

```yaml
uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
with:
  shellcheck-severity: style   # only where the tree is clean at that level
```

A repository then pins the same level on **both** sides. `style` where its scripts are its own; `error` where it carries a vendored script it does not own — `netresearch/typo3-testing-skill` ships a TYPO3-Core-derived `runTests.sh` whose 105 findings are mostly deliberate word splitting (`${CONTAINER_COMMON_PARAMS}` must expand into several docker arguments; quoting it would break the script).

## This repository takes the strict side

`self-test.yml` now calls the validator with `shellcheck-severity: style`, and the hook gains `-x` to match CI. That call closes a second hole while it is there: `lint.yml` calls `validate.yml@main`, so a change to the validator was never gated by the pull request making it — this one is.

`lint.yml` deliberately keeps calling `@main` **without** the new input: passing an input that `main` does not declare yet fails the run at startup. It follows in a one-line PR once this is merged.

## Verified

- `shellcheck -x -S style` over all 21 scripts: 0 findings.
- `tests/validate-skill.sh`, `tests/portable-manifest.sh`, `validate-skill.sh .`, `check-version-parity.sh`: all exit 0.
- `actionlint -shellcheck=shellcheck` on both changed workflows: clean.
- The new input is exercised by this PR's own run, not only after merge — that is what the `validate-self` job is for.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_
