### PR TITLE
fix(renovate): enable the pre-commit manager the config comment promises

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         files: (^skills/.+/SKILL\.md$|^SKILL\.md$|^skills/.+/checkpoints\.yaml$|^checkpoints\.yaml$|^\.claude-plugin/plugin\.json$|^composer\.json$)
         require_serial: true
   - repo: https://github.com/netresearch/skill-repo-skill
-    rev: v1.22.0
+    rev: v1.36.0
     hooks:
       - id: check-version-parity
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "config:recommended"
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Part of #252 — the source half.

The `.pre-commit-config.yaml` header (copied into every consumer repo) promises that Renovate bumps the pinned hook revs automatically. It does not: Renovate's `pre-commit` manager is opt-in and no repo opts in. Today's fleet survey: **27 of 29 consumers pinned at v1.22.0/v1.21.1** — this repo included, pinning *itself* at v1.22.0 — while CI validates against `main`; two repos were bitten the same day by the withdrawn 500-word cap the stale copy still enforces.

This PR enables the manager here and bumps the self-pin to v1.36.0, making the header's promise true for this repo. The 28 consumer repos get the same two-line change in a fleet sweep (in progress; the three repos without a `renovate.json` get the standard one with the manager enabled).

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01C7S9rbgu5giqCwnzwafrHA)_