### PR TITLE
feat(validate)!: a dangling SKILL.md path is an error

### DIFF
--- a/skills/skill-repo/references/skill-architecture.md
+++ b/skills/skill-repo/references/skill-architecture.md
@@ -147,7 +147,7 @@ For very large references (upwards of ~10k words), go further and tell the agent
 | `references/*.md` not named in `SKILL.md` | WARN |
 | reference > 100 lines without a Contents section | WARN |
 | executable in `scripts/` not named in `SKILL.md` | WARN |
-| `scripts/`, `references/`, `assets/` or `evals/` path named in `SKILL.md` that does not exist | WARN |
+| `scripts/`, `references/`, `assets/` or `evals/` path named in `SKILL.md` that does not exist | ERROR |
 
 Deliberately **not** linted, because no mechanical check decides them honestly: whether the description narrates a workflow, whether a verification step exists, whether an optional frontmatter field has a consumer. Those belong in review.
 

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -335,7 +335,9 @@ PYEOF
     # Skill-relative directories per the Agent Skills spec (scripts/,
     # references/, assets/) plus evals/; `${CLAUDE_SKILL_DIR}/` resolves to the
     # skill directory and is accepted as a prefix. Globs, placeholders and
-    # other variables are not paths and are skipped.
+    # other variables are not paths and are skipped. An error since the fleet
+    # was measured clean (skill-repo-skill#267): 40 GitHub and 37 GitLab skill
+    # repositories, every finding fixed at its source first.
     #
     # Both spellings count: a backticked span and a Markdown link target. A
     # SKILL.md that names its references as links only -- the common shape --
@@ -376,7 +378,7 @@ PYEOF
             grep -oE '\]\([^) ]+\)' <<<"$skill_body" || true
         )
         if [[ -n "$dangling" ]]; then
-            warning "${skill_dir_rel}: SKILL.md names path(s) that do not exist under the skill directory:${dangling} - fix the path or ship the file"
+            error "${skill_dir_rel}: SKILL.md names path(s) that do not exist under the skill directory:${dangling} - fix the path or ship the file"
         fi
     fi
 


### PR DESCRIPTION
Flips the check from #266 from WARN to ERROR. **Draft until every fix below is merged** — this workflow runs in every GitHub consumer's CI at `@main`, so merging first would turn them red. Fleet measured with the WARN build: 40 GitHub skill repositories (fleet-repos-github.txt) and 37 GitLab coding-ai projects shipping `skills/`; every finding has a fix open, listed on #267. GitLab consumers run their own vendored `scripts/validate-skill.sh` via the `claude-code-skill/skill-pipeline` component, so the flip reaches them only when they refresh that copy. Closes #267.