### PR TITLE
feat(validate): warn on skill-relative paths SKILL.md names that do not exist

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -52,7 +52,7 @@ description: "Use when <trigger conditions>"
 
 **Budgets** (spec): `name` ≤64, no doubled/edge hyphen, matches its directory. `description` ≤1024, warn past 500 — a router, not documentation. Body ≤500 lines, warn at 300. `compatibility` ≤500, usually omit.
 
-**Flat discovery**: references one level deep; SKILL.md names every `references/*.md` and every `scripts/` executable; `## Contents` past 100 lines. Rationale and trigger evals: [skill-architecture](references/skill-architecture.md). Audit: `scripts/audit-skills.sh`.
+**Flat discovery**: references one level deep; SKILL.md names every `references/*.md` and every `scripts/` executable; `## Contents` past 100 lines. Rationale and trigger evals: [skill-architecture](references/skill-architecture.md). Audit: `audit-skills.sh` in the repository's top-level `scripts/` (not shipped with the skill).
 
 ## Manifests
 

--- a/skills/skill-repo/references/skill-architecture.md
+++ b/skills/skill-repo/references/skill-architecture.md
@@ -147,6 +147,7 @@ For very large references (upwards of ~10k words), go further and tell the agent
 | `references/*.md` not named in `SKILL.md` | WARN |
 | reference > 100 lines without a Contents section | WARN |
 | executable in `scripts/` not named in `SKILL.md` | WARN |
+| `scripts/`, `references/`, `assets/` or `evals/` path named in `SKILL.md` that does not exist | WARN |
 
 Deliberately **not** linted, because no mechanical check decides them honestly: whether the description narrates a workflow, whether a verification step exists, whether an optional frontmatter field has a consumer. Those belong in review.
 

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -336,13 +336,21 @@ PYEOF
     # references/, assets/) plus evals/; `${CLAUDE_SKILL_DIR}/` resolves to the
     # skill directory and is accepted as a prefix. Globs, placeholders and
     # other variables are not paths and are skipped.
+    #
+    # Both spellings count: a backticked span and a Markdown link target. A
+    # SKILL.md that names its references as links only -- the common shape --
+    # would otherwise pass this check without a single path being looked at.
     if [[ -n "$skill_dir" && -d "$skill_dir" ]]; then
         dangling=""
         while IFS= read -r token; do
             token="${token#\`}"
             token="${token%\`}"
+            token="${token#](}"
+            token="${token%)}"
             token="${token%[.,;:)]}"
             rel="${token#\$\{CLAUDE_SKILL_DIR\}/}"
