### PR TITLE
fix(fleet-release): retry the bump commit once when a hook rewrites it

### DIFF
--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -6,6 +6,7 @@
 - Canonical Order: Bump PR Merged → Tag Pushed
 - Pre-Release Version-Parity Check
 - Changelog Rollover in the Bump Commit
+- A reformatting hook aborts the first bump commit
 - Cache Safety: Never Edit the Installed Copy
 - Multi-Skill-Repo Release Dry-Run
 - GitLab (`git.netresearch.de`) skill repos release on tag too
@@ -144,6 +145,29 @@ the roll is generated text, and generated text is exactly what nobody proofreads
 Boundary regexes are also **fence-blind** — a scan anchored on `^##` matches a
 heading-looking line inside a fenced code block and splices the new section into
 the middle of an example. Track fences while scanning.
+
+## A reformatting hook aborts the first bump commit
+
+A hook that rewrites a file it is checking — `pretty-format-json --autofix`,
+`black`, `ruff format`, `end-of-file-fixer` — modifies the staged tree and then
+*fails* the commit; re-staging its output and committing again is the remedy,
+and the second run passes because the file is already in the shape the hook
+wants. `fr_commit_allowlisted` therefore makes two attempts, and the log shows
+both (`COMMIT EXIT (1): 1`, `COMMIT EXIT (2): 0`). The retry re-walks the
+porcelain rather than re-adding the first pass's paths, so a hook that writes
+*outside* the version surfaces still fails the allowlist on the second pass.
+
+Before that retry existed, such a repo left the `bump` phase as
+`FAIL <repo>: commit` with a half-written worktree the resume then refused as
+dirty, and the operator had to commit by hand and re-run — `it-maintenance-skill`
+v1.15.0 and `netresearch-jira-skill` v2.11.1 both did on 2026-08-28 (#263).
+Their trigger is worth knowing because it recurs: `sync-plugin-manifest.sh`
+emits `.claude-plugin/plugin.json` in the source manifest's key order and
+`pretty-format-json` sorts the keys, so the two rewrite each other on every
+bump. Sorting the generator's output would settle that one pairing and no
+other — the same hook also escapes non-ASCII, which the fleet's descriptions
+are full of — so the retry, which is blind to *what* the hook changed, is the
+fix rather than agreeing with one formatter.
 
 ## Cache Safety: Never Edit the Installed Copy
 

--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -759,13 +759,12 @@ fr_lint_changelog() { # WT — the roll is generated text and generated text is
     fi
 }
 
-fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces may
-    # move; -z parsing (paths with spaces exist in the fleet), no add -A ever
-    local repo="$1" wt="$2" version="$3"
+fr_stage_allowlisted() { # REPO WT — stage every pending path, refusing anything
+    # outside the version surfaces; -z parsing (paths with spaces exist in the
+    # fleet), no add -A ever
+    local repo="$1" wt="$2"
     local entry status path
     local paths=()
-    echo "--- porcelain:"
-    git -C "$wt" status --porcelain
     while IFS= read -r -d '' entry; do
         [[ -n "$entry" ]] || continue
         status="${entry:0:2}"
@@ -783,11 +782,41 @@ fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces m
         paths+=("$path")
     done < <(git -C "$wt" status --porcelain -z)
     [[ "${#paths[@]}" -gt 0 ]] || { echo "FAIL $repo: nothing to commit after bump"; return 1; }
-    ( cd "$wt" && git add -- "${paths[@]}" \
-        && git commit -S --signoff -m "${FR_COMMIT_PREFIX}${version}" )
-    local ec=$?
-    echo "COMMIT EXIT: $ec"   # bare exit code — a pipe here once hid a hook abort
-    [[ "$ec" -eq 0 ]] || { echo "FAIL $repo: commit"; return 1; }
+    git -C "$wt" add -- "${paths[@]}"
+}
+
+fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces may
+    # move. Two attempts: a reformatting hook (pre-commit's pretty-format-json
+    # --autofix, black, ruff format, …) rewrites a staged file and FAILS the
+    # commit, and re-staging its output is the documented remedy — without it
+    # a bump dies as "FAIL <repo>: commit" and leaves a half-written worktree
+    # the resume then refuses as dirty (#263: it-maintenance-skill v1.15.0 and
+    # netresearch-jira-skill v2.11.1 in the 2026-08-28 sweep, where the hook
+    # sorts the keys sync-plugin-manifest.sh emits unsorted). The retry re-walks
+    # the porcelain instead of re-adding the first attempt's paths, so a hook
+    # that writes OUTSIDE the version surfaces still fails the allowlist. A
+    # deterministic rejection fails the second attempt too and reports as before.
+    local repo="$1" wt="$2" version="$3"
+    local attempt ec
+    for attempt in 1 2; do
+        echo "--- porcelain (attempt $attempt):"
+        git -C "$wt" status --porcelain
+        fr_stage_allowlisted "$repo" "$wt" || return 1
+        ( cd "$wt" && git commit -S --signoff -m "${FR_COMMIT_PREFIX}${version}" )
+        ec=$?
+        echo "COMMIT EXIT ($attempt): $ec"   # bare exit code — a pipe here once hid a hook abort
+        if [[ "$ec" -eq 0 ]]; then
+            return 0
+        fi
+        # An `if`, not `cond && echo`: the latter is the loop body's last
+        # command and returns 1 on the second pass, which would make the
+        # function's own status depend on how the caller suppresses `set -e`.
+        if [[ "$attempt" -eq 1 ]]; then
+            echo "commit failed — retrying once, in case a hook rewrote a staged file"
+        fi
+    done
+    echo "FAIL $repo: commit"
+    return 1
 }
 
 fr_create_and_record() { # REPO BRANCH VERSION BODY TARGET

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -327,6 +327,69 @@ check "partial re-survey replaced the requested row" 2 \
 check "partial re-survey left the others at gen 1" "1 1" \
     "$(jq -r 'select(.repo != "beta") | .gen' "$FR_WORKDIR/survey.jsonl" | tr '\n' ' ' | sed 's/ $//')"
 
+# --- commit retry: a reformatting hook aborts the first commit (#263) --------
+# pre-commit's pretty-format-json --autofix (and black, ruff format, …) rewrites
+# a staged file and then FAILS the run. Without the retry the bump dies as
+# "FAIL <repo>: commit" and leaves a half-written worktree the resume refuses.
+# The retry must re-walk the porcelain, not re-add the first pass's paths, or a
+# hook that writes outside the version surfaces would ride in on the second try.
+SIGNKEY="$WORK/signing-key"
+ssh-keygen -q -t ed25519 -N '' -C fleet-test -f "$SIGNKEY" < /dev/null
+mk_commit_repo() { # DIR HOOK-SCRIPT
+    local d="$1" hook="$2"
+    git init -q -b main "$d"
+    mkdir -p "$d/.claude-plugin"
+    printf '{"name":"demo","version":"1.0.0"}\n' > "$d/plugin.json"
+    printf '{"name":"demo","version":"1.0.0"}\n' > "$d/.claude-plugin/plugin.json"
+    ( cd "$d" && git add -A && git commit -q -m base )
+    git -C "$d" config gpg.format ssh
+    git -C "$d" config user.signingkey "$SIGNKEY.pub"
+    printf '%s\n' "$hook" > "$d/.git/hooks/pre-commit"
+    chmod +x "$d/.git/hooks/pre-commit"
+    # the bump itself: both version surfaces move
+    printf '{"name":"demo","version":"1.1.0"}\n' > "$d/plugin.json"
+    printf '{"name":"demo","version":"1.1.0"}\n' > "$d/.claude-plugin/plugin.json"
+}
+# Fires once, rewrites a staged ALLOWLISTED file, fails — then passes, exactly
+# as an --autofix hook behaves on the re-run.
+REFORMAT_HOOK='#!/bin/sh
+[ -f .git/HOOK_FIRED ] && exit 0
+: > .git/HOOK_FIRED
+printf %s "{\n  \"name\": \"demo\",\n  \"version\": \"1.1.0\"\n}\n" > .claude-plugin/plugin.json
+exit 1'
+mk_commit_repo "$WORK/commit-reformat" "$REFORMAT_HOOK"
+out=$(fr_commit_allowlisted demo "$WORK/commit-reformat" 1.1.0 2>&1)
+check "commit: first attempt fails on the reformatting hook (the defect)" yes \
+    "$(grep -q 'COMMIT EXIT (1): [^0]' <<< "$out" && echo yes || echo no)"
+check "commit: retry re-stages the hook's output and commits" yes \
+    "$(grep -q 'COMMIT EXIT (2): 0' <<< "$out" && echo yes || echo no)"
+check "commit: the bump landed as one commit" "chore(release): v1.1.0" \
+    "$(git -C "$WORK/commit-reformat" log -1 --format=%s)"
+check "commit: nothing left in the worktree afterwards" "" \
+    "$(git -C "$WORK/commit-reformat" status --porcelain)"
+# The retry must NOT widen the allowlist: a hook that writes an unrelated file
+# still fails, on the second pass as on the first.
+FOREIGN_HOOK='#!/bin/sh
+[ -f .git/HOOK_FIRED ] && exit 0
+: > .git/HOOK_FIRED
+echo junk > NOTES.md
+exit 1'
+mk_commit_repo "$WORK/commit-foreign" "$FOREIGN_HOOK"
+out=$(fr_commit_allowlisted demo "$WORK/commit-foreign" 1.1.0 2>&1; echo "rc=$?")
+check "commit: a hook writing outside the version surfaces still FAILs" yes \
+    "$(grep -q 'unexpected change outside the version surfaces: NOTES.md' <<< "$out" && echo yes || echo no)"
+check "commit: that failure is reported to the caller" yes \
+    "$(grep -q 'rc=1' <<< "$out" && echo yes || echo no)"
+# A deterministic rejection is not a reformat — it must not become a retry loop.
+REJECT_HOOK='#!/bin/sh
+exit 1'
+mk_commit_repo "$WORK/commit-reject" "$REJECT_HOOK"
+out=$(fr_commit_allowlisted demo "$WORK/commit-reject" 1.1.0 2>&1; echo "rc=$?")
+check "commit: a hook that always rejects fails after exactly two attempts" yes \
+    "$([ "$(grep -c 'COMMIT EXIT' <<< "$out")" = 2 ] && echo yes || echo no)"
+check "commit: the permanent rejection is reported to the caller" yes \
+    "$(grep -q 'FAIL demo: commit' <<< "$out" && grep -q 'rc=1' <<< "$out" && echo yes || echo no)"
+
 # --- the shipped fleet list is non-empty and comment-clean -------------------
 n=$(grep -cvE '^\s*(#|$)' "$SCRIPTS/fleet-repos-github.txt")
 check "fleet-repos-github.txt ships a non-empty list" yes \


### PR DESCRIPTION
Fixes #263

A pre-commit hook that reformats a file it checks — `pretty-format-json --autofix`, `black`, `ruff format` — modifies the staged tree and then *fails* the commit. `fr_commit_allowlisted` treated that as final, so the repo left the `bump` phase as `FAIL <repo>: commit` with a half-written worktree that `fr_resume_worktree` then refuses as dirty; the operator had to commit by hand in the release worktree and re-run `bump` to get the PR opened. `it-maintenance-skill` v1.15.0 and `netresearch-jira-skill` v2.11.1 both went that way in the 2026-08-28 sweep.

The commit now makes two attempts and logs both (`COMMIT EXIT (1): 1`, `COMMIT EXIT (2): 0`). Staging moved into its own `fr_stage_allowlisted`, so the retry re-walks the porcelain rather than re-adding the first pass's paths — a hook that writes *outside* the version surfaces still fails the allowlist on the second pass, and a deterministic rejection still fails after exactly two attempts.

## Why not fix the generator instead

The issue offered sorting `sync-plugin-manifest.sh`'s output as the first option. It is neither necessary nor sufficient. `pretty-format-json` also escapes non-ASCII by default, and the fleet's manifest descriptions are full of em dashes and umlauts, so one edit to any hook-carrying repo's description reopens the same bounce; meanwhile the sort would reorder the generated manifest in every repo, hook or not, to avoid one hook re-run in the four that have it. Measured on the current fleet: four repos run `pretty-format-json` (`it-account-lifecycle`, `it-maintenance`, `it-offboarding`, `netresearch-jira`), all four ASCII-only today. The retry is blind to *what* the hook changed, which is the property the fix needs.

## Tests

`fr_commit_allowlisted` had no tests; these are the first, and each was observed to fail against the single-attempt engine (`for attempt in 1`):

- reformatting hook on an allowlisted file → attempt 1 fails, attempt 2 commits, worktree clean afterwards
- hook writing a non-allowlisted file → still `unexpected change outside the version surfaces`, still reported to the caller
- hook that always rejects → exactly two attempts, then `FAIL`

The fixture is a plain `.git/hooks/pre-commit` that rewrites a staged file and exits 1 once — what `--autofix` does — with an ed25519 key for the `-S` in the commit. All ten `tests/*.sh` pass, shellcheck is clean, and `references/release-discipline.md` gains the section with the two-attempt log shape.

## Follow-up

`fleet-release-gitlab.sh` in `coding-ai/gitlab-skill` runs a vendored copy of this engine, and that is where the failure actually fired. Re-vendoring is a separate MR on that repo once this lands.

Copilot review is out of quota for the month, so this merges on a documented `Self-review:` attestation.
