### PR TITLE
docs: correct marketplace setup steps and document skills-dir route

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-mar
 ### Without a marketplace: skills directory (Claude Code 2.1.157+)
 
 ```bash
+mkdir -p ~/.claude/skills
 git clone https://github.com/netresearch/skill-repo-skill.git \
   ~/.claude/skills/skill-repo
 ```
 
-Loads as `skill-repo@skills-dir` on the next session, hooks and commands included. Update with `git pull`; remove by deleting the directory.
+Loads as `skill-repo@skills-dir` on the next session. Update with `git -C ~/.claude/skills/skill-repo pull` and start a new session; remove by deleting the directory.
 
 ### npx ([skills.sh](https://skills.sh))
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,23 @@ This is an **Agent Skill** following the [open standard](https://agentskills.io)
 
 ### Marketplace (recommended)
 
-Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-marketplace) once, then browse and install skills:
+Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-marketplace) once, then install this plugin from it:
 
 ```bash
 /plugin marketplace add netresearch/claude-code-marketplace
+/plugin install skill-repo@netresearch-claude-code-marketplace
 ```
+
+> **Do not** run `/plugin marketplace add netresearch/skill-repo-skill`. `marketplace add` needs a `.claude-plugin/marketplace.json` catalog; this repo ships a `.claude-plugin/plugin.json` plugin manifest, so that fails with `Marketplace file not found`.
+
+### Without a marketplace: skills directory (Claude Code 2.1.157+)
+
+```bash
+git clone https://github.com/netresearch/skill-repo-skill.git \
+  ~/.claude/skills/skill-repo
+```
+
+Loads as `skill-repo@skills-dir` on the next session, hooks and commands included. Update with `git pull`; remove by deleting the directory.
 
 ### npx ([skills.sh](https://skills.sh))
 
@@ -150,10 +162,10 @@ The layout for a Netresearch skill repository (one or more skills per repo):
 
 ### Installation methods (summary)
 
