### PR TITLE
fix(fleet-release): treat lint-config churn as a CI-only delta

### DIFF
--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -49,10 +49,15 @@ FR_RELEASE_TIMEOUT="${FR_RELEASE_TIMEOUT:-600}"
 FR_SELF_LOGIN="${FR_SELF_LOGIN:-}"        # resolved by the driver (gh/glab)
 FR_BRANCH_PREFIX="release/v"              # owned by github-release-skill
 FR_COMMIT_PREFIX="chore(release): v"      # owned by github-release-skill
-# CI-only delta filter: commits touching only these paths ship a byte-identical
-# archive — not a release (release-discipline.md).
+# CI-only delta filter: commits touching only these paths make no
+# consumer-visible change, so they are not a release (release-discipline.md).
+# Note the test is "nothing a consumer can observe", not "byte-identical
+# archive": the lint configs below DO travel inside the release archive, but a
+# hook-pin bump changes nothing about the skill a consumer installs. The
+# `.github/**` entries are byte-identical as well; the others are not, and that
+# is deliberate.
 # shellcheck disable=SC2034  # consumed by the host drivers' survey callbacks
-FR_CI_ONLY_RE='^\.github/|^\.gitlab-ci\.yml$|^renovate\.json$'
+FR_CI_ONLY_RE='^\.github/|^\.gitlab-ci\.yml$|^renovate\.json$|^\.pre-commit-config\.yaml$|^\.markdownlint(-cli2)?\.jsonc$|^\.yamllint\.yml$|^\.editorconfig$'
 # The only files a bump commit may touch.
 FR_ALLOWLIST_RE='^(plugin\.json|\.claude-plugin/plugin\.json|skills/[^/]+/SKILL\.md|CHANGELOG\.md)$'
 # Version-aware compare/sort, shared by every jq call site. Extracts the

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -236,6 +236,32 @@ check "classify: UNREACHABLE" UNREACHABLE \
     "$(fr_classify '{"host":"test","repo":"gone","unreachable":true}')"
 check "classify: EMPTY" EMPTY \
     "$(fr_classify '{"host":"test","repo":"bare","resolved":"o/bare","empty":true}')"
+
+# --- FR_CI_ONLY_RE ----------------------------------------------------------
+# The survey counts a changed path as consumer-visible unless this filter
+# matches it; nonci=0 is what turns a row into SKIP-CI-ONLY. Exercised through
+# the same jq `test()` the driver uses, so a pattern valid in grep but not in
+# Oniguruma fails here rather than in a live sweep.
+nonci() { # FILES-JSON -> count of paths the filter does NOT absorb
+    jq --arg f "$FR_CI_ONLY_RE" '[.[] | select(test($f) | not)] | length' <<< "$1"
+}
+check "ci-only: workflow file" 0 "$(nonci '[".github/workflows/tests.yml"]')"
+check "ci-only: renovate.json" 0 "$(nonci '["renovate.json"]')"
+check "ci-only: .gitlab-ci.yml" 0 "$(nonci '[".gitlab-ci.yml"]')"
+check "ci-only: pre-commit hook pin (#287)" 0 "$(nonci '[".pre-commit-config.yaml"]')"
+check "ci-only: markdownlint configs" 0 \
+    "$(nonci '[".markdownlint-cli2.jsonc",".markdownlint.jsonc"]')"
+check "ci-only: yamllint and editorconfig" 0 \
+    "$(nonci '[".yamllint.yml",".editorconfig"]')"
+# The filter must not swallow anything a consumer installs.
+check "not ci-only: SKILL.md" 1 "$(nonci '["skills/foo/SKILL.md"]')"
+check "not ci-only: README.md" 1 "$(nonci '["README.md"]')"
+check "not ci-only: plugin manifest" 1 "$(nonci '[".claude-plugin/plugin.json"]')"
+# Anchored at the repo root: a config shipped inside a skill is content.
+check "not ci-only: nested pre-commit config" 1 \
+    "$(nonci '["skills/foo/templates/.pre-commit-config.yaml"]')"
+check "not ci-only: mixed delta still counts the content file" 1 \
+    "$(nonci '[".pre-commit-config.yaml","skills/foo/SKILL.md"]')"
 # A FAILED compare measurement (sentinel -1) must never read as "no delta" —
 # that silently drops a repo with releasable commits from the sweep.
 check "classify: failed compare is SURVEY-INCOMPLETE, never UP-TO-DATE" SURVEY-INCOMPLETE \


### PR DESCRIPTION
Closes #287.

`FR_CI_ONLY_RE` did not list `.pre-commit-config.yaml`, so a repo whose only delta was a Renovate hook-pin bump counted as a consumer-visible change and classified `BUMP` instead of `SKIP-CI-ONLY`. Once the pre-commit manager was enabled fleet-wide this fired almost everywhere at once — 21 of 31 rows in the 2026-09-05 survey, each showing `Non-CI: 1` for that single file. A sweep trusting the classification ships 21 releases whose skill content is byte-for-byte the previous tag.

## Scope beyond the one file

The issue asked whether the sibling lint configs belong in the same class. They do, so they are included — but measured against the fleet first rather than added on the strength of the argument:

| File | Repos that have it |
|---|---|
| `.pre-commit-config.yaml` | 39 |
| `.yamllint.yml` | 38 |
| `.markdownlint-cli2.jsonc` | 36 |
| `.markdownlint.jsonc` | 18 |
| `.editorconfig` | 1 |

## The comment was wrong, not just incomplete

It claimed these paths "ship a byte-identical archive". That holds for `.github/**`; it does not hold for the lint configs, which do travel inside the release archive. The comment now states the test actually being applied — no consumer-visible change — and says explicitly that the two groups differ in this respect, so the next person extending the constant is not misled into checking the wrong property.

## Tests

`FR_CI_ONLY_RE` had no coverage at all. The new cases drive it through the same `jq test()` call the survey uses, so a pattern that is valid in grep but not in Oniguruma fails here rather than mid-sweep. They pin both directions — what the filter absorbs, and what it must not: `SKILL.md`, `README.md`, `.claude-plugin/plugin.json`, and a `.pre-commit-config.yaml` nested inside a skill's templates, which is content and must stay counted.

**Seen to fail before being trusted.** Against the old regex, four of the new cases go red with the expected counts:

```
FAIL ci-only: pre-commit hook pin (#287): expected '0', got '1'
FAIL ci-only: markdownlint configs: expected '0', got '2'
FAIL ci-only: yamllint and editorconfig: expected '0', got '2'
FAIL not ci-only: mixed delta still counts the content file: expected '1', got '2'
```

With the fix the full suite passes and `shellcheck -x` is clean on both changed files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_
