### PR TITLE
chore(release): v1.36.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "skill-repo",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "1.35.0"
+  version: "1.36.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Version bump only — `plugin.json`, `.claude-plugin/plugin.json`, `skills/skill-repo/SKILL.md`, written by `scripts/bump-version.sh 1.36.0 --apply`. No other change.

**44 commits since `v1.35.0`** (2026-08-17), from several sessions. No `BREAKING CHANGE` markers and no `!` types; 13 `feat` commits, so a minor.

## What consumers will notice

The skill architecture gate (#250). `validate-skill.sh` now measures the budgets the Agent Skills specification actually states:

| Check | Level | Was |
|---|---|---|
| `description` > 1024 chars | ERROR | unchecked |
| `description` > 500 chars | WARN | unchecked |
| `name` with leading, trailing or doubled hyphen | ERROR | accepted by the character class |
| `compatibility` > 500 chars | ERROR | unchecked |
| `SKILL.md` body > 500 **lines** | ERROR | 500 **words** over the whole file |
| `SKILL.md` body > 300 lines | WARN | — |

**The verdict can move in both directions**, so it is worth a look after upgrading: a repo that failed the word count may now pass, and a repo with an over-long description, a doubled hyphen in its name, or a body past 500 lines now fails where it did not.

The word budget was a mis-transcription of *"Keep your main `SKILL.md` under 500 lines"*. Words are a far tighter and differently shaped constraint, and counting the whole file charged the frontmatter to the body — putting the `description`, the one surface that decides whether a skill is used at all, in competition with the instructions it routes to. This repository sat at 499 of 500 for that reason and left a script undocumented rather than spend fourteen words on it.

New **warnings** for flat discovery, from *"Keep file references one level deep from `SKILL.md`. Avoid deeply nested reference chains"*: a `references/*.md` reachable only through another reference, a reference nothing names, a reference over 100 lines with no `## Contents`, and an executable under `scripts/` that `SKILL.md` never names. Non-executable files are exempt — a sourced library is not a capability the agent invokes.

`references/skill-architecture.md` records the reasoning with sources: the three surfaces and when each enters context, every budget and where its number comes from, worked good and bad layouts, and the trigger-eval method that settles description arguments better than counting characters.

## Also in this range

- shellcheck pinned to the version the pre-commit hook pins, fetched over a checked scheme with a SHA256 (`65f90ed`, `d23a978`, #249)
- apt and every reusable job bounded so a stall cannot hold a runner (#247)
- PHP test entrypoints actually run, not only shell and Python (#244)
- every `evals.json` validated rather than the first one found (#243)
- A/B evals decided by majority over repeated samples, and each delta bound to the actor that produced it (#237, #229)
- four coverage gaps closed in the shared validation stack (#241)

## Release checks

`validate-skill.sh`: 0 errors, 0 warnings. All 10 files in `tests/` pass. `check-version-parity.sh v1.36.0`: OK. Pre-commit clean.

Tag follows once this is merged, per `references/release-discipline.md` — tagging first releases the old code.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01MNg1MysJVugv1xo2husknU)_