-1. **Marketplace** — `/plugin marketplace add netresearch/claude-code-marketplace`
-2. **npx (skills.sh)** — `npx skills add <repo-url> --skill <name>`
-3. **Release download** — GitHub Releases (skill files only)
-4. **Git clone** — direct clone
+1. **Marketplace** (recommended) — `/plugin marketplace add netresearch/claude-code-marketplace`, then `/plugin install <plugin-name>@netresearch-claude-code-marketplace`
+2. **Skills directory** — clone into `~/.claude/skills/<plugin-name>/`; loads as `<plugin-name>@skills-dir`, no marketplace (Claude Code 2.1.157+)
+3. **npx (skills.sh)** — `npx skills add <repo-url> --skill <name>` (skills only: drops hooks, agents, commands, `bin/`)
+4. **Release download** — GitHub Releases (skill files only)
 5. **Composer** — `composer require netresearch/<repo-name>` (PHP projects)
 6. **npm** — coordinator + `github:<org>/<repo>` (Node projects)
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,6 @@ npx skills add https://github.com/netresearch/skill-repo-skill --skill skill-rep
 
 Download the [latest release](https://github.com/netresearch/skill-repo-skill/releases/latest) and extract to your agent’s skills directory.
 
-### Git clone
-
-```bash
-git clone https://github.com/netresearch/skill-repo-skill.git
-```
-
 ### Composer (PHP projects)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Install with any [Agent Skills](https://agentskills.io)-compatible agent:
 npx skills add https://github.com/netresearch/skill-repo-skill --skill skill-repo
 ```
 
+> **Limitation:** `npx skills` installs `SKILL.md`-based skills only. It reads `.claude-plugin/plugin.json` to *locate* skills, not to register a plugin, so `hooks/`, `agents/`, `commands/`, `bin/` and `.mcp.json` are left out. Use the marketplace or the skills directory when a repo ships any of those.
+
 ### Download release
 
 Download the [latest release](https://github.com/netresearch/skill-repo-skill/releases/latest) and extract to your agent’s skills directory.

--- a/skills/skill-repo/references/installation-methods.md
+++ b/skills/skill-repo/references/installation-methods.md
@@ -3,13 +3,14 @@
 ## Contents
 
 - Method 1: Netresearch Marketplace (Recommended)
-- Method 2: Download Release
-- Method 3: Composer (PHP Projects)
-- Method 4: npm (Node Projects)
+- Method 2: Skills Directory (no marketplace)
+- Method 3: Download Release
+- Method 4: Composer (PHP Projects)
+- Method 5: npm (Node Projects)
 - Choosing a Method
 - Directory Locations
 
-Four methods for installing Netresearch skills.
+Five methods for installing Netresearch skills.
 
 ## Method 1: Netresearch Marketplace (Recommended)
 
@@ -27,18 +28,83 @@ The marketplace aggregates all Netresearch skills in one place.
 # Browse available plugins
 /plugin
 
-# Install specific skill
-/plugin install {skill-name}
+# Install a specific plugin
+/plugin install {plugin-name}@netresearch-claude-code-marketplace
 ```
+
+`{plugin-name}` is the `name` field of the repo's entry in the catalog's
+`marketplace.json`, which is **not** always the repo name — `jira-skill` is
+`jira-integration`, `matrix-skill` is `matrix-communication`,
+`php-ast-edit-skill` is `php-structured-edit`. Read the name from the catalog,
+never derive it from the repo slug.
+
+### Do not point `marketplace add` at a skill repo
+
+```bash
+# WRONG — fails with: Marketplace file not found at .../marketplace.json
+/plugin marketplace add netresearch/{repo-name}
+```
+
+`marketplace add` requires the target repo to contain a
+`.claude-plugin/marketplace.json` **catalog**. Skill repos ship a
+`.claude-plugin/plugin.json` **plugin manifest** instead, so this fails. The
+catalog is `netresearch/claude-code-marketplace`; its entries point back at
+each skill repo as their source, so installing from it still fetches the code
+from this repo.
 
 ### Benefits
 
 - Curated collection
-- Automatic updates via sync
+- Automatic updates — the only route with `claude plugin update` and a version in `/plugin`
 - Easy discovery
 - No manual file management
 
-## Method 2: Download Release
+## Method 2: Skills Directory (no marketplace, Claude Code 2.1.157+)
+
+Since Claude Code 2.1.157: *"Plugins in `.claude/skills` directories are now
+automatically loaded, no marketplace required."* Any folder under a skills
+directory containing `.claude-plugin/plugin.json` loads as
+`{plugin-name}@skills-dir` on the next session — discovered in place, not
+copied into the plugin cache.
+
+### Installation
+
+```bash
+git clone https://github.com/netresearch/{repo-name}.git \
+  ~/.claude/skills/{plugin-name}
+```
+
+### What loads
+
+Personal scope (`~/.claude/skills/`) loads the whole plugin — skills, agents,
+hooks, commands, `bin/`, `.mcp.json`, `.lsp.json` — with no restrictions.
+
+Project scope (`<cwd>/.claude/skills/`, checked into a repo) loads only after
+the workspace trust dialog, and restricts what runs: MCP servers need
+per-server approval, LSP servers start only after trust, and background
+monitors do not load at all. Project-scope plugins are found only in the
+session's primary working directory — they do not walk up to the repo root, so
+launch from the repo root or move there with `/cd` (2.1.246+).
+
+### Update and removal
+
+```bash
+git -C ~/.claude/skills/{plugin-name} pull   # update
+rm -rf ~/.claude/skills/{plugin-name}        # remove
+claude plugin disable {plugin-name}@skills-dir  # keep on disk, stop loading
+```
+
+There is no uninstall step, because nothing was installed from a marketplace.
+`SKILL.md` edits apply immediately; changes to `hooks/`, `.mcp.json`,
+`agents/` and output styles need `/reload-plugins` or a restart.
+
+### Trade-off vs. the marketplace
+
+No `claude plugin update`, no version in `/plugin`, no discovery — updating is
+whatever `git pull` gives you. Use it for pinning to a branch or working from
+a local checkout; prefer the marketplace otherwise.
+
+## Method 3: Download Release
 
 Download packaged skill files from GitHub Releases.
 
@@ -67,7 +133,7 @@ Release packages contain only skill-relevant files:
 - `composer.json` (separate distribution)
 - Dev configuration files
 
-## Method 3: Composer (PHP Projects)
+## Method 4: Composer (PHP Projects)
 
 For PHP projects, install skills as Composer packages.
 
@@ -100,7 +166,7 @@ composer require netresearch/{repo-name}
 - Project-specific skill sets
 - Easy updates with `composer update`
 
-## Method 4: npm (Node Projects)
+## Method 5: npm (Node Projects)
 
 For Node.js / TypeScript projects, install skills as npm packages discovered by `@netresearch/agent-skill-coordinator`.
 
@@ -207,6 +273,8 @@ The npm path registers only `SKILL.md` content into `AGENTS.md`. **Slash command
 |----------|-------------------|
 | General Claude Code use | Marketplace |
 | Offline/air-gapped | Release download |
+| Repo not in the catalog | Skills directory |
+| Pinning to a branch, or hacking on the skill | Skills directory |
 | PHP project | Composer |
 | Node / TypeScript project | npm |
 | CI/CD automation | Composer or npm |
@@ -217,6 +285,7 @@ The npm path registers only `SKILL.md` content into `AGENTS.md`. **Slash command
 | Method | Location |
 |--------|----------|
 | Marketplace | Managed by Claude Code |
+| Skills directory | `~/.claude/skills/{plugin-name}/` (loaded in place) |
 | Release | `~/.claude/skills/{skill-name}/` |
 | Composer | `vendor/netresearch/{repo-name}/` |
 | npm | `node_modules/@netresearch/{repo-name}/` |

--- a/skills/skill-repo/references/installation-methods.md
+++ b/skills/skill-repo/references/installation-methods.md
@@ -70,6 +70,7 @@ copied into the plugin cache.
 ### Installation
 
 ```bash
+mkdir -p ~/.claude/skills
 git clone https://github.com/netresearch/{repo-name}.git \
   ~/.claude/skills/{plugin-name}
 ```

--- a/skills/skill-repo/references/marketplace-integration.md
+++ b/skills/skill-repo/references/marketplace-integration.md
@@ -159,8 +159,15 @@ Updated in `.claude-plugin/marketplace.json`:
 ### Install Skill
 
 ```bash
-/plugin install {skill-name}
+/plugin install {plugin-name}@netresearch-claude-code-marketplace
 ```
+
+`{plugin-name}` is the entry's `name` in the catalog, not necessarily the repo
+name. `marketplace add` must point at the catalog repo — pointing it at an
+individual skill repo fails, because a skill repo ships
+`.claude-plugin/plugin.json`, not `.claude-plugin/marketplace.json`. See
+[`installation-methods.md`](installation-methods.md) for the marketplace-free
+skills-directory route.
 
 ## Benefits of Marketplace Distribution
 

--- a/skills/skill-repo/references/readme-template.md
+++ b/skills/skill-repo/references/readme-template.md
@@ -29,7 +29,7 @@ Use **exact** level-2 headings so agents can grep them:
 - `## Context requirements`
 - `## Example prompts` — **minimum three** fenced or bulleted realistic prompts (distinct scenarios).
 - `## Related skills` — slugs/URLs **or** explicit `none (justified: …)`.
-- `## Installation` — must include Netresearch marketplace path (`/plugin marketplace add netresearch/claude-code-marketplace`) **or** pointer to org-standard install doc.
+- `## Installation` — must include the Netresearch marketplace path, **both** lines (`/plugin marketplace add netresearch/claude-code-marketplace` followed by `/plugin install {plugin-name}@netresearch-claude-code-marketplace`), **or** a pointer to the org-standard install doc. The `marketplace add` target is always the catalog repo — never the skill's own repo, which has no `marketplace.json` and fails.
 - `## Contributing`
 - `## License`
 

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -49,11 +49,27 @@
 
 ### Marketplace (recommended)
 
-Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-marketplace) once, then browse and install skills:
+Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-marketplace) once, then install this plugin from it:
 
 ```bash
 /plugin marketplace add netresearch/claude-code-marketplace
+/plugin install {plugin-name}@netresearch-claude-code-marketplace
 ```
