### PR TITLE
feat(fleet-release): surface an empty CHANGELOG [Unreleased] in the manifest

### DIFF
--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -25,7 +25,7 @@
 # Normalized survey row schema (both hosts emit exactly these keys):
 #   host repo resolved default archived empty unreachable duplicate_of
 #   last_release last_tag root_plugin claude_plugin composer_has_version
-#   release_gate ci_status ahead nonci files_truncated subjects files
+#   release_gate ci_status ahead nonci changelog_unreleased files_truncated subjects files
 #   open_release_prs [{id,url,author,branch,title}] ci_tag_rules notes
 #
 # Every phase writes into $FR_WORKDIR:
@@ -82,6 +82,23 @@ fr_tool() { # NAME — locate a skill-repo tool (bump-version.sh, roll-changelog
 
 fr_note() { printf '%s\n' "$*"; }
 fr_err()  { printf 'ERROR: %s\n' "$*" >&2; }
+
+fr_changelog_state() { # RAW-CONTENT — "absent" | "empty" | "has-content" |
+    # "no-unreleased" | "unknown". An empty argument means the survey found no
+    # CHANGELOG.md. Classification is delegated to roll-changelog.py
+    # --check-unreleased so the survey warns by the SAME emptiness rule the
+    # bump-time roll enforces — five repos failed mid-bump on empty
+    # [Unreleased] sections in the 2026-08-27 sweep, each one visible to the
+    # survey that ran hours earlier.
+    local raw="$1" tool tmp state
+    [[ -n "$raw" ]] || { echo "absent"; return 0; }
+    tool=$(fr_tool roll-changelog.py 2> /dev/null) || { echo "unknown"; return 0; }
+    tmp=$(mktemp "${TMPDIR:-/tmp}/fr-clstate.XXXXXX") || { echo "unknown"; return 0; }
+    printf '%s\n' "$raw" > "$tmp"
+    state=$(python3 "$tool" --check-unreleased "$tmp" 2> /dev/null) || state="unknown"
+    rm -f "$tmp"
+    echo "${state:-unknown}"
+}
 fr_die()  { fr_err "$*"; exit 1; }
 
 # ---------------------------------------------------------------------------
@@ -425,8 +442,8 @@ fr_manifest() {
         echo "Approval covers ONLY the PRs this sweep opens. Rows marked"
         echo "BLOCKED-FOREIGN-PR need that author's separate go-ahead."
         echo
-        echo "| Repo | Class | Last tag | Release | plugin.json | Ahead | Non-CI | CI on default | Notes |"
-        echo "|---|---|---|---|---|---|---|---|---|"
+        echo "| Repo | Class | Last tag | Release | plugin.json | Ahead | Non-CI | Changelog | CI on default | Notes |"
+        echo "|---|---|---|---|---|---|---|---|---|---|"
     } > "$manifest"
     while IFS= read -u 3 -r row; do
         cls=$(fr_classify "$row")
@@ -439,6 +456,7 @@ fr_manifest() {
               (.claude_plugin | ordash),
               ((.ahead // "") | tostring | ordash),
               ((.nonci // "") | tostring | ordash),
+              ((.changelog_unreleased // "") | if . == "empty" then "EMPTY" else ordash end),
               (.ci_status | ordash),
               ([ (if (.open_release_prs // []) | length > 0
                   then "PRs: " + ([.open_release_prs[] | "\(.url) by @\(.author)"] | join("; "))
@@ -454,6 +472,9 @@ fr_manifest() {
                   else empty end),
                  (if $cls == "BLOCKED-ARCHIVED"
                   then "unarchive is a human decision; afterwards re-run survey --repos \(.repo)"
+                  else empty end),
+                 (if $cls == "BUMP" and (.changelog_unreleased // "") == "empty"
+                  then "CHANGELOG [Unreleased] is empty — write the release entries before the bump phase, or its roll fails on exactly this"
                   else empty end),
                  (if $cls == "SURVEY-INCOMPLETE"
                   then "the compare MEASUREMENT failed (this is not a no-delta result) — re-run survey --repos \(.repo)"

--- a/skills/skill-repo/scripts/fleet-release-github.sh
+++ b/skills/skill-repo/scripts/fleet-release-github.sh
@@ -109,6 +109,13 @@ host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
         release_gate=false
     fi
 
+    # Unreleased-section state, by the same rule the bump-time roll enforces —
+    # an empty section becomes a manifest warning instead of a mid-bump failure.
+    local cl_raw cl_state
+    cl_raw=$(gh_json -H "Accept: application/vnd.github.raw" \
+        "repos/$FR_ORG/$r/contents/CHANGELOG.md?ref=$def" || echo "")
+    cl_state=$(fr_changelog_state "$cl_raw")
+
     # Measured CI state of the default branch — the manifest's precondition
     # column must show a value, never an assumed checkmark.
     local ci_status
@@ -168,12 +175,14 @@ host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
         --arg ci "$ci_status" --argjson ahead "$ahead" --argjson nonci "$nonci" \
         --argjson subjects "$subjects" --argjson files "$files" \
         --argjson trunc "$files_truncated" --argjson prs "$prs" \
+        --arg clstate "$cl_state" \
         '{host: $host, repo: $repo, resolved: $resolved, default: $def, head: $head,
           archived: $archived, empty: false, unreachable: false, duplicate_of: "",
           last_release: $rel, last_tag: $last_tag,
           root_plugin: $rootv, claude_plugin: $cpv,
           composer_has_version: $chv, release_gate: $gate, ci_status: $ci,
           ahead: $ahead, nonci: $nonci, files_truncated: $trunc,
+          changelog_unreleased: $clstate,
           subjects: $subjects, files: $files,
           open_release_prs: $prs, ci_tag_rules: "", notes: ""}'
 }

--- a/skills/skill-repo/scripts/roll-changelog.py
+++ b/skills/skill-repo/scripts/roll-changelog.py
@@ -107,7 +107,11 @@ def parse_args():
         description="Roll the [Unreleased] CHANGELOG section into a release."
     )
     parser.add_argument("file", help="path to CHANGELOG.md")
-    parser.add_argument("version", help="release version (leading v stripped)")
+    parser.add_argument(
+        "version",
+        nargs="?",
+        help="release version (leading v stripped); not needed with --check-unreleased",
+    )
     parser.add_argument(
         "--date",
         default=datetime.datetime.now(datetime.timezone.utc)
@@ -121,7 +125,19 @@ def parse_args():
         action="store_true",
         help="print the new heading and moved-section size, write nothing",
     )
+    parser.add_argument(
+        "--check-unreleased",
+        action="store_true",
+        help="report the Unreleased section's state (no-unreleased | empty | "
+        "has-content) with the SAME emptiness rule the roll enforces, write "
+        "nothing; surveys use this so an empty section surfaces before the "
+        "bump fails on it",
+    )
     args = parser.parse_args()
+    if args.check_unreleased:
+        return args
+    if args.version is None:
+        fail("version is required (only --check-unreleased goes without one)")
     args.version = args.version.lstrip("v")
     if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", args.version):
         fail(f"'{args.version}' is not a semantic version")
@@ -203,8 +219,39 @@ def write_atomic(path, out):
         fail(str(exc))
 
 
+def unreleased_state(lines):
+    """One of 'no-unreleased' | 'empty' | 'has-content', by the same section
+    boundaries and comments-are-not-content rule the roll itself enforces."""
+    unreleased_at = []
+    heading_at = []
+    for i, line, in_fence in scan(lines):
+        if in_fence:
+            continue
+        if UNRELEASED_RE.match(line):
+            unreleased_at.append(i)
+        elif line.startswith("## "):
+            heading_at.append(i)
+    if not unreleased_at:
+        return "no-unreleased"
+    if len(unreleased_at) > 1:
+        fail(
+            f"{len(unreleased_at)} Unreleased headings outside code fences "
+            f"(need exactly 1)"
+        )
+    idx = unreleased_at[0]
+    end = next((h for h in heading_at if h > idx), len(lines))
+    section = "\n".join(lines[idx + 1 : end])
+    if re.sub(r"<!--.*?-->", "", section, flags=re.DOTALL).strip():
+        return "has-content"
+    return "empty"
+
+
 def main() -> None:
     args = parse_args()
+    if args.check_unreleased:
+        lines, _eol, _tn = read_changelog(args.file)
+        print(unreleased_state(lines))
+        return
     version = args.version
     lines, eol, trailing_newline = read_changelog(args.file)
     idx, first_released = locate_headings(lines)

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -354,6 +354,7 @@ if command -v gh > /dev/null 2>&1; then
         row '.repo = "own-pr" | .resolved = "o/own-pr" | .open_release_prs = [{"id":"8","url":"https://example.invalid/8","author":"sweep-bot","branch":"release/v2.5.0","title":"chore(release): v2.5.0"}]'
         row '.repo = "blipped" | .resolved = "o/blipped" | .ahead = -1 | .nonci = -1'
         row '.repo = "ruled" | .resolved = "o/ruled" | .ci_tag_rules = "12: rules | if CI_COMMIT_TAG;30:release_job:"'
+        row '.repo = "cl-empty" | .resolved = "o/cl-empty" | .changelog_unreleased = "empty"'
     } > "$MWD/survey.jsonl"
     out=$(FR_SELF_LOGIN=sweep-bot bash "$SCRIPTS/fleet-release-github.sh" manifest --workdir "$MWD" 2>&1)
     check "manifest: runs offline on a fixture survey" yes \
@@ -366,6 +367,10 @@ if command -v gh > /dev/null 2>&1; then
         "$(grep -q '| ci-only | SKIP-CI-ONLY |' "$MWD/manifest.md" && echo yes || echo no)"
     check "manifest: foreign PR blocked with author named" yes \
         "$(grep -q '| foreign | BLOCKED-FOREIGN-PR |.*@colleague' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: empty Unreleased flagged in column and note" yes \
+        "$(grep -q '| cl-empty | BUMP |.*| EMPTY |.*write the release entries before the bump' "$MWD/manifest.md" && echo yes || echo no)"
+    check "manifest: rows without the changelog field render a dash" yes \
+        "$(grep -qE '\| bump-me \| BUMP \|.*\| — \| success \|' "$MWD/manifest.md" && echo yes || echo no)"
     check "manifest: skeleton prefills TAG-ONLY version" 1.10.0 \
         "$(jq -r 'select(.repo == "prepared") | .version' "$MWD/plan.skeleton.jsonl")"
     # Assert the row EXISTS before asserting its emptiness — an absent row also

--- a/tests/roll-changelog.sh
+++ b/tests/roll-changelog.sh
@@ -241,6 +241,29 @@ before=$(cat "$f")
 check "dry run exits 0" 0 "$(roll "$f" 1.1.0 --dry-run)"
 check "dry run leaves the file untouched" "$before" "$(cat "$f")"
 
+# --- --check-unreleased ------------------------------------------------------
+f="$WORK/chk.md"
+printf '# C\n\n## [Unreleased]\n\n- pending\n\n## [1.0.0] - 2026-01-01\n\n- b\n' > "$f"
+check "check-unreleased: content exits 0" 0 "$(roll "$f" --check-unreleased)"
+check "check-unreleased: content reported" has-content "$(cat "$WORK/out.txt")"
+check "check-unreleased: file untouched" yes \
+    "$(grep -q '^- pending$' "$f" && echo yes)"
+
+printf '# C\n\n## [Unreleased]\n\n<!-- only a comment -->\n\n## [1.0.0] - 2026-01-01\n\n- b\n' > "$f"
+check "check-unreleased: comment-only is empty (same rule as the roll)" empty \
+    "$(roll "$f" --check-unreleased > /dev/null; cat "$WORK/out.txt")"
+
+printf '# C\n\n## [1.0.0] - 2026-01-01\n\n- b\n' > "$f"
+check "check-unreleased: no Unreleased heading" no-unreleased \
+    "$(roll "$f" --check-unreleased > /dev/null; cat "$WORK/out.txt")"
+
+# shellcheck disable=SC2016  # the backticks are a literal markdown fence
+printf '# C\n\n## [Unreleased]\n\n```\n## [Unreleased]\n```\n\n## [1.0.0] - 2026-01-01\n' > "$f"
+check "check-unreleased: fenced lookalike is no heading; fence body counts as content" has-content \
+    "$(roll "$f" --check-unreleased > /dev/null; cat "$WORK/out.txt")"
+
+check "no version without --check-unreleased still refused" 1 "$(roll "$f")"
+
 echo
 if [ "$fail" -eq 0 ]; then
     echo "All roll-changelog tests passed"


### PR DESCRIPTION
Retro P4 from the 2026-08-27 sweep, where five repos failed mid-bump on an empty [Unreleased] section that the survey had seen hours earlier.

roll-changelog.py gains --check-unreleased (no-unreleased / empty / has-content), deliberately delegating to the same section boundaries and comments-are-not-content rule the roll itself enforces — no drift between the warning and the failure. The engine gains fr_changelog_state and a Changelog manifest column plus a BUMP-row note; the GitHub driver fetches CHANGELOG.md at the surveyed tip. Rows from older surveys without the field render a dash.

Tests: 5 new cases in tests/roll-changelog.sh (content, comment-only-is-empty, no-heading, fenced-lookalike bounds, version-still-required) and 2 in tests/fleet-release.sh (EMPTY column + note on a BUMP row; dash for rows without the field) — full suites green (97 + 26 checks).

Follow-up after merge: the GitLab arm (coding-ai/gitlab-skill) vendors this engine and its driver needs the same one-field survey addition; the manifest change is backward-compatible either way.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_019wx8ueHuqUidp5yybDQ2CN)_