### PR TITLE
docs(evals): say what the A/B harness cannot measure, and warn when nothing does

### DIFF
--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -11,6 +11,7 @@
 - Rule 5: PR template
 - Rule 6: Target area mapping
 - Rule 7: Eval format (skill-repo convention)
+  - What these evals cannot measure, and why it matters
 - Rule 8: Per-private-repo confirmation
 - Rule 9: New-skill scaffolding
 - See also
@@ -236,6 +237,46 @@ Two things change for evals **without** a samples block: patterns are now checke
 parseable by `grep -E`, and an unparseable one fails — except under a `*_contains` type,
 where the value is usually a literal and the mismatch is the grader's, so it only warns.
 Nothing else about validation changed, and no evals.json in the fleet changes verdict.
+
+### What these evals cannot measure, and why it matters
+
+`run-ab-evals.sh` builds the "with" arm by pasting the whole `SKILL.md` into
+`--append-system-prompt`, and runs both arms with `--tools ""`. The skill is
+force-fed. **There is no routing in this harness at all**, so no eval in any
+`evals.json` can detect the one failure a description can have: never being
+picked up.
+
+That is not hypothetical. Measured in
+[netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals),
+`typo3-conformance` — the skill for what a TYPO3 extension declares about
+supported versions — sat in the fleet across three cases about exactly that and
+was loaded in **1 of 25 trials**, because its description never named those
+artefacts. Its 30 evals all passed throughout: 29 of their prompts are phrased
+in the skill's own vocabulary (*"Check this TYPO3 extension for conformance to
+current standards"*), so they measure what it does once loaded and cannot see
+that nothing reaches it. Across the 58 installed Netresearch skills there are
+**1335 evals and no trigger evals**.
+
+Two consequences for anyone reading an A/B result:
+
+- **A green A/B says the content helps when supplied.** It says nothing about
+  whether the skill is ever consulted, and the two are independent — a skill can
+  win every eval and be reached by nobody.
+- **A `tool_use` assertion does not observe a tool call.** The grader matches
+  `value or pattern` against the answer text with `grep -qiE`, whatever the
+  type, and the arm runs with no tools. It is a text assertion wearing another
+  name.
+
+**Where trigger testing belongs.** A trigger eval needs the skill *installed as
+a skill* rather than pasted, tools enabled, and the transcript inspected for an
+invocation. `agent-system-evals` already does this — its `skill_invoked`
+endpoint counts `Skill(...)` calls in the recorded trajectory, and
+`scripts/invocation-census` reports the rate per case. Write the queries in the
+format [agentskills.io documents](https://agentskills.io/skill-creation/optimizing-descriptions)
+— realistic prompts labelled `should_trigger` — keep them in
+`evals/eval_queries.json` beside `evals.json`, and take the phrasings from
+requests real users actually made rather than from the description they are
+meant to test.
 
 ## Rule 8: Per-private-repo confirmation
 

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -490,6 +490,46 @@ while IFS='|' read -r level msg; do
   esac
 done <<< "$RESULT"
 
+# --- Trigger evals -----------------------------------------------------------
+# evals.json cannot detect a description that never routes: run-ab-evals.sh
+# pastes the whole SKILL.md into the system prompt, so the skill is force-fed
+# and routing never happens. A skill whose description omits the words its users
+# say passes every eval and is reached by nobody -- measured at 1 of 25 trials
+# for one fleet skill whose 30 evals were green throughout. See
+# references/materialization-contract.md, Rule 7.
+#
+# A warning, not an error: nothing in this repository runs these queries yet,
+# and failing a build for a missing file whose runner does not exist would be a
+# gate nobody can pass.
+TRIGGER_FILE="$(dirname "$EVALS_FILE")/eval_queries.json"
+if [[ -f "$TRIGGER_FILE" ]]; then
+  n_q=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    print(-1); raise SystemExit
+q = d.get('queries') if isinstance(d, dict) else d
+print(len(q) if isinstance(q, list) else -1)
+" "$TRIGGER_FILE" 2>/dev/null || echo -1)
+  if [[ "$n_q" -lt 0 ]]; then
+    fail "$(basename "$TRIGGER_FILE") is not readable as a list of queries"
+  else
+    n_pos=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+q = d.get('queries') if isinstance(d, dict) else d
+print(sum(1 for x in q if x.get('should_trigger')))
+" "$TRIGGER_FILE" 2>/dev/null || echo 0)
+    pass "$(basename "$TRIGGER_FILE"): $n_q trigger quer(y|ies), $n_pos labelled should_trigger"
+    if [[ "$n_pos" -eq "$n_q" ]]; then
+      warn "every trigger query is a positive - without negatives the file cannot catch a description that fires on everything"
+    fi
+  fi
+else
+  warn "no eval_queries.json beside this file - evals.json measures what the skill does once loaded, never whether a real request reaches it (materialization-contract.md, Rule 7)"
+fi
+
 # --- Summary ---
 echo ""
 echo "---"

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -503,29 +503,45 @@ done <<< "$RESULT"
 # gate nobody can pass.
 TRIGGER_FILE="$(dirname "$EVALS_FILE")/eval_queries.json"
 if [[ -f "$TRIGGER_FILE" ]]; then
-  n_q=$(python3 -c "
+  # One reader, one verdict. Counting positives in a second call meant a
+  # malformed entry raised there and `|| echo 0` turned the failure into
+  # "0 positives", so the validator printed PASS for a file it could not read.
+  TRIGGER_READ=$(python3 -c "
 import json, sys
 try:
     d = json.load(open(sys.argv[1]))
-except Exception:
-    print(-1); raise SystemExit
+except Exception as exc:
+    print('ERR|not valid JSON: %s' % exc); raise SystemExit
 q = d.get('queries') if isinstance(d, dict) else d
-print(len(q) if isinstance(q, list) else -1)
-" "$TRIGGER_FILE" 2>/dev/null || echo -1)
-  if [[ "$n_q" -lt 0 ]]; then
-    fail "$(basename "$TRIGGER_FILE") is not readable as a list of queries"
-  else
-    n_pos=$(python3 -c "
-import json, sys
-d = json.load(open(sys.argv[1]))
-q = d.get('queries') if isinstance(d, dict) else d
-print(sum(1 for x in q if x.get('should_trigger')))
-" "$TRIGGER_FILE" 2>/dev/null || echo 0)
-    pass "$(basename "$TRIGGER_FILE"): $n_q trigger quer(y|ies), $n_pos labelled should_trigger"
-    if [[ "$n_pos" -eq "$n_q" ]]; then
-      warn "every trigger query is a positive - without negatives the file cannot catch a description that fires on everything"
-    fi
-  fi
+if not isinstance(q, list):
+    print('ERR|no list of queries (expected a top-level list, or a queries key)')
+    raise SystemExit
+bad = [i for i, x in enumerate(q) if not isinstance(x, dict) or 'query' not in x
+       or not isinstance(x.get('should_trigger'), bool)]
+if bad:
+    print('ERR|entr(y|ies) %s lack a query string or a boolean should_trigger'
+          % ', '.join(str(i) for i in bad[:5]))
+    raise SystemExit
+print('OK|%d|%d' % (len(q), sum(1 for x in q if x['should_trigger'])))
+" "$TRIGGER_FILE" 2>&1)
+
+  case "$TRIGGER_READ" in
+    OK\|*)
+      n_q=$(echo "$TRIGGER_READ" | cut -d'|' -f2)
+      n_pos=$(echo "$TRIGGER_READ" | cut -d'|' -f3)
+      if [[ "$n_q" -eq 0 ]]; then
+        warn "$(basename "$TRIGGER_FILE") carries no queries - an empty file is not a trigger test"
+      else
+        pass "$(basename "$TRIGGER_FILE"): $n_q trigger quer(y|ies), $n_pos labelled should_trigger"
+        if [[ "$n_pos" -eq "$n_q" ]]; then
+          warn "every trigger query is a positive - without negatives the file cannot catch a description that fires on everything"
+        fi
+      fi
+      ;;
+    *)
+      fail "$(basename "$TRIGGER_FILE"): ${TRIGGER_READ#ERR|}"
+      ;;
+  esac
 else
   warn "no eval_queries.json beside this file - evals.json measures what the skill does once loaded, never whether a real request reaches it (materialization-contract.md, Rule 7)"
 fi

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -519,7 +519,7 @@ if not isinstance(q, list):
 bad = [i for i, x in enumerate(q) if not isinstance(x, dict) or 'query' not in x
        or not isinstance(x.get('should_trigger'), bool)]
 if bad:
-    print('ERR|entr(y|ies) %s lack a query string or a boolean should_trigger'
+    print('ERR|entries %s lack a query string or a boolean should_trigger'
           % ', '.join(str(i) for i in bad[:5]))
     raise SystemExit
 print('OK|%d|%d' % (len(q), sum(1 for x in q if x['should_trigger'])))
@@ -532,7 +532,7 @@ print('OK|%d|%d' % (len(q), sum(1 for x in q if x['should_trigger'])))
       if [[ "$n_q" -eq 0 ]]; then
         warn "$(basename "$TRIGGER_FILE") carries no queries - an empty file is not a trigger test"
       else
-        pass "$(basename "$TRIGGER_FILE"): $n_q trigger quer(y|ies), $n_pos labelled should_trigger"
+        pass "$(basename "$TRIGGER_FILE"): $n_q trigger queries, $n_pos labelled should_trigger"
         if [[ "$n_pos" -eq "$n_q" ]]; then
           warn "every trigger query is a positive - without negatives the file cannot catch a description that fires on everything"
         fi


### PR DESCRIPTION
`run-ab-evals.sh` builds the "with" arm by pasting the whole `SKILL.md` into `--append-system-prompt`, and runs both arms with `--tools ""`. The skill is force-fed. **There is no routing in this harness at all**, so no eval in any `evals.json` can detect the one failure a description can have: never being picked up.

## Measured, not argued

`typo3-conformance` is the skill for what a TYPO3 extension declares about the versions it supports. Across three cases about exactly that in [netresearch/agent-system-evals](https://github.com/netresearch/agent-system-evals), it sat in the fleet and was loaded in **1 of 25 trials** — its description never named those artefacts. Its **30 evals were green throughout**, because 29 of their prompts are phrased in the skill's own vocabulary (*"Check this TYPO3 extension for conformance to current standards"*) and therefore measure what it does once loaded.

Across the 58 installed Netresearch skills: **1335 evals, zero trigger evals.**

## What this PR changes

**`materialization-contract.md`** gains a section under Rule 7 stating the limit and two readings that follow from it:

- A green A/B says the content helps *when supplied*. It says nothing about whether the skill is ever consulted, and the two are independent — a skill can win every eval and be reached by nobody.
- A `tool_use` assertion does not observe a tool call. The grader matches `value or pattern` against the answer text with `grep -qiE` whatever the type, in an arm that has no tools. It is a text assertion wearing another name.

It also names where trigger testing belongs: a harness that installs the skill *as a skill*, enables tools, and inspects the transcript for an invocation — which `agent-system-evals` already does via its `skill_invoked` endpoint and `scripts/invocation-census`.

**`validate-evals.sh`** looks for `eval_queries.json` beside `evals.json`, reports how many queries it carries and how many are positives, and warns when it is missing or carries only positives (a file with no negatives cannot catch a description that fires on everything).

**A warning, not an error.** Nothing in this repository runs those queries yet, and a gate nobody can pass is worse than no gate. The first such file is in [typo3-conformance-skill#119](https://github.com/netresearch/typo3-conformance-skill/pull/119), where every prompt is a request that was actually put to an agent, carrying its source and measured invocation rate.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
