### PR TITLE
feat(validate): warn when a skill with scripts/ grants an interpreter

### DIFF
--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -116,12 +116,13 @@ validate_skill_md() {
             # continuation line is not missed.
             at_value=$(echo "$frontmatter" | awk '
                 /^allowed-tools:/ { found = 1; print; next }
-                found && /^[[:space:]]/ { print; next }
-                found && /^-[[:space:]]/ { print; next }
+                # A blank line is legal inside a folded or literal scalar, so it
+                # continues the value; only a new top-level key ends it.
+                found && (/^[[:space:]]/ || /^-[[:space:]]/ || /^$/) { print; next }
                 found { exit }
             ')
             if [[ -n "$at_value" ]] && echo "$at_value" \
-                | grep -qE '(Bash([[:space:]]|$)|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
+                | grep -qE '(Bash([[:space:],\"'\''"]|$)|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
                 warning "$rel ships scripts/ but allowed-tools grants an interpreter (or bare Bash) - name the scripts instead, e.g. Bash(\${CLAUDE_SKILL_DIR}/scripts/*); see repository-quality-rules.md"
             fi
         fi

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -99,6 +99,24 @@ validate_skill_md() {
             error "$rel frontmatter has non-spec fields: $field_names (allowed: name, description, license, compatibility, metadata, allowed-tools)"
         fi
 
+        # allowed-tools: a skill that ships scripts should name the scripts, not
+        # the interpreter. Bash(bash:*) pre-approves every bash command the skill
+        # issues for the whole turn; a bare Bash covers every shell command there
+        # is. ${CLAUDE_SKILL_DIR} is substituted in the frontmatter Bash rules as
+        # well as in the body, so a rule can name the shipped scripts without
+        # pinning an install path. See references/repository-quality-rules.md,
+        # section "allowed-tools".
+        # Warning, not error: the field is optional, the narrower form is a
+        # judgement call for tools the agent runs itself, and a skill may have
+        # reasons to keep an interpreter listed.
+        if [[ -d "$(dirname "$skill_file")/scripts" ]]; then
+            at_line=$(echo "$frontmatter" | grep -m1 "^allowed-tools:" || true)
+            if [[ -n "$at_line" ]] && echo "$at_line" \
+                | grep -qE '^allowed-tools:.*(Bash( |$)|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
+                warning "$rel ships scripts/ but allowed-tools grants an interpreter (or bare Bash) - name the scripts instead, e.g. Bash(\${CLAUDE_SKILL_DIR}/scripts/*); see repository-quality-rules.md"
+            fi
+        fi
+
         # Check name field
         if echo "$frontmatter" | grep -q "^name:"; then
             skill_name=$(echo "$frontmatter" | grep "^name:" | head -1 | sed 's/name: *//' | tr -d '"')

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -110,19 +110,46 @@ validate_skill_md() {
         # judgement call for tools the agent runs itself, and a skill may have
         # reasons to keep an interpreter listed.
         if [[ -d "$(dirname "$skill_file")/scripts" ]]; then
-            # The value may be a plain scalar, a folded/literal block, or a YAML
-            # list, all of which the spec accepts. Take the key line plus every
-            # indented continuation, or a "- " item block, so a rule on a
-            # continuation line is not missed.
-            at_value=$(echo "$frontmatter" | awk '
-                /^allowed-tools:/ { found = 1; print; next }
-                # A blank line is legal inside a folded or literal scalar, so it
-                # continues the value; only a new top-level key ends it.
-                found && (/^[[:space:]]/ || /^-[[:space:]]/ || /^$/) { print; next }
-                found { exit }
-            ')
-            if [[ -n "$at_value" ]] && echo "$at_value" \
-                | grep -qE '(Bash([[:space:],\"'\''"]|$)|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
+            # The spec accepts a plain scalar, a folded or literal block and a
+            # YAML list, in block or flow style, quoted or not, space- or
+            # comma-separated. Rather than widen a pattern per shape -- each
+            # review round found another legal spelling -- take the whole value
+            # and split it into entries.
+            #
+            # Collect: key line plus every continuation. Only a new top-level key
+            # ends the value, so a blank line inside a folded scalar keeps it
+            # open. Comment lines and trailing comments are dropped; they are not
+            # part of the value.
+            #
+            # Split: on whitespace, comma, bracket and quote, but only at
+            # parenthesis depth 0 -- Bash(git:*,make:*,bash:*) is one entry with
+            # commas inside it, and Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*)
+            # carries a space.
+            at_tokens=$(echo "$frontmatter" | awk '
+                /^allowed-tools:/ { found = 1; sub(/^allowed-tools:/, ""); }
+                !found { next }
+                found && NR > 1 && !/^[[:space:]]/ && !/^-[[:space:]]/ && !/^$/ && !/^allowed-tools:/ { exit }
+                {
+                    sub(/^[[:space:]]*#.*$/, "")
+                    # A " #" outside quotes starts a YAML comment; the rest
+                    # of the line is not part of the value, parentheses included.
+                    sub(/[[:space:]]#.*$/, "")
+                    depth = 0
+                    for (i = 1; i <= length($0); i++) {
+                        c = substr($0, i, 1)
+                        if (c == "(") depth++
+                        else if (c == ")") depth--
+                        if (depth == 0 && (c == " " || c == "\t" || c == "," || \
+                                           c == "[" || c == "]" || c == "\"" || c == "'"'"'"))
+                            printf "\n"
+                        else
+                            printf "%s", c
+                    }
+                    printf "\n"
+                }
+            ' | sed -e 's/^-$//' -e '/^$/d')
+            if [[ -n "$at_tokens" ]] && echo "$at_tokens" \
+                | grep -qE '^(Bash$|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
                 warning "$rel ships scripts/ but allowed-tools grants an interpreter (or bare Bash) - name the scripts instead, e.g. Bash(\${CLAUDE_SKILL_DIR}/scripts/*); see repository-quality-rules.md"
             fi
         fi

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -110,9 +110,18 @@ validate_skill_md() {
         # judgement call for tools the agent runs itself, and a skill may have
         # reasons to keep an interpreter listed.
         if [[ -d "$(dirname "$skill_file")/scripts" ]]; then
-            at_line=$(echo "$frontmatter" | grep -m1 "^allowed-tools:" || true)
-            if [[ -n "$at_line" ]] && echo "$at_line" \
-                | grep -qE '^allowed-tools:.*(Bash( |$)|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
+            # The value may be a plain scalar, a folded/literal block, or a YAML
+            # list, all of which the spec accepts. Take the key line plus every
+            # indented continuation, or a "- " item block, so a rule on a
+            # continuation line is not missed.
+            at_value=$(echo "$frontmatter" | awk '
+                /^allowed-tools:/ { found = 1; print; next }
+                found && /^[[:space:]]/ { print; next }
+                found && /^-[[:space:]]/ { print; next }
+                found { exit }
+            ')
+            if [[ -n "$at_value" ]] && echo "$at_value" \
+                | grep -qE '(Bash([[:space:]]|$)|Bash\([^)]*\b(bash|sh|python3?|uv|node|perl|ruby):\*)'; then
                 warning "$rel ships scripts/ but allowed-tools grants an interpreter (or bare Bash) - name the scripts instead, e.g. Bash(\${CLAUDE_SKILL_DIR}/scripts/*); see repository-quality-rules.md"
             fi
         fi

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -206,6 +206,43 @@ for absent in present.md present.sh 'references/*.md' 'references/<topic>.md' 'a
         echo "  FAIL [dangling] $absent wrongly reported"; ((FAIL++)); else ((PASS++)); fi
 done
 
+# --- allowed-tools: interpreter-wide rule in a skill that ships scripts (#271)
+# Warns only when both hold. A skill without scripts/ keeps its interpreter
+# rule without comment, and a converted rule must stay silent -- otherwise the
+# warning would fire across a fleet that has already done the work.
+at_case() { # at_case <allowed-tools line> <with-scripts:yes|no> <expect:warn|quiet> <label>
+    local line="$1" with_scripts="$2" expect="$3" label="$4" dir out hit
+    dir="$(mktemp -d)"; mkdir -p "$dir/skills/d"
+    [[ "$with_scripts" == yes ]] && { mkdir -p "$dir/skills/d/scripts"; printf '#!/usr/bin/env bash\necho hi\n' > "$dir/skills/d/scripts/x.sh"; }
+    printf '{"name":"d","version":"1.0.0"}\n' > "$dir/plugin.json"
+    {
+        printf -- '---\n'
+        printf 'name: d\n'
+        printf 'description: "Use when exercising the allowed-tools check."\n'
+        printf '%s\n' "$line"
+        printf -- '---\n\n# D\n'
+    } > "$dir/skills/d/SKILL.md"
+    out="$(run_validator fallback "$dir")"
+    hit="$(grep -cF 'allowed-tools grants an interpreter' <<<"$out" || true)"
+    rm -rf "$dir"
+    if [[ "$expect" == warn && "$hit" -ge 1 ]] || [[ "$expect" == quiet && "$hit" -eq 0 ]]; then
+        ((PASS++))
+    else
+        echo "  FAIL [allowed-tools] $label: expected $expect, got $hit hit(s)"; ((FAIL++))
+    fi
+}
+at_case 'allowed-tools: Bash(bash:*) Read'                                    yes warn  'interpreter rule'
+at_case 'allowed-tools: Bash(python3:*) Read'                                 yes warn  'python3 rule'
+at_case 'allowed-tools: Bash(uv:*) Read'                                      yes warn  'uv rule'
+at_case 'allowed-tools: Bash(git:*,make:*,bash:*) Read'                       yes warn  'comma syntax hides bash'
+at_case 'allowed-tools: Bash Read Write'                                      yes warn  'bare Bash'
+# Single-quoted on purpose: the validator must see the variable unexpanded,
+# the way it appears in a real frontmatter line.
+# shellcheck disable=SC2016
+at_case 'allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(git:*) Read' yes quiet 'converted rule'
+at_case 'allowed-tools: Bash(git:*) Bash(gh:*) Read'                          yes quiet 'no interpreter at all'
+at_case 'allowed-tools: Bash(bash:*) Read'                                    no  quiet 'no scripts/ to name'
+
 echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"
 [[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -268,6 +268,16 @@ at_case 'allowed-tools: "Bash"'                                               ye
 # shellcheck disable=SC2016
 at_case 'allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*),Read'             yes quiet 'comma-separated, converted'
 
+# A comment is not part of the value, and a flow list is still a list.
+at_case 'allowed-tools:
+  - Read
+  # Bash(python3:*) is not granted'                                           yes quiet 'comment mentioning an interpreter'
+at_case 'allowed-tools: [Bash]'                                               yes warn  'flow list, bare Bash'
+at_case 'allowed-tools: [Bash(bash:*), Read]'                                 yes warn  'flow list, interpreter'
+# shellcheck disable=SC2016
+at_case 'allowed-tools: [Bash(${CLAUDE_SKILL_DIR}/scripts/*), Read]'          yes quiet 'flow list, converted'
+at_case 'allowed-tools: Read # Bash(bash:*) would be wrong'                   yes quiet 'trailing comment'
+
 echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"
 [[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -243,6 +243,20 @@ at_case 'allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(git:*) Read' ye
 at_case 'allowed-tools: Bash(git:*) Bash(gh:*) Read'                          yes quiet 'no interpreter at all'
 at_case 'allowed-tools: Bash(bash:*) Read'                                    no  quiet 'no scripts/ to name'
 
+# The spec accepts a plain scalar, a folded/literal block and a YAML list, so a
+# check that reads only the key line misses a rule on a continuation line.
+# shellcheck disable=SC2016
+at_case 'allowed-tools: >-
+  Bash(bash:*)
+  Read'                                                                       yes warn  'folded scalar'
+at_case 'allowed-tools:
+  - Bash(python3:*)
+  - Read'                                                                     yes warn  'yaml list'
+# shellcheck disable=SC2016
+at_case 'allowed-tools: >-
+  Bash(${CLAUDE_SKILL_DIR}/scripts/*)
+  Read'                                                                       yes quiet 'folded scalar, converted'
+
 echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"
 [[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -257,6 +257,17 @@ at_case 'allowed-tools: >-
   Bash(${CLAUDE_SKILL_DIR}/scripts/*)
   Read'                                                                       yes quiet 'folded scalar, converted'
 
+# A blank line is legal inside a folded scalar, and the spec allows comma
+# separation and quoting -- all three defeated an earlier version of the check.
+at_case 'allowed-tools: >-
+  Read
+
+  Bash(python3:*)'                                                            yes warn  'blank line inside value'
+at_case 'allowed-tools: Bash,Read'                                            yes warn  'comma-separated bare Bash'
+at_case 'allowed-tools: "Bash"'                                               yes warn  'quoted bare Bash'
+# shellcheck disable=SC2016
+at_case 'allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*),Read'             yes quiet 'comma-separated, converted'
+
 echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"
 [[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }


### PR DESCRIPTION
Closes #271. The rule in `repository-quality-rules.md` (§ allowed-tools) has been documentation only, and a rule nothing checks drifts.

## What it flags

Both conditions must hold: the skill directory contains `scripts/`, **and** `allowed-tools` grants an interpreter (`bash`, `sh`, `python`, `python3`, `uv`, `node`, `perl`, `ruby`) or a bare `Bash`. A skill without `scripts/` keeps its interpreter rule without comment.

Two forms are matched that a naive pattern misses, and both showed up in the fleet sweep this check follows:

- `Bash(git:*,make:*,bash:*)` — comma syntax, with the interpreter buried mid-list (`agent-harness`);
- `Bash` with no parentheses at all, the widest form the field takes (`peer-qa-review`).

My own first sweep used the naive `Bash(bash:*)` pattern and reported the fleet clean while those two repositories were not. That is the reason the pattern here is wider than it looks like it needs to be.

Warning rather than error, on purpose: the field is optional, and whether a tool belongs in the narrow form is a judgement call — `git`, `jq`, `gh` that the agent runs itself stay listed separately.

## The timing was the condition on the issue

All nine repositories shipping skills with `scripts/` are converted first: netresearch/agent-rules-skill#109, #273, netresearch/automated-assessment-skill#82, netresearch/enterprise-readiness-skill#102, netresearch/jira-skill#214, netresearch/matrix-skill#127, netresearch/retro-skill#87, netresearch/agent-harness-skill#66, netresearch/peer-qa-review-skill#51.

Verified against fresh clones of all nine current `main` branches: **zero** warnings. A warning that fires everywhere on the day it lands trains people to ignore it.

## Verification

```
10/10 repository tests pass, 43 assertions
8 new cases, both directions (5 interpreter forms warn, 3 quiet cases stay quiet)
without the check, 5 of the 8 fail — confirmed by reverting the validator and re-running
shellcheck clean; pre-commit run --files <changed>: all hooks pass
```

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01JYQciiXoiApXBfcJrFMnA9)_
