### PR TITLE
chore(fleet): refresh the GitHub fleet list to the 2026-08-27 org state

### DIFF
--- a/skills/skill-repo/scripts/fleet-repos-github.txt
+++ b/skills/skill-repo/scripts/fleet-repos-github.txt
@@ -1,7 +1,7 @@
 # Default repo list for fleet-release-github.sh survey (--repos/--repos-file
 # override it). One repo per line, org-relative; '#' and blank lines ignored.
 #
-# Snapshot of the public GitHub skill fleet as of the 2026-08-13 sweep.
+# Snapshot of the public GitHub skill fleet as of the 2026-08-27 sweep.
 # Naming conventions do NOT enumerate this fleet (plugins and oddly-named
 # repos exist), so the list is maintained here — reviewable, and cheap to
 # refresh:
@@ -11,9 +11,7 @@
 # here becomes a DUPLICATE row, never a second bump PR.
 agent-harness-skill
 agent-rules-skill
-agents-skill
 automated-assessment-skill
-claude-coach-skill
 cli-tools-skill
 concourse-ci-skill
 context7-skill
@@ -32,8 +30,8 @@ markdown-to-pdf-skill
 matrix-skill
 netresearch-branding-skill
 orocommerce-skill
-pagerangers-skill
 peer-qa-review-skill
+php-ast-edit-skill
 php-modernization-skill
 retro-skill
 security-audit-skill


### PR DESCRIPTION
The 2026-08-27 sweep surveyed against a corrected copy of this list: php-ast-edit-skill is live but missing (it released v0.1.0 today), while agents-skill (rename redirect to agent-rules-skill), claude-coach-skill and pagerangers-skill no longer appear in the no-archived org listing. The two composer-*-plugin repos stay excluded as before — they are composer plugins, not skill repos.