+            # A link may point into a file: references/x.md#section is x.md.
+            rel="${rel%%#*}"
             case "$rel" in
                 scripts/*|references/*|assets/*|evals/*) ;;
                 *) continue ;;
@@ -351,7 +359,10 @@ PYEOF
             [[ -e "$skill_dir/$rel" ]] && continue
             case " $dangling " in *" $rel "*) continue ;; esac
             dangling="$dangling $rel"
-        done < <(grep -oE "\`[^\`]+\`" <<<"$skill_body" || true)
+        done < <(
+            grep -oE "\`[^\`]+\`" <<<"$skill_body" || true
+            grep -oE '\]\([^) ]+\)' <<<"$skill_body" || true
+        )
         if [[ -n "$dangling" ]]; then
             warning "${skill_dir_rel}: SKILL.md names path(s) that do not exist under the skill directory:${dangling} - fix the path or ship the file"
         fi

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -65,7 +65,7 @@ validate_skill_md() {
     local closing_line frontmatter extra_fields field_names desc compat
     local desc_chars body_lines skill_body base unnamed linked_from ref_lines
     local relative_paths count skill_dir skill_dir_rel checkpoints_justified
-    local untested misclassified f s base
+    local untested misclassified f s base dangling token rel
     # After the local declarations, not before them: `local skill_dir` resets a
     # value assigned above it, so an earlier assignment silently becomes unset
     # and `set -u` then aborts the run mid-way -- which prints no summary and
@@ -322,6 +322,38 @@ PYEOF
                     warning "${skill_dir_rel}: references/${base} is $ref_lines lines with no Contents section - agents preview long files; add one so the rest is discoverable"
                 fi
             done
+        fi
+    fi
+
+    # --- Dangling references -------------------------------------------------
+    # The mirror image of flat discovery: a path SKILL.md names must exist under
+    # the skill directory. A reference that resolves to nothing is a door the
+    # agent opens onto a wall -- it costs a tool call and returns an error where
+    # the skill promised content. retro-skill#19 hit this in production: the
+    # skill shipped with scripts/ and references/ outside the declared skill
+    # directory, so every path in SKILL.md was dead on a faithful install.
+    # Skill-relative directories per the Agent Skills spec (scripts/,
+    # references/, assets/) plus evals/; `${CLAUDE_SKILL_DIR}/` resolves to the
+    # skill directory and is accepted as a prefix. Globs, placeholders and
+    # other variables are not paths and are skipped.
+    if [[ -n "$skill_dir" && -d "$skill_dir" ]]; then
+        dangling=""
+        while IFS= read -r token; do
+            token="${token#\`}"
+            token="${token%\`}"
+            token="${token%[.,;:)]}"
+            rel="${token#\$\{CLAUDE_SKILL_DIR\}/}"
+            case "$rel" in
+                scripts/*|references/*|assets/*|evals/*) ;;
+                *) continue ;;
+            esac
+            case "$rel" in *'*'*|*'<'*|*'>'*|*'{'*|*'}'*|*'$'*|*' '*|*'?'*) continue ;; esac
+            [[ -e "$skill_dir/$rel" ]] && continue
+            case " $dangling " in *" $rel "*) continue ;; esac
+            dangling="$dangling $rel"
+        done < <(grep -oE "\`[^\`]+\`" <<<"$skill_body" || true)
+        if [[ -n "$dangling" ]]; then
+            warning "${skill_dir_rel}: SKILL.md names path(s) that do not exist under the skill directory:${dangling} - fix the path or ship the file"
         fi
     fi
 

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -347,6 +347,13 @@ PYEOF
             token="${token%\`}"
             token="${token#](}"
             token="${token%)}"
+            # `[x](<references/y.md>)` is a valid link. Only a wholly wrapped
+            # target is unwrapped, so the `references/<topic>.md` placeholder
+            # keeps its angle brackets and stays filtered out below.
+            if [[ "$token" == "<"*">" ]]; then
+                token="${token#<}"
+                token="${token%>}"
+            fi
             token="${token%[.,;:)]}"
             rel="${token#\$\{CLAUDE_SKILL_DIR\}/}"
             # A link may point into a file: references/x.md#section is x.md.

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -190,12 +190,13 @@ chmod +x "$dang/skills/d/scripts/present.sh"
     printf '%s\n' "Run \`scripts/present.sh\` or \`\${CLAUDE_SKILL_DIR}/scripts/missing.sh\`;"
     printf 'never \x60references/*.md\x60 wholesale, nor \x60references/<topic>.md\x60.\n'
     printf 'See [here](references/present.md#anchor) and [gone](references/linked.md).\n'
+    printf 'Angle-wrapped targets are links too: [w](<references/wrapped.md>).\n'
 } > "$dang/skills/d/SKILL.md"
 dang_out="$(run_validator fallback "$dang")"
 dang_line="$(grep -F 'names path(s) that do not exist' <<<"$dang_out" || true)"
 if [[ -n "$dang_line" ]]; then ((PASS++)); else
     echo "  FAIL [dangling] missing paths were not reported"; ((FAIL++)); fi
-for want in references/missing.md scripts/missing.sh references/linked.md; do
+for want in references/missing.md scripts/missing.sh references/linked.md references/wrapped.md; do
     if grep -qF " $want" <<<"$dang_line"; then ((PASS++)); else
         echo "  FAIL [dangling] $want not named in: $dang_line"; ((FAIL++)); fi
 done

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -171,6 +171,37 @@ found_count="$(grep -cF 'SKILL.md found:' <<<"$multi_out")"
 if [[ "$found_count" -eq 3 ]]; then ((PASS++)); else
     echo "  FAIL [multi] expected 3 discovered skills, got $found_count"; ((FAIL++)); fi
 
+# Dangling references: a skill-relative path named in SKILL.md must exist under
+# the skill directory (retro-skill#19 shipped scripts/ and references/ outside
+# it, so every path was dead on a faithful install). The present file must not
+# be reported, the missing ones must -- including the ${CLAUDE_SKILL_DIR} form.
+# Globs and placeholders are not paths and must stay silent.
+echo "== Dangling references =="
+dang="$TMP/fx_dangling"
+rm -rf "$dang"
+mkdir -p "$dang/skills/d/references" "$dang/skills/d/scripts"
+printf '# present\n' > "$dang/skills/d/references/present.md"
+printf '#!/bin/sh\n' > "$dang/skills/d/scripts/present.sh"
+chmod +x "$dang/skills/d/scripts/present.sh"
+{
+    printf '%b' "${hdr}description: Use when doing X\n---\n# D\n"
+    printf 'Read \x60references/present.md\x60 and \x60references/missing.md\x60.\n'
+    printf '%s\n' "Run \`scripts/present.sh\` or \`\${CLAUDE_SKILL_DIR}/scripts/missing.sh\`;"
+    printf 'never \x60references/*.md\x60 wholesale, nor \x60references/<topic>.md\x60.\n'
+} > "$dang/skills/d/SKILL.md"
+dang_out="$(run_validator fallback "$dang")"
+dang_line="$(grep -F 'names path(s) that do not exist' <<<"$dang_out" || true)"
+if [[ -n "$dang_line" ]]; then ((PASS++)); else
+    echo "  FAIL [dangling] missing paths were not reported"; ((FAIL++)); fi
+for want in references/missing.md scripts/missing.sh; do
+    if grep -qF " $want" <<<"$dang_line"; then ((PASS++)); else
+        echo "  FAIL [dangling] $want not named in: $dang_line"; ((FAIL++)); fi
+done
+for absent in present.md present.sh 'references/*.md' 'references/<topic>.md'; do
+    if grep -qF "$absent" <<<"$dang_line"; then
+        echo "  FAIL [dangling] $absent wrongly reported"; ((FAIL++)); else ((PASS++)); fi
+done
+
 echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"
 [[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -175,7 +175,8 @@ if [[ "$found_count" -eq 3 ]]; then ((PASS++)); else
 # the skill directory (retro-skill#19 shipped scripts/ and references/ outside
 # it, so every path was dead on a faithful install). The present file must not
 # be reported, the missing ones must -- including the ${CLAUDE_SKILL_DIR} form.
-# Globs and placeholders are not paths and must stay silent.
+# Globs and placeholders are not paths and must stay silent. Markdown link
+# targets count as names too, and a link's #anchor is not part of the path.
 echo "== Dangling references =="
 dang="$TMP/fx_dangling"
 rm -rf "$dang"
@@ -188,12 +189,13 @@ chmod +x "$dang/skills/d/scripts/present.sh"
     printf 'Read \x60references/present.md\x60 and \x60references/missing.md\x60.\n'
     printf '%s\n' "Run \`scripts/present.sh\` or \`\${CLAUDE_SKILL_DIR}/scripts/missing.sh\`;"
     printf 'never \x60references/*.md\x60 wholesale, nor \x60references/<topic>.md\x60.\n'
+    printf 'See [here](references/present.md#anchor) and [gone](references/linked.md).\n'
 } > "$dang/skills/d/SKILL.md"
 dang_out="$(run_validator fallback "$dang")"
 dang_line="$(grep -F 'names path(s) that do not exist' <<<"$dang_out" || true)"
 if [[ -n "$dang_line" ]]; then ((PASS++)); else
     echo "  FAIL [dangling] missing paths were not reported"; ((FAIL++)); fi
-for want in references/missing.md scripts/missing.sh; do
+for want in references/missing.md scripts/missing.sh references/linked.md; do
     if grep -qF " $want" <<<"$dang_line"; then ((PASS++)); else
         echo "  FAIL [dangling] $want not named in: $dang_line"; ((FAIL++)); fi
 done


### PR DESCRIPTION
The flat-discovery checks ask whether every `references/*.md` and `scripts/` executable is named in `SKILL.md`; nothing asked the reverse — whether a path `SKILL.md` names exists under the skill directory. [netresearch/retro-skill#19](https://github.com/netresearch/retro-skill/issues/19) shipped with `scripts/` and `references/` outside the declared skill directory, so every path in its `SKILL.md` was dead on a faithful install and `/retro` fell back to a degraded pass. This repository's own `SKILL.md` named `scripts/audit-skills.sh`, which lives at the repository root, not in the skill — the line now says where it is.

**Check.** `scripts/`, `references/`, `assets/` and `evals/` paths named in `SKILL.md` must resolve under the skill directory. Both spellings count — a backticked span and a Markdown link target — with or without a `${CLAUDE_SKILL_DIR}/` prefix, and a link's `#anchor` is stripped before the file is looked for. Globs (`references/*.md`) and placeholders (`references/<topic>.md`) are skipped. Reading backticks only would have let this repository's own `SKILL.md` line past the check, since it names its reference as a link. Covered by a new case in `tests/validate-skill.sh` (present file silent, two missing paths named, glob and placeholder silent); `skill-architecture.md`'s check table gains the row.

**Level: WARN, deliberately.** This validator runs in every consuming repository's CI. Measured over the 120 skills installed on one machine, 8 currently name a path that does not exist (`agent-harness`, `automated-assessment`/`add-checkpoints`, `dxp-frontend` ×2, `netresearch-account-lifecycle`/`netresearch-offboarding`, `netresearch-branding`, `skill-repo`, `typo3-upgrade-estimator`). Switching to ERROR now would turn those red without a fix in hand; the flip is tracked in a follow-up issue once they are clean.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01F91Rh11LCehJojefpo5aCF)_

_Review round assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Txqmch9od8QmcXqPyVJ7bD)_
