### PR TITLE
feat(validate): enforce the Agent Skills budgets and flat discovery

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,12 @@ permissions: {}
 jobs:
   validate:
     name: Skill Validation
-    uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
+    # Local reference, not netresearch/skill-repo-skill/...@main. This IS that
+    # repository: pointing at main runs the workflow this pull request is
+    # changing, from before the change, so a workflow or validator edit is
+    # judged by the version it replaces and can never be green on its own pull
+    # request. self-test.yml already calls it locally; this is the same call
+    # made consistent. Consumer repos keep the remote @main reference.
+    uses: ./.github/workflows/validate.yml
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,6 @@ permissions: {}
 jobs:
   validate:
     name: Skill Validation
-    # Local reference, not netresearch/skill-repo-skill/...@main. This IS that
-    # repository: pointing at main runs the workflow this pull request is
-    # changing, from before the change, so a workflow or validator edit is
-    # judged by the version it replaces and can never be green on its own pull
-    # request. self-test.yml already calls it locally; this is the same call
-    # made consistent. Consumer repos keep the remote @main reference.
-    uses: ./.github/workflows/validate.yml
+    uses: netresearch/skill-repo-skill/.github/workflows/validate.yml@main
     permissions:
       contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,7 +60,21 @@ jobs:
           cache-dependency-glob: ""
 
       - name: Run skill validation
-        run: bash .skill-repo-tools/skills/skill-repo/scripts/validate-skill.sh .
+        # When the CALLER is skill-repo-skill itself, validate with the copy
+        # under test rather than with the one on main. Both jobs that run this
+        # workflow used the .skill-repo-tools checkout, so a pull request that
+        # changed the validator was judged by the version it was replacing --
+        # including the job literally named "this PR's validator". A validator
+        # change could therefore never be green on its own pull request.
+        # github.repository is the CALLER's repository inside a reusable
+        # workflow, so consumers keep using the pinned tools checkout.
+        run: |
+          if [ "${{ github.repository }}" = "netresearch/skill-repo-skill" ]; then
+            echo "Self-validation: using the working copy under test"
+            bash skills/skill-repo/scripts/validate-skill.sh .
+          else
+            bash .skill-repo-tools/skills/skill-repo/scripts/validate-skill.sh .
+          fi
 
       # Root plugin.json (Agent Plugins 1.0.0) is the source of truth for the
       # shared metadata. No-op in repos that have not adopted it yet.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,10 +40,25 @@ repos:
       - id: check-yaml
         args: [--allow-multiple-documents]
 
+  # validate-skill runs from the WORKING COPY, not from the pinned release.
+  # This repository ships that validator, so pinning it to the last tag means a
+  # change to it is never exercised by its own pre-commit until after it is
+  # published -- and a SKILL.md written against the new rules is rejected by the
+  # old ones, with no way out but weakening the content or bypassing the gate.
+  # check-version-parity stays pinned: it is not authored against itself.
+  - repo: local
+    hooks:
+      - id: validate-skill
+        name: Validate skill repo structure
+        description: Run validate-skill.sh against the repo when skill metadata changes.
+        entry: skills/skill-repo/scripts/validate-skill.sh
+        language: script
+        pass_filenames: false
+        files: (^skills/.+/SKILL\.md$|^SKILL\.md$|^skills/.+/checkpoints\.yaml$|^checkpoints\.yaml$|^\.claude-plugin/plugin\.json$|^composer\.json$)
+        require_serial: true
   - repo: https://github.com/netresearch/skill-repo-skill
     rev: v1.22.0
     hooks:
-      - id: validate-skill
       - id: check-version-parity
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -12,25 +12,23 @@ allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 
 # Skill Repository Structure Guide
 
-Standards for Netresearch skill repository layout and distribution.
-
 ## Repository Structure
 
 ```
 {repo-name}/
-├── plugin.json                  # portable manifest (required)
+├── plugin.json                  # portable manifest
 ├── .claude-plugin/plugin.json   # generated
-├── skills/{name}/SKILL.md       # AI instructions (required)
-├── README.md                    # Human docs (required)
-├── LICENSE-MIT                  # Code license (required)
-├── LICENSE-CC-BY-SA-4.0         # Content license (required)
-├── composer.json                # PHP distribution (required)
-├── references/                  # Extended docs for >500w content
-├── scripts/                     # Automation
+├── skills/{name}/SKILL.md       # the control plane
+├── README.md                    # human docs
+├── LICENSE-MIT                  # code
+├── LICENSE-CC-BY-SA-4.0         # content
+├── composer.json                # PHP distribution
+├── references/                  # detail, loaded on demand
+├── scripts/                     # executables, never loaded
 └── .github/workflows/
-    ├── release.yml              # Tag-triggered release
-    ├── validate.yml             # Caller for reusable validation
-    └── auto-merge-deps.yml      # Caller for dep auto-merge
+    ├── release.yml              # tag-triggered
+    ├── validate.yml             # validation caller
+    └── auto-merge-deps.yml      # dep auto-merge caller
 ```
 
 ## Licensing (Split Model)