+
+`{plugin-name}` is the `name` this repo has in the marketplace catalog, which is not always the repo name. Only this route supports `claude plugin update` and shows a version in `/plugin`.
+
+> **Do not** run `/plugin marketplace add netresearch/{repo-name}`. `marketplace add` requires a `.claude-plugin/marketplace.json` catalog; this repo ships a `.claude-plugin/plugin.json` plugin manifest, so pointing it here fails with `Marketplace file not found`.
+
+### Without a marketplace: skills directory (Claude Code 2.1.157+)
+
+Clone the repo into your personal skills directory. Claude Code loads any folder there that has a `.claude-plugin/plugin.json` as `{plugin-name}@skills-dir` on the next session — with no install step, and including hooks, agents and commands:
+
+```bash
+git clone https://github.com/netresearch/{repo-name}.git \
+  ~/.claude/skills/{plugin-name}
+```
+
+Update with `git pull`. There is no uninstall step: delete the directory, or run `claude plugin disable {plugin-name}@skills-dir`.
 
 ### npx ([skills.sh](https://skills.sh))
 
@@ -63,15 +79,11 @@ Install with any [Agent Skills](https://agentskills.io)-compatible agent:
 npx skills add https://github.com/netresearch/{repo-name} --skill {skill-name}
 ```
 
+> **Limitation:** `npx skills` installs `SKILL.md`-based skills only. It reads `.claude-plugin/plugin.json` to *locate* skills, not to register a plugin, so `hooks/`, `agents/`, `commands/`, `bin/` and `.mcp.json` are silently left out. Repos shipping any of those need the marketplace or skills-directory route for full functionality.
+
 ### Download release
 
 Download the [latest release](https://github.com/netresearch/{repo-name}/releases/latest) and extract to your agent’s skills directory.
-
-### Git clone
-
-```bash
-git clone https://github.com/netresearch/{repo-name}.git
-```
 
 ### Composer (PHP projects)
 

--- a/skills/skill-repo/templates/README.md.template
+++ b/skills/skill-repo/templates/README.md.template
@@ -62,14 +62,15 @@ Add the [Netresearch marketplace](https://github.com/netresearch/claude-code-mar
 
 ### Without a marketplace: skills directory (Claude Code 2.1.157+)
 
-Clone the repo into your personal skills directory. Claude Code loads any folder there that has a `.claude-plugin/plugin.json` as `{plugin-name}@skills-dir` on the next session — with no install step, and including hooks, agents and commands:
+Clone the repo into your personal skills directory. Claude Code loads any folder there that has a `.claude-plugin/plugin.json` as `{plugin-name}@skills-dir` on the next session — with no install step, and including any hooks, agents and commands it ships:
 
 ```bash
+mkdir -p ~/.claude/skills
 git clone https://github.com/netresearch/{repo-name}.git \
   ~/.claude/skills/{plugin-name}
 ```
 
-Update with `git pull`. There is no uninstall step: delete the directory, or run `claude plugin disable {plugin-name}@skills-dir`.
+Update with `git -C ~/.claude/skills/{plugin-name} pull` and start a new session. There is no uninstall step: delete the directory, or run `claude plugin disable {plugin-name}@skills-dir`.
 
 ### npx ([skills.sh](https://skills.sh))
 


### PR DESCRIPTION
Reported downstream in netresearch/retro-skill#90: the documented install steps fail. This fixes the canonical text that 31 fleet READMEs drifted from.

## The defect

`/plugin marketplace add netresearch/<skill-repo>` cannot work. `marketplace add` requires the target repo to contain a `.claude-plugin/marketplace.json` **catalog**; a skill repo ships a `.claude-plugin/plugin.json` **plugin manifest**. Reproduced against the real repo on Claude Code 2.1.263 (reporter saw it on 2.1.236):

```
$ claude plugin marketplace add netresearch/retro-skill
✘ Failed to add marketplace: Marketplace file not found at
  ~/.claude/plugins/marketplaces/netresearch-retro-skill/.claude-plugin/marketplace.json
```

The catalog is `netresearch/claude-code-marketplace`. Its entries point back at each skill repo as their `source`, so installing from the catalog still fetches code from the skill repo — only the `marketplace add` target differs.

The install line was incomplete as well: `/plugin install <name>@<marketplace>` takes the **catalog entry name**, which is not always the repo name — `jira-skill` is `jira-integration`, `matrix-skill` is `matrix-communication`, `php-ast-edit-skill` is `php-structured-edit`.

## What changed

- **`templates/README.md.template`** — both install lines, an explicit "do not point `marketplace add` here" callout, and a new skills-directory section. Drops the bare `git clone` entry, which cloned into the current directory and installed nothing.
- **`references/installation-methods.md`** — Method 1 corrected; new Method 2 for the skills directory, including the personal- vs project-scope restrictions; methods renumbered; both summary tables updated.
- **`references/marketplace-integration.md`** — install line corrected, with a pointer to the marketplace-free route.
- **`references/readme-template.md`** — the `## Installation` requirement now demands both lines and names the catalog as the only valid `marketplace add` target.
- **`README.md`** — this repo's own install section, same fix, and the bare `git clone` entry removed: it cloned into the current directory, which no skills directory scans.

## Marketplace-free route, now documented

Claude Code 2.1.157: *"Plugins in `.claude/skills` directories are now automatically loaded, no marketplace required."* A repo cloned to `~/.claude/skills/<plugin-name>/` loads as `<plugin-name>@skills-dir` with hooks, agents and commands included. Personal scope has no restrictions; project scope (`.claude/skills/` in a repo) gates MCP per server, starts LSP only after workspace trust, and does not load monitors at all.

It stays the secondary route: no `claude plugin update`, no version in `/plugin`, no discovery.

## npx (skills.sh) claim bounded

The template recommended `npx skills add` unconditionally. Per its own README it installs `SKILL.md`-based skills only, reading `plugin.json` to *locate* skills rather than to register a plugin — so `hooks/`, `agents/`, `commands/`, `bin/` and `.mcp.json` are silently dropped. **19 fleet repos ship at least one of those**, so the note now says what gets lost.

## Verification

- Failure and error message reproduced against the live repo on 2.1.263; probe cleaned up, marketplace list unchanged.
- 2.1.157 changelog entry quoted verbatim from `anthropics/claude-code`.
- Scope and restriction wording taken from the `plugins-reference` "Skills-directory plugins" section, read raw rather than summarized.
- `markdownlint-cli2` clean on all four changed Markdown files; pre-commit hooks passed.

Note: `check-template-drift.yml` governs `.github/` trees only, so nothing enforces README install text across the fleet. The remaining repos need a separate sweep: 30 on GitHub, plus `dxp-frontend-skill` on git.netresearch.de, whose fix points at the internal `coding-ai/marketplace` catalog instead.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_
