### PR TITLE
docs(evals): say that a trigger query must not be copied from a benchmark

### DIFF
--- a/skills/skill-repo/references/materialization-contract.md
+++ b/skills/skill-repo/references/materialization-contract.md
@@ -278,6 +278,24 @@ format [agentskills.io documents](https://agentskills.io/skill-creation/optimizi
 requests real users actually made rather than from the description they are
 meant to test.
 
+**Never copy them from a benchmark that measures the skill.** This advice, read
+literally, produced exactly that: the first trigger file written under it took
+its queries verbatim from `agent-system-evals`, named that repository's case
+identifiers, and recorded the routing rate each case had measured — including
+the rate for the case that was measuring the skill at the time. The benchmark's
+contamination check raised nineteen hits the first moment a fleet resolved the
+skill, and the arm had to be rebuilt and the comparison re-run.
+
+The line is between subject and sentences. A trigger eval for a conformance
+skill is about version declarations, and so is the case that measures it;
+sharing that subject is unavoidable and carries nothing. Sharing the case's
+sentences hands the agent the prompt it will be given, and a case identifier
+hands it the answer key. So write each query from the artefact it is about, in
+a maintainer's words, then check mechanically: no case identifier, no measured
+figure, and no run of words shared with any instruction in the benchmark beyond
+an ordinary noun phrase. `evals.json` is not exempt — its prompts reach the
+same fleet.
+
 ## Rule 8: Per-private-repo confirmation
 
 Before pushing to a private host (`git.netresearch.de`, `gitlab.com/<private-org>`, etc.), prompt the user. Decision is remembered per `(session, repo-url)` for the duration of the active retro-skill session; not persisted across sessions.

--- a/skills/skill-repo/scripts/validate-evals.sh
+++ b/skills/skill-repo/scripts/validate-evals.sh
@@ -507,7 +507,7 @@ if [[ -f "$TRIGGER_FILE" ]]; then
   # malformed entry raised there and `|| echo 0` turned the failure into
   # "0 positives", so the validator printed PASS for a file it could not read.
   TRIGGER_READ=$(python3 -c "
-import json, sys
+import json, re, sys
 try:
     d = json.load(open(sys.argv[1]))
 except Exception as exc:
@@ -522,13 +522,27 @@ if bad:
     print('ERR|entries %s lack a query string or a boolean should_trigger'
           % ', '.join(str(i) for i in bad[:5]))
     raise SystemExit
-print('OK|%d|%d' % (len(q), sum(1 for x in q if x['should_trigger'])))
+# A benchmark case identifier is a shape no user request carries, and it is
+# how the first trigger file written under this rule leaked: queries copied
+# from the benchmark that was measuring the skill, its case ids beside them.
+# Shaped like OFR-TYPO3-EXT-001: uppercase words, then a zero-padded
+# three-digit ordinal. Deliberately not four digits, so CVE-2024-1234 and
+# OWASP-A01-2021 -- which a security skill may legitimately quote -- do not
+# trip it.
+marks = sorted(set(re.findall(r'\\b[A-Z]{2,}(?:-[A-Z][A-Z0-9]*)+-\\d{3}\\b',
+                              json.dumps(q))))
+print('OK|%d|%d|%s' % (len(q), sum(1 for x in q if x['should_trigger']),
+                       ','.join(marks[:5])))
 " "$TRIGGER_FILE" 2>&1)
 
   case "$TRIGGER_READ" in
     OK\|*)
       n_q=$(echo "$TRIGGER_READ" | cut -d'|' -f2)
       n_pos=$(echo "$TRIGGER_READ" | cut -d'|' -f3)
+      case_ids=$(echo "$TRIGGER_READ" | cut -d'|' -f4)
+      if [[ -n "$case_ids" ]]; then
+        fail "$(basename "$TRIGGER_FILE") names benchmark case identifier(s): ${case_ids} - a trigger query is a user's request, and a case id is the answer key to the run measuring this skill (materialization-contract.md, Rule 7)"
+      fi
       if [[ "$n_q" -eq 0 ]]; then
         warn "$(basename "$TRIGGER_FILE") carries no queries - an empty file is not a trigger test"
       else


### PR DESCRIPTION
Rule 7 told authors to take trigger-query phrasings from requests real users actually made. Read literally, that produced the defect it exists to prevent: the first trigger file written under it took its queries verbatim from [agent-system-evals](https://github.com/netresearch/agent-system-evals), named that repository's case identifiers, and recorded the routing rate each case had measured — including the rate for the case that was measuring the skill at the time. The benchmark's contamination check raised nineteen hits the moment a fleet resolved the skill; the arm had to be rebuilt and the comparison re-run ([typo3-conformance-skill#120](https://github.com/netresearch/typo3-conformance-skill/pull/120), [agent-system-evals#37](https://github.com/netresearch/agent-system-evals/pull/37)).

The line is between subject and sentences. A trigger eval for a conformance skill is about version declarations, and so is the case that measures it — sharing that subject is unavoidable and carries nothing. Sharing the case's sentences hands the agent the prompt it will be given, and a case identifier hands it the answer key.

The identifier half is now mechanical. `validate-evals.sh` fails on a case identifier anywhere in `eval_queries.json`. The pattern is uppercase words followed by a zero-padded three-digit ordinal — deliberately not four digits, so `CVE-2024-1234` and `OWASP-A01-2021`, which a security skill may legitimately quote, do not trip it. Exercised in both directions on a real trigger file and against both of those.

The sentence half stays prose, because this repository cannot see the benchmark's instructions to diff against them; the rule says to check it, and how.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_012XjwqvXjw8sA67NoZcoSw7)_