@@ -52,9 +50,9 @@ description: "Use when <trigger conditions>"
 ---
 ```
 
-**Budgets** (spec): `name` ≤64, no doubled/edge hyphen, matches the directory. `description` ≤1024 (warn past 500) — a router, not documentation. Body ≤500 lines (warn at 300). `compatibility` ≤500, usually omit.
+**Budgets** (spec): `name` ≤64, no doubled/edge hyphen, matches its directory. `description` ≤1024, warn past 500 — a router, not documentation. Body ≤500 lines, warn at 300. `compatibility` ≤500, usually omit.
 
-**Flat discovery**: references one level deep; name every `references/*.md` and every `scripts/` executable in SKILL.md; `## Contents` past 100 lines. Why, and how to test triggering: [skill-architecture](references/skill-architecture.md). Audit: `scripts/audit-skills.sh`. Catalog fields belong in README, not frontmatter.
+**Flat discovery**: references one level deep; SKILL.md names every `references/*.md` and every `scripts/` executable; `## Contents` past 100 lines. Rationale and trigger evals: [skill-architecture](references/skill-architecture.md). Audit: `scripts/audit-skills.sh`.
 
 ## Manifests
 
@@ -101,24 +99,18 @@ Bump root `plugin.json` → sync → PR → merge → pull main → verify parit
 
 ## Installation
 
-1. **Marketplace**: `/plugin marketplace add netresearch/claude-code-marketplace`
-2. **Release**: Download to `~/.claude/skills/{name}/`
-3. **Composer**: `composer require netresearch/{repo-name}`
-4. **npm**: `npm i -D @netresearch/agent-skill-coordinator github:netresearch/{repo-name}`. Use `templates/package.json.template` (minimal `files` default).
+Marketplace, release download, Composer, npm — commands and the npm `files` default in [installation-methods](references/installation-methods.md).
 
 ## Validation
 
 `scripts/validate-skill.sh` (layout, manifests, budgets, flat discovery). Shell portability: [authoring-ci-gotchas](references/authoring-ci-gotchas.md).
 
-Other `scripts/` executables, named here because the control plane is where a script becomes findable: `bump-version.sh` (raise every version surface), `check-version-parity.sh` (assert they agree), `sync-plugin-manifest.sh` (regenerate the Claude manifest), `roll-changelog.py` (Unreleased → dated release), `fleet-release-github.sh` (release across the fleet), `migrate-licensing.sh` (dual-licence layout), `validate-evals.sh` (check `evals/`).
+Named here so they are findable: `bump-version.sh`, `check-version-parity.sh`, `sync-plugin-manifest.sh`, `roll-changelog.py`, `fleet-release-github.sh`, `migrate-licensing.sh`, `validate-evals.sh` — each with `--help`.
 
 ## References (`references/`)
 
 [agent-plugins-compat](references/agent-plugins-compat.md) · [installation-methods](references/installation-methods.md) · [composer-setup](references/composer-setup.md) · [release-discipline](references/release-discipline.md) · [review-replies](references/review-replies.md) · [skill-quality](references/skill-quality.md) · [repository-quality-rules](references/repository-quality-rules.md) · [readme-template](references/readme-template.md) · [skill-discovery-metadata](references/skill-discovery-metadata.md) · [validation-checklist](references/validation-checklist.md) · [marketplace-integration](references/marketplace-integration.md) · [materialization-contract](references/materialization-contract.md) · [authoring-ci-gotchas](references/authoring-ci-gotchas.md) · [skill-retirement](references/skill-retirement.md)
 
-## See Also
-
-[`agent-rules-skill`](https://github.com/netresearch/agent-rules-skill), [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill), [`retro-skill`](https://github.com/netresearch/retro-skill).
 
 ---
 

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -47,12 +47,14 @@ SPDX: `(MIT AND CC-BY-SA-4.0)`. Copyright: `Netresearch DTT GmbH`. No bare `LICE
 
 ```yaml
 ---
-name: skill-name          # lowercase, hyphens, max 64 chars
+name: skill-name
 description: "Use when <trigger conditions>"
 ---
 ```
 
-Body ≤500 words; description ≤1,536 chars (target 100–300, trigger first). Every `references/*.md` must be reachable from SKILL.md (no orphans). Audit: `scripts/audit-skills.sh`. Put discovery/catalog fields in README or optional YAML, not frontmatter.
+**Budgets** (spec): `name` ≤64, no doubled/edge hyphen, matches the directory. `description` ≤1024 (warn past 500) — a router, not documentation. Body ≤500 lines (warn at 300). `compatibility` ≤500, usually omit.
+
+**Flat discovery**: references one level deep; name every `references/*.md` and every `scripts/` executable in SKILL.md; `## Contents` past 100 lines. Why, and how to test triggering: [skill-architecture](references/skill-architecture.md). Audit: `scripts/audit-skills.sh`. Catalog fields belong in README, not frontmatter.
 
 ## Manifests
 
@@ -106,7 +108,9 @@ Bump root `plugin.json` → sync → PR → merge → pull main → verify parit
 
 ## Validation
 
-`scripts/validate-skill.sh` (layout, manifests). Shell portability: [authoring-ci-gotchas](references/authoring-ci-gotchas.md).
+`scripts/validate-skill.sh` (layout, manifests, budgets, flat discovery). Shell portability: [authoring-ci-gotchas](references/authoring-ci-gotchas.md).
+
+Other `scripts/` executables, named here because the control plane is where a script becomes findable: `bump-version.sh` (raise every version surface), `check-version-parity.sh` (assert they agree), `sync-plugin-manifest.sh` (regenerate the Claude manifest), `roll-changelog.py` (Unreleased → dated release), `fleet-release-github.sh` (release across the fleet), `migrate-licensing.sh` (dual-licence layout), `validate-evals.sh` (check `evals/`).
 
 ## References (`references/`)
 

--- a/skills/skill-repo/references/agent-plugins-compat.md
+++ b/skills/skill-repo/references/agent-plugins-compat.md
@@ -1,5 +1,14 @@
 # Agent Plugins 1.0.0 compatibility
 
+## Contents
+
+- Why two files
+- The portable manifest
+- Generating the Claude manifest
+- Migrating a repo
+- What validation enforces
+- Out of scope
+
 Netresearch skill repos ship **two** manifests. This page says what each one is
 for, which is authoritative, and how to migrate a repo that has only the
 Claude Code one.

--- a/skills/skill-repo/references/authoring-ci-gotchas.md
+++ b/skills/skill-repo/references/authoring-ci-gotchas.md
@@ -1,5 +1,14 @@
 # Authoring & CI Gotchas
 
+## Contents
+
+- Word-budget-first authoring
+- macOS / BSD portability for shell **and** test scripts
+- Lint without dirtying the worktree
+- "Skill Validation" can run more than once — wait for all of it
+- Installing the Claude Code CLI with `--ignore-scripts`
+- Generated YAML: exactly one trailing newline
+
 Process learnings from a cross-session retrospective (2026-06-27). Companion to
 [`skill-quality.md`](skill-quality.md) (SKILL.md sizing) and the
 [`validation-checklist.md`](validation-checklist.md) (pre-completion checks).

--- a/skills/skill-repo/references/composer-setup.md
+++ b/skills/skill-repo/references/composer-setup.md
@@ -1,5 +1,17 @@
 # Composer Setup for Skills
 
+## Contents
+
+- When to Add composer.json
+- composer.json Structure
+- Multi-Skill Packages
+- Publishing to Packagist
+- Skill repos that ship their own PHP code
+- Files to NOT Include
+- Validation
+- Integration with Plugin
+- Troubleshooting
+
 Guide for adding Composer distribution to Netresearch skills.
 
 ## When to Add composer.json

--- a/skills/skill-repo/references/installation-methods.md
+++ b/skills/skill-repo/references/installation-methods.md
@@ -1,5 +1,14 @@
 # Installation Methods
 
+## Contents
+
+- Method 1: Netresearch Marketplace (Recommended)
+- Method 2: Download Release
+- Method 3: Composer (PHP Projects)
+- Method 4: npm (Node Projects)
+- Choosing a Method
+- Directory Locations
+
 Four methods for installing Netresearch skills.
 
 ## Method 1: Netresearch Marketplace (Recommended)

--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -1,5 +1,20 @@
 # Materialization Contract
 
+## Contents
+
+- Scope
+- Failure-pattern schema
+- Rule 1: Patches target source repos, never local cache
+- Rule 2: Workspace preference order
+- Rule 3: Branch convention
+- Rule 4: Commit conventions
+- Rule 5: PR template
+- Rule 6: Target area mapping
+- Rule 7: Eval format (skill-repo convention)
+- Rule 8: Per-private-repo confirmation
+- Rule 9: New-skill scaffolding
+- See also
+
 How external tools (notably `retro-skill`) materialize **skill improvements** or **new skills** by submitting PRs to skill repositories that follow `skill-repo-skill` conventions.
 
 ## Scope

--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -1,5 +1,20 @@
 # Release Discipline
 
+## Contents
+
+- Fleet sweeps: use the shipped driver, do not hand-write a new one
+- Canonical Order: Bump PR Merged → Tag Pushed
+- Pre-Release Version-Parity Check
+- Changelog Rollover in the Bump Commit
+- Cache Safety: Never Edit the Installed Copy
+- Multi-Skill-Repo Release Dry-Run
+- GitLab (`git.netresearch.de`) skill repos release on tag too
+- A pushed tag is not a release — check the pattern the release job matches
+- Immutable-Release Caveat
+- Tag Signing (Mandatory)
+- No `--latest` Drift for Non-Default Branches
+- Supply-Chain Attestation
+
 Every step that caused the "30 failed plugin releases" incident, codified as rules.
 
 ## Fleet sweeps: use the shipped driver, do not hand-write a new one

--- a/skills/skill-repo/references/repository-quality-rules.md
+++ b/skills/skill-repo/references/repository-quality-rules.md
@@ -1,5 +1,17 @@
 # Repository Quality Rules (skill repositories)
 
+## Contents
+
+- Lizenz (Netresearch Split-Modell)
+- Mindestbestandteile eines Skill-Repos
+- Scripts-first (mechanisch prüfbare Regeln)
+- Pflicht für README-Oberfläche
+- SKILL.md vs. Discovery
+- Related Skills (Repo-Ebene)
+- Marketplace-Sync (Quelle bleibt Repo)
+- GitHub Repository SEO
+- GitHub Pages policy
+
 Prüfbare Regeln für **einzelne Skill-Repositories** (`netresearch/*-skill`).
 **Nicht** für das Marketplace-Repository — Discovery-Katalog- und SEO-Governance für den Hub liegen in **`netresearch/claude-code-marketplace`** (`AGENTS.md` dort).
 

--- a/skills/skill-repo/references/skill-architecture.md
+++ b/skills/skill-repo/references/skill-architecture.md
@@ -1,0 +1,174 @@
+# Skill Architecture: flat discovery, small routing metadata, details on demand
+
+## Contents
+
+- The three surfaces
+- Budgets, and where each number comes from
+- The description is a router, not documentation
+- Flat discovery: one level, always
+- What belongs in SKILL.md and what does not
+- Long references need a Contents section
+- What the validator enforces
+- Testing whether a skill triggers
+- Sources
+
+## The three surfaces
+
+A skill is read in three stages, at three different moments. Putting a fact on the wrong one is why a capability that exists still does not get used.
+
+| Surface | When it enters context | Size | What a gap there costs |
+|---|---|---|---|
+| `name` + `description` | **always**, at startup, for every installed skill | ~100 tokens | **The only true skip.** The skill is never activated, so nothing else is ever read. |
+| `SKILL.md` body | when the skill is activated | < 5000 tokens recommended | A blind spot: the skill runs and does not know the thing exists. |
+| `references/`, `scripts/`, `assets/` | only when the agent decides to reach for one | unbounded | Nothing — until it is needed. |
+
+> *"Metadata (~100 tokens): The `name` and `description` fields are loaded at startup for all skills. Instructions (< 5000 tokens recommended): The full `SKILL.md` body is loaded when the skill is activated. Resources (as needed): Files … are loaded only when required."*
+
+The practical consequence: **a missing capability in the description cannot be recovered later.** A missing capability in the body can at least be found by an agent that reads a reference. A missing reference costs nothing until something needs it.
+
+## Budgets, and where each number comes from
+
+| Element | Limit | Kind | Target |
+|---|---|---|---|
+| `name` | 64 chars, `[a-z0-9-]`, no leading/trailing hyphen, no `--`, must match the directory name | **spec, hard** | 15–40 |
+| `description` | **1024 chars** | **spec, hard** | see below |
+| `compatibility` | 500 chars | **spec, hard** | one sentence, usually omit |
+| `SKILL.md` body | **< 500 lines**, < 5000 tokens | spec recommendation | 100–250 |
+| reference file | none | — | add a Contents list past 100 lines |
+
+Two traps worth naming:
+
+**Lines, not words.** The recommendation is *"Keep your main `SKILL.md` under 500 lines"*. A word budget is a different and far tighter constraint. This repository's validator counted 500 **words over the whole file** until 2026-08; a consuming repo sat at 499 of 500 and left a script out of its `SKILL.md` rather than spend fourteen words on it.
+
+**Frontmatter is not body.** Counting them together makes the description — the surface that decides whether the skill is used at all — compete with the instructions for one allowance. That trade is always the wrong way round.
+
+## The description is a router, not documentation
+
+The description carries the entire burden of triggering. It is not a summary of the workflow.
+
+Write **what + when**, and stop:
+
+```yaml
+description: "Use when formatting or validating text for Jira — descriptions, comments, wiki markup, or converting Markdown to Jira syntax."
+```
+
+Not:
+
+```yaml
+description: >
+  Handles Jira content by first detecting Markdown, then converting it with
+  md2jira.sh, validating the result, checking special tables, escaping
+  characters and finally producing Jira wiki markup…
+```
+
+The second wastes routing context, and it can actively harm: a description containing a condensed workflow invites the agent to follow **that** summary instead of activating the skill and reading the real instructions.
+
+On length, two pulls exist and both are real. The official guidance says *"A few sentences to a short paragraph"* and also *"Err on the side of being pushy. Explicitly list contexts where the skill applies"* — that argues for covering the scope properly. Against it: every description competes for a shared listing budget, and an over-broad one triggers when it should not.
+
+So: **1024 is a validation limit, not a target.** Past roughly 500 characters, check whether what you added is trigger information or process narration. Cut the narration; keep the contexts.
+
+## Flat discovery: one level, always
+
+> *"Keep file references one level deep from `SKILL.md`. Avoid deeply nested reference chains."*
+
+The reason is mechanical. `SKILL.md` is read in full on activation. A reference is read only if `SKILL.md` said what it contains and when to open it. A file reachable only through a second hop sits behind a door with no sign on it — nothing states what it holds or why it matters, so the agent must open the middle file speculatively and then guess again.
+
+Good:
+
+```
+jira-communication/
+├── SKILL.md
+├── references/
+│   ├── jira-syntax.md
+│   ├── jira-style.md
+│   └── issue-fields.md
+└── scripts/
+    ├── md2jira.sh
+    └── validate-jira.sh
+```
+
+with every one of them named in `SKILL.md`:
+
+```markdown
+## Resources
+
+- Jira wiki markup rules: `references/jira-syntax.md`
+- Wording and issue conventions: `references/jira-style.md`
+- Convert Markdown to Jira markup: run `scripts/md2jira.sh`
+- Validate generated markup: run `scripts/validate-jira.sh`
+```
+
+`jira-syntax.md` may of course also say "run `scripts/md2jira.sh`". That is **redundancy for orientation**, and it is welcome. What it must not be is the *only* path by which the agent learns the script exists.
+
+Bad, and specifically bad:
+
+- `SKILL.md` → `scripts.md` → `scripts/foo.sh` — an index file that only points at scripts adds indirection with no information. Delete it and give the scripts a real `--help`.
+- `SKILL.md` → `jira-style.md` → `md2jql.sh` **as the only path** — the script is invisible unless that one reference happens to be opened.
+
+Split by topic at the **first** level rather than nesting: `topic-a.md` and `topic-b.md`, both listed, each with its own trigger.
+
+## What belongs in SKILL.md and what does not
+
+`SKILL.md` is a **control plane**, not a handbook.
+
+In it:
+
+1. Invariants that must never be forgotten.
+2. Decisions — "if X, read/run Y".
+3. Workflow order, where order matters.
+4. Guardrails.
+5. The resource map: every reference and every executable, each with a trigger.
+6. Verification — how the agent knows it is done.
+
+Not in it: API documentation, syntax references, long examples, mappings, lookup tables, historical explanations, CLI references, schemas, the fiftieth edge case. Those go to `references/`.
+
+And anything deterministic — conversion, parsing, validation, AST manipulation, formatting, mechanical checks — belongs in `scripts/`. Scripts are **executed, never loaded**, so their body costs no context at all. A script named in `SKILL.md` costs one line and buys the only chance the agent has of knowing it exists.
+
+## Long references need a Contents section
+
+Agents preview long files — `head`, an excerpt, a targeted search — rather than reading them whole. A contents list at the top makes the rest of the file visible anyway. Past about 100 lines, add one.
+
+For very large references (upwards of ~10k words), go further and tell the agent in `SKILL.md` what to search for, not just which file to open.
+
+## What the validator enforces
+
+`scripts/validate-skill.sh` checks the mechanically decidable part:
+
+| Check | Level |
+|---|---|
+| `description` > 1024 chars | ERROR (spec) |
+| `description` > 500 chars | WARN |
+| `description` missing / not `Use when …` | ERROR |
+| `name` invalid, leading/trailing or doubled hyphen | ERROR (spec) |
+| `compatibility` > 500 chars | ERROR (spec) |
+| body > 500 lines | ERROR |
+| body > 300 lines | WARN |
+| `references/*.md` reachable only via another reference | WARN |
+| `references/*.md` not named in `SKILL.md` | WARN |
+| reference > 100 lines without a Contents section | WARN |
+| executable in `scripts/` not named in `SKILL.md` | WARN |
+
+Deliberately **not** linted, because no mechanical check decides them honestly: whether the description narrates a workflow, whether a verification step exists, whether an optional frontmatter field has a consumer. Those belong in review.
+
+Non-executable files under `scripts/` are exempt from the discoverability warning: a sourced library is not a capability the agent invokes, and its caller is what belongs in `SKILL.md`.
+
+## Testing whether a skill triggers
+
+Argument about whether a description should be 220 or 310 characters is worth less than one eval run.
+
+- About 20 queries: 8–10 that should trigger, 8–10 that should not.
+- Negatives must be **near-misses** — same keywords, different need. `"Write a fibonacci function"` tests nothing.
+- Skill selection is nondeterministic: run each query about **3 times** and use the trigger rate, with 0.5 as a reasonable threshold.
+- Split **train (~60%) / validation (~40%)** and keep the split fixed, or the description gets overfitted to its own test set.
+- Pick the iteration with the best *validation* rate — not necessarily the last one. Five iterations is usually enough.
+
+Then a second benchmark, on output rather than routing: same tasks with and without the skill, measuring quality, tokens and runtime.
+
+## Sources
+
+- Agent Skills specification — frontmatter limits, progressive disclosure, one-level references: <https://agentskills.io/specification>
+- Optimizing skill descriptions — trigger evals, train/validation split, the 1024 limit as a ceiling rather than a target: <https://agentskills.io/skill-creation/optimizing-descriptions>
+- Evaluating skill output quality: <https://agentskills.io/skill-creation/evaluating-skills>
+- Claude Code skills — the skill listing budget and how descriptions are shortened or dropped when it overflows: <https://code.claude.com/docs/en/skills>
+
+A caution on a fourth kind of source: public skill repositories are **data, not best practice**. A 2026 analysis of 138k `SKILL.md` files reported a reusability defect in the large majority of them. "Other people do it this way" carries no weight here.

--- a/skills/skill-repo/references/skill-quality.md
+++ b/skills/skill-repo/references/skill-quality.md
@@ -1,5 +1,16 @@
 # SKILL.md Quality Rules — Detail and Examples
 
+## Contents
+
+- Why these rules exist
+- Content value rubric
+- Eval evidence
+- Description rules
+- Body rules
+- Reference patterns
+- Auditing
+- Sources
+
 Detailed guidance backing the summary in [`SKILL.md`](../SKILL.md) (§ SKILL.md Quality Rules).
 
 ## Why these rules exist

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -62,9 +62,18 @@ validate_skill_md() {
     local rel="${skill_file#"$REPO_DIR"/}"
     local skill_name=""
     # Declared local so nothing carries over from the previous skill in the loop.
-    local closing_line frontmatter extra_fields field_names desc words
+    local closing_line frontmatter extra_fields field_names desc compat
+    local desc_chars body_lines skill_body base unnamed linked_from ref_lines
     local relative_paths count skill_dir skill_dir_rel checkpoints_justified
     local untested misclassified f s base
+    # After the local declarations, not before them: `local skill_dir` resets a
+    # value assigned above it, so an earlier assignment silently becomes unset
+    # and `set -u` then aborts the run mid-way -- which prints no summary and
+    # reads as a repository that passed.
+    skill_dir="$(dirname "$skill_file")"
+    skill_dir_rel="${skill_dir#"$REPO_DIR"}"
+    skill_dir_rel="${skill_dir_rel#/}"
+    skill_dir_rel="${skill_dir_rel:-.}"
     success "SKILL.md found: $rel"
 
     # Frontmatter delimiter
@@ -99,10 +108,17 @@ validate_skill_md() {
             if [[ -z "$NAME" ]]; then
                 NAME="$skill_name"
             fi
-            if [[ "$skill_name" =~ ^[a-z0-9-]{1,64}$ ]]; then
-                success "$rel name valid: $skill_name"
-            else
+            # The spec forbids more than the character class does: no leading
+            # or trailing hyphen, and no consecutive hyphens. A name that only
+            # passes the class still fails a spec-conformant loader.
+            if [[ ! "$skill_name" =~ ^[a-z0-9-]{1,64}$ ]]; then
                 error "$rel name invalid (lowercase, hyphens, max 64): $skill_name"
+            elif [[ "$skill_name" == -* || "$skill_name" == *- ]]; then
+                error "$rel name must not start or end with a hyphen: $skill_name"
+            elif [[ "$skill_name" == *--* ]]; then
+                error "$rel name must not contain consecutive hyphens: $skill_name"
+            else
+                success "$rel name valid: $skill_name"
             fi
         else
             error "$rel missing 'name' field"
@@ -181,19 +197,64 @@ PYEOF
             else
                 error "$rel description must start with 'Use when': ${desc:0:60}..."
             fi
+
+            # The description is a ROUTER, not documentation. It is the only
+            # thing loaded at startup for every skill, so it decides whether
+            # this skill is ever consulted -- a gap here is the one failure
+            # that cannot be recovered later. The spec sets a hard 1024.
+            #
+            # The soft 500 is a nudge, not a defect: the official guidance is
+            # "a few sentences to a short paragraph" and explicitly says to
+            # err on the side of being pushy about listing contexts. Long is
+            # not automatically wrong; long AND full of workflow steps is.
+            if [[ "$desc" != "__PARSE_ERROR__" ]]; then
+                desc_chars=${#desc}
+                if (( desc_chars > 1024 )); then
+                    error "$rel description is $desc_chars chars (spec hard limit 1024) - cut process detail, keep capability and trigger"
+                elif (( desc_chars > 500 )); then
+                    warning "$rel description is $desc_chars chars - past 500 it is usually workflow narration; the description should say WHAT and WHEN, not HOW"
+                else
+                    success "$rel description is $desc_chars chars"
+                fi
+            fi
         else
             error "$rel missing 'description' field"
+        fi
+
+        # compatibility: spec caps it at 500 characters, and most skills should
+        # not carry the field at all.
+        if echo "$frontmatter" | grep -q "^compatibility:"; then
+            # Octal escapes for the two quote characters: a literal quote here
+            # would terminate the string it lives in (the same trap the awk
+            # programs in this file avoid the same way).
+            compat=$(echo "$frontmatter" | grep "^compatibility:" | head -1 \
+                     | sed 's/compatibility: *//' | tr -d '\42\47')
+            if (( ${#compat} > 500 )); then
+                error "$rel compatibility is ${#compat} chars (spec max 500)"
+            fi
         fi
     else
         error "$rel missing frontmatter (must start with ---)"
     fi
 
-    # Word count check (max 500)
-    words=$(wc -w < "$skill_file")
-    if [[ $words -le 500 ]]; then
-        success "$rel is $words words (under 500 limit)"
+    # Body size. The spec recommends "Keep your main SKILL.md under 500 lines"
+    # and "< 5000 tokens recommended" for the instructions loaded on activation.
+    # This used to count 500 WORDS over the WHOLE file -- a much tighter and
+    # differently shaped budget, and one that charged the frontmatter to the
+    # body. That inversion is the expensive part: the description is the
+    # routing surface, so making it compete with the instructions for one
+    # allowance buys a shorter description at the price of an undocumented
+    # capability. Lines, body only.
+    #
+    # 300 is the WARN, not the target: past it, ask which lines are control
+    # flow and which are reference material that belongs in references/.
+    body_lines=$(awk 'BEGIN{d=0} /^---$/{d++; next} d>=2{print}' "$skill_file" | wc -l)
+    if (( body_lines > 500 )); then
+        error "$rel body is $body_lines lines (spec recommends under 500) - move reference material into references/"
+    elif (( body_lines > 300 )); then
+        warning "$rel body is $body_lines lines - past 300, split reference material out and keep SKILL.md the control plane"
     else
-        error "$rel is $words words (max 500)"
+        success "$rel body is $body_lines lines"
     fi
     # Check for relative script paths that should use ${CLAUDE_SKILL_DIR}
     # Matches: uv run scripts/, python3 scripts/, python scripts/, bash scripts/, ./scripts/, sh scripts/
@@ -204,13 +265,69 @@ PYEOF
         warning "$rel has $count script reference(s) using relative paths instead of \${CLAUDE_SKILL_DIR}/scripts/"
     fi
 
+    # --- Flat discovery ------------------------------------------------------
+    # Agent Skills spec: "Keep file references one level deep from SKILL.md.
+    # Avoid deeply nested reference chains." The rule exists because each hop is
+    # a decision the agent may not make. SKILL.md is read in full on activation;
+    # a reference is read only if SKILL.md said what it holds and when to open
+    # it. A file reachable only through a second hop sits behind an unmarked
+    # door. These are warnings, not errors: a chain is a smell, not a breach.
+    if [[ -n "$skill_dir" && -d "$skill_dir" ]]; then
+        skill_body=$(awk 'BEGIN{d=0} /^---$/{d++; next} d>=2{print}' "$skill_file")
+
+        # Scripts are executed, never loaded into context, so naming one costs a
+        # line and is the only chance the agent has of knowing it exists.
+        if [[ -d "$skill_dir/scripts" ]]; then
+            unnamed=""
+            for f in "$skill_dir"/scripts/*; do
+                [[ -f "$f" ]] || continue
+                base="$(basename "$f")"
+                case "$base" in *.md|*.txt|README*) continue ;; esac
+                # Non-executable files are sourced libraries, not capabilities
+                # the agent invokes; their caller is what belongs in SKILL.md.
+                [[ -x "$f" ]] || continue
+                grep -qF "$base" <<<"$skill_body" || unnamed="$unnamed $base"
+            done
+            if [[ -n "$unnamed" ]]; then
+                warning "${skill_dir_rel}: script(s) not named in SKILL.md:${unnamed} - a script reachable only through a reference is found only if that reference is opened"
+            fi
+        fi
+
+        if [[ -d "$skill_dir/references" ]]; then
+            for f in "$skill_dir"/references/*.md; do
+                [[ -f "$f" ]] || continue
+                base="$(basename "$f")"
+
+                if ! grep -qF "$base" <<<"$skill_body"; then
+                    linked_from=""
+                    for other in "$skill_dir"/references/*.md; do
+                        [[ -f "$other" && "$other" != "$f" ]] || continue
+                        if grep -qF "$base" "$other"; then
+                            linked_from="$(basename "$other")"
+                            break
+                        fi
+                    done
+                    if [[ -n "$linked_from" ]]; then
+                        warning "${skill_dir_rel}: references/${base} is reachable only via references/${linked_from} - the spec asks for one level; link it from SKILL.md too"
+                    else
+                        warning "${skill_dir_rel}: references/${base} is not named in SKILL.md - nothing tells the agent it exists or when to read it"
+                    fi
+                fi
+
+                # Agents preview long files rather than reading them whole, so a
+                # contents list is what makes the rest of a long reference
+                # visible at all.
+                ref_lines=$(grep -c "" "$f")
+                if (( ref_lines > 100 )) && ! grep -qiE '^#{1,3} +(contents|table of contents|overview|in this (file|document))' "$f"; then
+                    warning "${skill_dir_rel}: references/${base} is $ref_lines lines with no Contents section - agents preview long files; add one so the rest is discoverable"
+                fi
+            done
+        fi
+    fi
+
     # checkpoints.yaml presence (warning only — many skills legitimately lack
     # one; a documented justification marker suppresses the warning per
     # add-checkpoints' suitability criteria, e.g. purely conceptual skills)
-    skill_dir="$(dirname "$skill_file")"
-    skill_dir_rel="${skill_dir#"$REPO_DIR"}"
-    skill_dir_rel="${skill_dir_rel#/}"
-    skill_dir_rel="${skill_dir_rel:-.}"
     checkpoints_justified=0
     for f in "$skill_file" "$REPO_DIR/README.md"; do
         if [[ -f "$f" ]] && grep -qiE "^[[:space:]]*([*-][[:space:]]+)?checkpoints:[[:space:]]*none[[:space:]]*\(justified" "$f"; then

--- a/tests/validate-skill-architecture.sh
+++ b/tests/validate-skill-architecture.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Regression test: validate-skill.sh enforces the Agent Skills budgets and the
+# flat-discovery rule.
+#
+# Two things this pins that were wrong before:
+#
+#   * The size budget counted 500 WORDS over the WHOLE file. The spec says
+#     "Keep your main SKILL.md under 500 lines", and counting the frontmatter
+#     put the description -- the only surface that decides whether a skill is
+#     used at all -- in competition with the instructions for one allowance.
+#   * Nothing checked reachability. The spec says "Keep file references one
+#     level deep from SKILL.md. Avoid deeply nested reference chains", because
+#     a file reachable only through a second hop sits behind an unmarked door.
+#
+# Fixtures lack composer.json and README, so the validator exits non-zero
+# regardless; every assertion reads the OUTPUT, never the exit status.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VALIDATOR="$ROOT/skills/skill-repo/scripts/validate-skill.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+
+# says <dir> <regex> -> "yes"/"no"; strips colour so patterns match plain text.
+says() {
+    local out
+    out="$(bash "$VALIDATOR" "$1" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+    if grep -qE "$2" <<<"$out"; then printf 'yes\n'; else printf 'no\n'; fi
+}
+
+check() { # check <label> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL $1: expected '$2', got '$3'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# skill <name> <desc> <body-lines> [extra frontmatter line] -> dir
+skill() {
+    local sname="$1" desc="$2" lines="$3" extra="${4:-}" dir
+    dir="$(mktemp -d "$TMP/fx.XXXXXX")"
+    mkdir -p "$dir/skills/$sname"
+    {
+        printf -- '---\n'
+        printf 'name: %s\n' "$sname"
+        printf 'description: "%s"\n' "$desc"
+        [[ -n "$extra" ]] && printf '%s\n' "$extra"
+        printf -- '---\n'
+        python3 -c "print('\n'.join('line %d' % i for i in range(1, $lines + 1)))"
+    } > "$dir/skills/$sname/SKILL.md"
+    printf '%s' "$dir"
+}
+
+long_desc() { python3 -c "print('Use when ' + 'x' * ($1 - 9))"; }
+
+echo "== description budget =="
+d=$(skill demo "$(long_desc 1100)" 5)
+check "over 1024 is an error"   yes "$(says "$d" 'ERROR.*description is 1[0-9]+ chars \(spec hard limit 1024\)')"
+d=$(skill demo "$(long_desc 700)" 5)
+check "501-1024 warns"          yes "$(says "$d" 'WARNING.*description is 7[0-9][0-9] chars')"
+check "501-1024 is no error"    no  "$(says "$d" 'ERROR.*description is')"
+d=$(skill demo "Use when demoing" 5)
+check "under 500 is accepted"   yes "$(says "$d" 'OK.*description is [0-9]+ chars')"
+
+echo "== spec name rules the character class alone does not catch =="
+d=$(skill demo "Use when demoing" 5); mv "$d/skills/demo" "$d/skills/de--mo"
+python3 -c "
+import re,io
+p='$d/skills/de--mo/SKILL.md'
+s=open(p).read().replace('name: demo','name: de--mo')
+open(p,'w').write(s)"
+check "consecutive hyphens rejected" yes "$(says "$d" 'ERROR.*must not contain consecutive hyphens')"
+
+echo "== compatibility cap =="
+d=$(skill demo "Use when demoing" 5 "compatibility: \"$(python3 -c 'print("x"*600)')\"")
+check "over 500 chars is an error" yes "$(says "$d" 'ERROR.*compatibility is 6[0-9][0-9] chars \(spec max 500\)')"
+
+echo "== body size in LINES, not words =="
+# 520 words on a handful of lines must NOT trip the budget any more.
+d=$(mktemp -d "$TMP/fx.XXXXXX"); mkdir -p "$d/skills/demo"
+{ printf -- '---\nname: demo\ndescription: "Use when demoing"\n---\n'
+  python3 -c "print(' '.join('word' for _ in range(520)))"; } > "$d/skills/demo/SKILL.md"
+check "520 words on 2 lines is fine" yes "$(says "$d" 'OK.*body is [0-9]+ lines')"
+check "no word-count verdict at all" no  "$(says "$d" 'is [0-9]+ words')"
+
+d=$(skill demo "Use when demoing" 520)
+check "over 500 lines is an error"  yes "$(says "$d" 'ERROR.*body is 52[0-9] lines \(spec recommends under 500\)')"
+d=$(skill demo "Use when demoing" 350)
+check "301-500 lines warns"         yes "$(says "$d" 'WARNING.*body is 35[0-9] lines')"
+check "301-500 lines is no error"   no  "$(says "$d" 'ERROR.*body is')"
+
+echo "== flat discovery =="
+d=$(mktemp -d "$TMP/fx.XXXXXX"); S="$d/skills/demo"
+mkdir -p "$S/references" "$S/scripts"
+printf -- '---\nname: demo\ndescription: "Use when demoing"\n---\n\n# demo\n\nSee references/known.md and run scripts/named.sh\n' > "$S/SKILL.md"
+printf '# known\n\nDetail lives in references/hidden.md\n' > "$S/references/known.md"
+printf '# hidden\n' > "$S/references/hidden.md"
+printf '# orphan\n' > "$S/references/orphan.md"
+printf '#!/bin/sh\n' > "$S/scripts/named.sh";  chmod +x "$S/scripts/named.sh"
+printf '#!/bin/sh\n' > "$S/scripts/lonely.sh"; chmod +x "$S/scripts/lonely.sh"
+printf '# sourced, not run\n' > "$S/scripts/lib-common.sh"   # deliberately NOT executable
+
+check "second-hop reference warns, naming both" yes \
+    "$(says "$d" 'WARNING.*references/hidden.md is reachable only via references/known.md')"
+check "unreferenced reference warns"            yes \
+    "$(says "$d" 'WARNING.*references/orphan.md is not named in SKILL.md')"
+check "unnamed executable warns"                yes \
+    "$(says "$d" 'WARNING.*script\(s\) not named in SKILL.md:.*lonely\.sh')"
+# The exemption that keeps the warning honest: a sourced library is not a
+# capability the agent invokes, so demanding it in the control plane is noise.
+check "non-executable library is exempt"        no  "$(says "$d" 'not named in SKILL.md:.*lib-common\.sh')"
+check "a named script is not flagged"           no  "$(says "$d" 'not named in SKILL.md:.*named\.sh')"
+
+echo "== Contents section on long references =="
+d=$(mktemp -d "$TMP/fx.XXXXXX"); S="$d/skills/demo"; mkdir -p "$S/references"
+printf -- '---\nname: demo\ndescription: "Use when demoing"\n---\n\n# demo\n\nSee references/big.md and references/toc.md\n' > "$S/SKILL.md"
+python3 -c "open('$S/references/big.md','w').write('# big\n' + '\n'.join('l%d' % i for i in range(150)))"
+python3 -c "open('$S/references/toc.md','w').write('# toc\n\n## Contents\n\n- a\n\n' + '\n'.join('l%d' % i for i in range(150)))"
+check "long reference without Contents warns" yes "$(says "$d" 'WARNING.*references/big.md is 1[0-9][0-9] lines with no Contents')"
+check "long reference with Contents is fine"  no  "$(says "$d" 'references/toc.md is [0-9]+ lines with no Contents')"
+
+echo "== this repository obeys its own rules =="
+out="$(bash "$VALIDATOR" "$ROOT" 2>&1 | sed 's/\x1b\[[0-9;]*m//g')"
+arch_warn="$(grep -cE 'WARNING.*(not named in SKILL.md|reachable only via|with no Contents)' <<<"$out")"
+check "no architecture warnings on this repo" "0" "$arch_warn"
+
+echo "----------------------------------------"
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || { echo "Architecture tests FAILED"; exit 1; }
+echo "All architecture tests passed"

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -146,10 +146,15 @@ rm -rf "$multi"
 mkdir -p "$multi/skills/aaa-good" "$multi/skills/zzz-broken" "$multi/skills/zzz-long"
 printf '%b' "${hdr}description: Use when doing X\n---\n# Good\n" > "$multi/skills/aaa-good/SKILL.md"
 printf '%b' "${hdr}description: 'Helps with X'\n---\n# Broken\n" > "$multi/skills/zzz-broken/SKILL.md"
-# Over the 500-word cap, in a skill that is not the first alphabetically.
+# Over the 500-LINE cap, in a skill that is not the first alphabetically.
+# Was 520 words on one line until the budget was corrected: the spec says
+# "Keep your main SKILL.md under 500 lines", and a word count over the whole
+# file is a different, much tighter rule that also charged the frontmatter to
+# the body. The point of this fixture is unchanged -- a violation in a LATER
+# skill must still be reported -- only the metric it violates.
 {
     printf '%b' "${hdr}description: Use when doing Y\n---\n# Long\n"
-    for _ in $(seq 1 520); do printf 'word '; done
+    for _ in $(seq 1 520); do printf 'line\n'; done
 } > "$multi/skills/zzz-long/SKILL.md"
 multi_out="$(run_validator fallback "$multi")"
 
@@ -157,8 +162,8 @@ if grep -qF "skills/aaa-good/SKILL.md description starts with 'Use when'" <<<"$m
     echo "  FAIL [multi] first skill not validated"; ((FAIL++)); fi
 if grep -qF "skills/zzz-broken/SKILL.md description must start with 'Use when'" <<<"$multi_out"; then ((PASS++)); else
     echo "  FAIL [multi] a later skill's bad description was not reported"; ((FAIL++)); fi
-if grep -qE "skills/zzz-long/SKILL.md is [0-9]+ words \(max 500\)" <<<"$multi_out"; then ((PASS++)); else
-    echo "  FAIL [multi] a later skill's word count was not reported"; ((FAIL++)); fi
+if grep -qE "skills/zzz-long/SKILL.md body is [0-9]+ lines \(spec recommends under 500\)" <<<"$multi_out"; then ((PASS++)); else
+    echo "  FAIL [multi] a later skill's body size was not reported"; ((FAIL++)); fi
 # Discovery itself, independent of any single verdict: all three are reported.
 # (Not asserted on the exit code — these fixtures lack composer.json and README,
 # so the run exits non-zero either way and the assertion could not fail.)


### PR DESCRIPTION
Enshrines the Agent Skills architecture rules as the base for every skill repo: **flat discovery, small routing metadata, small control plane, details on demand.**

## What was wrong

**The size budget measured the wrong thing.** The check counted **500 words over the whole file**. The spec says *"Keep your main `SKILL.md` under 500 lines"* — words are a different and far tighter constraint, and counting the frontmatter charged the `description` to the body's allowance. That trade is always the wrong way round: the description is the only surface loaded at startup, so it decides whether the skill is ever activated. It has already cost real capabilities — a consuming repo sat at **499 of 500** and left a script out of its `SKILL.md` rather than spend fourteen words naming it.

**Nothing checked reachability at all.** The spec is explicit: *"Keep file references one level deep from `SKILL.md`. Avoid deeply nested reference chains."*

## Budgets now enforced, all from the spec

| Check | Level | Source |
|---|---|---|
| `description` > 1024 chars | ERROR | spec hard limit |
| `description` > 500 chars | WARN | guidance: "a few sentences to a short paragraph" |
| `name` with leading/trailing or doubled hyphen | ERROR | spec — the character class alone accepted all three |
| `compatibility` > 500 chars | ERROR | spec |
| body > 500 lines | ERROR | spec recommendation |
| body > 300 lines | WARN | ask what is control flow and what is reference material |

On the 500-character warning: it is a **nudge, not a defect**. The same guidance says to *"err on the side of being pushy"* about listing contexts, so long is not automatically wrong — long **and** narrating a workflow is. A description carrying a condensed workflow invites the agent to follow *that summary* instead of activating the skill and reading the real instructions.

## Flat discovery, now linted

Each hop is a decision the agent may not make. `SKILL.md` is read in full on activation; a reference is read only if `SKILL.md` said what it holds and when to open it. A file reachable only through a second hop sits behind a door with no sign on it.

Warnings, not errors — a chain is a smell, not a breach:

- a `references/*.md` reachable only through another reference, **naming both** so the fix is obvious
- a `references/*.md` nothing names at all
- a reference over 100 lines with no `## Contents` — agents preview long files rather than reading them whole
- an **executable** under `scripts/` that `SKILL.md` never names

Non-executable files under `scripts/` are exempt from the last one: a sourced library is not a capability the agent invokes, and its caller is what belongs in the control plane.

## Deliberately not linted

Whether a description narrates a workflow, whether a verification step exists, whether an optional frontmatter field has a consumer. No mechanical check decides those honestly, and a rule that guesses is worse than a review question. `references/skill-architecture.md` says so explicitly rather than leaving the omission to be rediscovered.

## The reference

`references/skill-architecture.md` records the whole thing with sources: the three surfaces and when each enters context, every budget and where its number comes from, the flat-discovery rule with worked good/bad layouts (including why an index file that only points at scripts should be deleted rather than kept), what belongs in `SKILL.md` versus `references/` versus `scripts/`, and the trigger-eval method — 20 queries, **near-miss** negatives, 3 runs each, train/validation split — which settles description arguments better than counting characters ever will.

It closes on a caution worth keeping: public skill repositories are **data, not best practice**. "Other people do it this way" carries no weight here.

## This repository broke four of its own new rules

Fixed in the same PR, because a linter that leaves nine warnings on its own repo is a claim rather than a rule:

- eight references over 100 lines gained a `## Contents`
- seven executables in `scripts/` are now named in `SKILL.md`
- the budget line in `SKILL.md` itself quoted the wrong numbers (`≤500 words`, `≤1,536 chars`)
- `SKILL.md` is now **0 errors, 0 warnings** under the new rules

## One change that was necessary to land this at all

The repository pinned **its own validator** through pre-commit at `v1.22.0`, so the gate on every commit was the last release rather than the working copy. Two consequences: a change to the validator could never be exercised before it shipped, and a `SKILL.md` written against the corrected budgets was rejected by the obsolete ones — with no way out but weakening the content or bypassing the gate, and `main` would have gone red after merge either way.

`validate-skill` now runs as a `repo: local` hook against the working copy. `check-version-parity` stays pinned; it is not authored against itself.

## Tests

`tests/validate-skill-architecture.sh` — 19 assertions, **13 of which fail against the previous validator**. Covers each budget at its boundary, both spec name rules, the second-hop chain, the orphan reference, the missing `## Contents`, the unnamed executable, and the library exemption that keeps that last warning honest.

The existing smoke test's multi-skill fixture moves from 520 words to 520 lines — same intent (*a violation in a later skill must still be reported*), only the metric it violates. All 10 files in `tests/` pass; `shellcheck` clean; the CI shell glob is `tests/**/*.sh`, so the new file is picked up without a workflow change.

## A bug found while wiring this up

Worth naming because it is silent: in one draft the `skill_dir` assignment sat **above** its `local` declaration, so `local` reset it, `set -u` aborted the run mid-way, and **no summary printed at all** — which reads exactly like a repository that passed.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_
