### PR TITLE
refactor(skill-repo): declare the shipped scripts in allowed-tools, not bash and python3

### DIFF
--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   author: Netresearch DTT GmbH
   version: "1.37.0"
   repository: https://github.com/netresearch/skill-repo-skill
-allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
+allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*) Bash(skills/skill-repo/scripts/*) Bash(bash skills/skill-repo/scripts/*) Read Write Glob Grep
 ---
 
 # Skill Repository Structure Guide


### PR DESCRIPTION
Closes #270 — the repository that states the rule now follows it.

```yaml
- allowed-tools: Bash(bash:*) Bash(python3:*) Read Write Glob Grep
+ allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*) Bash(skills/skill-repo/scripts/*) Bash(bash skills/skill-repo/scripts/*) Read Write Glob Grep
```

## A correction to the issue's own reasoning

#270 said this was not a mechanical swap because `roll-changelog.py` is invoked as `python3 …`. It is not. The script carries a shebang and the executable bit, and `fleet-release-common.sh` locates it via `fr_tool` and runs it directly — there is no `python3` call site anywhere in `SKILL.md` or the references, and no standalone `bash` call either. I had assumed that rather than measured it when filing. Both interpreter rules turned out to be removable outright.

## Why four rules

A pattern only helps where it matches, and the documented call sites use four forms:

| Rule | Covers |
|---|---|
| `Bash(${CLAUDE_SKILL_DIR}/scripts/*)` | installed skill, direct call |
| `Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*)` | installed skill, `bash` prefix |
| `Bash(skills/skill-repo/scripts/*)` | working in this repository |
| `Bash(bash skills/skill-repo/scripts/*)` | the same, `bash` prefix |

The repository-local pair is deliberate rather than sloppy: `release-discipline.md` documents `skills/skill-repo/scripts/check-version-parity.sh` and `validation-checklist.md` documents `bash skills/skill-repo/scripts/validate-skill.sh`. Both are how a contributor to *this* repository runs them, and dropping them would put a prompt in front of the checklist this skill asks people to work through.

`scripts/audit-skills.sh` stays out. It lives in the repository-root `scripts/`, `SKILL.md` itself says it is "not shipped with the skill", and a rule covering it would cover every root script — which is the breadth this change exists to remove.

## Verification

```
validate-skill.sh: 0 errors, 0 warnings
10/10 repository tests pass
pre-commit run --files skills/skill-repo/SKILL.md: all hooks pass
```

Same limit as on #272: a session with permission prompts bypassed cannot show whether a pattern matches, so this is reasoned from the documented call sites, not measured against the permission flow.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_
