### PR TITLE
fix(fleet-release): route every gh api capture through gh_json

### DIFF
--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -25,7 +25,8 @@
 # Normalized survey row schema (both hosts emit exactly these keys):
 #   host repo resolved default archived empty unreachable duplicate_of
 #   last_release last_tag root_plugin claude_plugin composer_has_version
-#   release_gate ci_status ahead nonci changelog_unreleased files_truncated subjects files
+#   release_gate ci_status ahead nonci changelog_unreleased files_truncated
+#   tags_failed subjects files
 #   open_release_prs [{id,url,author,branch,title}] ci_tag_rules notes
 #
 # Every phase writes into $FR_WORKDIR:
@@ -412,6 +413,11 @@ fr_classify() { # ROW-JSON — one shared implementation for both hosts; blocks
         elif ([.open_release_prs[]? | select(.author != $self)] | length) > 0 then "BLOCKED-FOREIGN-PR"
         elif ([.open_release_prs[]? | select(.author == $self)] | length) > 0 then "OWN-PR-OPEN"
         elif .release_gate == false then "NO-RELEASE-JOB"
+        # Before FIRST-RELEASE, deliberately: a failed tag query leaves
+        # last_tag empty, which is indistinguishable from "never tagged" and
+        # would offer an initial tag over an existing history. Placed here and
+        # not in the else-branch because every branch below reads last_tag.
+        elif (.tags_failed // false) == true then "SURVEY-INCOMPLETE"
         elif (.last_release // "") == "" and (.last_tag // "") == "" then "FIRST-RELEASE"
         elif (.last_tag // "") != "" and (.last_tag != (.last_release // "")) then "TAG-RELEASE-DIVERGED"
         else
@@ -477,7 +483,10 @@ fr_manifest() {
                   then "CHANGELOG [Unreleased] is empty — write the release entries before the bump phase, or its roll fails on exactly this"
                   else empty end),
                  (if $cls == "SURVEY-INCOMPLETE"
-                  then "the compare MEASUREMENT failed (this is not a no-delta result) — re-run survey --repos \(.repo)"
+                  then (if (.tags_failed // false) == true
+                        then "the TAG QUERY failed (this is not an untagged repo) — re-run survey --repos \(.repo)"
+                        else "the compare MEASUREMENT failed (this is not a no-delta result) — re-run survey --repos \(.repo)"
+                        end)
                   else empty end),
                  (if (.ci_tag_rules // "") != ""
                   then "tag rules: " + (.ci_tag_rules | gsub("\\|"; "¦"))

--- a/skills/skill-repo/scripts/fleet-release-github.sh
+++ b/skills/skill-repo/scripts/fleet-release-github.sh
@@ -99,11 +99,17 @@ host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
     # into ["Not Found", …]. The map(.name) below then fails, last_tag comes
     # back empty, and a rate-limited repo classifies FIRST-RELEASE — the survey
     # would offer to tag v1.0.0 over an existing history.
+    local tags_failed=false
     if tags=$(gh_json --paginate "repos/$FR_ORG/$r/tags?per_page=100"); then
-        tags=$(jq -s '[.[][]]' <<< "$tags" 2> /dev/null || echo '[]')
+        tags=$(jq -s '[.[][]]' <<< "$tags" 2> /dev/null) || { tags='[]'; tags_failed=true; }
     else
         tags='[]'
+        tags_failed=true
     fi
+    # A failed query is NOT an empty tag list. Conflating them is how a
+    # rate-limited repo reaches FIRST-RELEASE, so the failure travels in the row
+    # and fr_classify turns it into SURVEY-INCOMPLETE — the same convention the
+    # negative ahead/nonci sentinels already use for a failed compare.
     last_tag=$(jq -r "$FR_JQ_VPARSE"' map(.name) | max_by(vparse) // empty' <<< "$tags")
 
     local rootv cpv composer_has_version release_gate
@@ -195,13 +201,14 @@ host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
         --arg ci "$ci_status" --argjson ahead "$ahead" --argjson nonci "$nonci" \
         --argjson subjects "$subjects" --argjson files "$files" \
         --argjson trunc "$files_truncated" --argjson prs "$prs" \
-        --arg clstate "$cl_state" \
+        --arg clstate "$cl_state" --argjson tagsfailed "$tags_failed" \
         '{host: $host, repo: $repo, resolved: $resolved, default: $def, head: $head,
           archived: $archived, empty: false, unreachable: false, duplicate_of: "",
           last_release: $rel, last_tag: $last_tag,
           root_plugin: $rootv, claude_plugin: $cpv,
           composer_has_version: $chv, release_gate: $gate, ci_status: $ci,
           ahead: $ahead, nonci: $nonci, files_truncated: $trunc,
+          tags_failed: $tagsfailed,
           changelog_unreleased: $clstate,
           subjects: $subjects, files: $files,
           open_release_prs: $prs, ci_tag_rules: "", notes: ""}'

--- a/skills/skill-repo/scripts/fleet-release-github.sh
+++ b/skills/skill-repo/scripts/fleet-release-github.sh
@@ -66,6 +66,18 @@ gh_json() { # ARGS... — gh api that NEVER leaks an HTTP error body as data:
     return 1
 }
 
+fr_resolve_self_login() { # set FR_SELF_LOGIN, or die — never leave it poisoned.
+    # `gh api user --jq .login` applies the filter to the ERROR body too, so an
+    # expired token yields the string "null". The author gate then compares
+    # every PR author against "null" and classifies the sweep's own PRs as
+    # BLOCKED-FOREIGN-PR. Failing here says why; a statement, not a $( ), so
+    # fr_die ends the run instead of a subshell.
+    [[ -n "$FR_SELF_LOGIN" ]] && return 0
+    FR_SELF_LOGIN=$(gh_json user | jq -r '.login // empty') || FR_SELF_LOGIN=""
+    [[ -n "$FR_SELF_LOGIN" ]] \
+        || fr_die "cannot resolve the authenticated gh login — check 'gh auth status'"
+}
+
 host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
     local r="$1" meta resolved archived def
     meta=$(gh_json "repos/$FR_ORG/$r") || return 1
@@ -82,8 +94,16 @@ host_survey_repo() { # REPO — one normalized row on stdout, or exit 1
     # (a release workflow that ran and died). The tags list tells them apart —
     # and it is NOT date-ordered, so pick the max by version, never .[0].
     # --paginate: one page would hide the newest tag of a >100-tag repo.
-    tags=$(gh api --paginate "repos/$FR_ORG/$r/tags?per_page=100" 2> /dev/null \
-        | jq -s '[.[][]]' || echo '[]')
+    # Same poisoned-capture class as host_release_verify: on 403/404 gh prints
+    # the error body to STDOUT, and `[.[][]]` happily flattens {"message":…}
+    # into ["Not Found", …]. The map(.name) below then fails, last_tag comes
+    # back empty, and a rate-limited repo classifies FIRST-RELEASE — the survey
+    # would offer to tag v1.0.0 over an existing history.
+    if tags=$(gh_json --paginate "repos/$FR_ORG/$r/tags?per_page=100"); then
+        tags=$(jq -s '[.[][]]' <<< "$tags" 2> /dev/null || echo '[]')
+    else
+        tags='[]'
+    fi
     last_tag=$(jq -r "$FR_JQ_VPARSE"' map(.name) | max_by(vparse) // empty' <<< "$tags")
 
     local rootv cpv composer_has_version release_gate
@@ -278,7 +298,11 @@ host_release_verify() { # REPO TAG — a pushed tag is not a release; assert the
     local r="$1" tag="$2" deadline rel assets
     deadline=$(($(date +%s) + FR_RELEASE_TIMEOUT))
     while true; do
-        rel=$(gh api "repos/$FR_ORG/$r/releases/tags/$tag" 2> /dev/null || echo "")
+        # gh_json, not a bare capture: while the Release workflow is queued
+        # this 404s, and gh prints the error body to STDOUT, so `|| echo ""`
+        # leaves {"message":"Not Found"} in $rel — non-empty, and the jq below
+        # then errors on every poll of every repo (19 batch logs, 2026-09-03).
+        rel=$(gh_json "repos/$FR_ORG/$r/releases/tags/$tag") || rel=""
         if [[ -n "$rel" ]]; then
             assets=$(jq '[.assets[].name] | length' <<< "$rel")
             if [[ "$assets" -gt 0 ]]; then
@@ -334,17 +358,17 @@ case "$CMD" in
         fr_survey $REPOS
         ;;
     manifest)
-        FR_SELF_LOGIN="${FR_SELF_LOGIN:-$(gh api user --jq .login)}"
+        fr_resolve_self_login
         fr_preflight manifest gh
         fr_manifest
         ;;
     bump)
-        FR_SELF_LOGIN="${FR_SELF_LOGIN:-$(gh api user --jq .login)}"
+        fr_resolve_self_login
         fr_preflight bump gh
         fr_bump "$PLAN"
         ;;
     finish)
-        FR_SELF_LOGIN="${FR_SELF_LOGIN:-$(gh api user --jq .login)}"
+        fr_resolve_self_login
         fr_preflight finish gh
         fr_finish "$PLAN" "$CONTINUE"
         ;;

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -460,6 +460,19 @@ else
     echo "  skip manifest golden tests (gh not installed)"
 fi
 
+# --- poisoned-capture invariant ---------------------------------------------
+# `gh` prints HTTP error bodies to STDOUT, so `$(gh api …)` captures the error
+# as data: the caller sees non-empty output and parses {"message":"Not Found"}
+# as if it were the resource. gh_json exists to make that impossible, and the
+# only legitimate `$(gh api` in the driver is the one inside it. This is a
+# source invariant rather than a behavioural test because the survey and
+# release-verify paths are network-bound and out of this suite's offline scope.
+# shellcheck disable=SC2016  # the patterns are literal source text, not expansions
+stray_api=$(grep -n '\$(gh api' "$SCRIPTS/fleet-release-github.sh" \
+    | grep -Ev '^[0-9]+: *#' \
+    | grep -Fv 'out=$(gh api "$@"' || true)
+check "no bare \$(gh api ...) capture outside gh_json" "" "$stray_api"
+
 echo
 if [ "$fail" -eq 0 ]; then
     echo "All fleet-release tests passed"

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -460,6 +460,24 @@ else
     echo "  skip manifest golden tests (gh not installed)"
 fi
 
+# --- a failed tag query is not an untagged repo ------------------------------
+# A 403 or rate-limit on the tags endpoint leaves last_tag empty, which reads
+# exactly like "never tagged" and would offer an initial tag over an existing
+# history. The row carries the failure instead.
+check "classify: tags_failed outranks FIRST-RELEASE" SURVEY-INCOMPLETE \
+    "$(fr_classify "$(row '.tags_failed = true | .last_release = "" | .last_tag = ""')")"
+check "classify: tags_failed outranks a normal BUMP row" SURVEY-INCOMPLETE \
+    "$(fr_classify "$(row '.tags_failed = true')")"
+# Blocks still outrank it: an archived repo is archived whether or not the tag
+# query answered.
+check "classify: BLOCKED-ARCHIVED still outranks tags_failed" BLOCKED-ARCHIVED \
+    "$(fr_classify "$(row '.tags_failed = true | .archived = true')")"
+# A row from a driver that does not emit the key at all must behave as before.
+check "classify: absent tags_failed is not a failure" BUMP \
+    "$(fr_classify "$(row 'del(.tags_failed)')")"
+check "classify: tags_failed = false is not a failure" BUMP \
+    "$(fr_classify "$(row '.tags_failed = false')")"
+
 # --- poisoned-capture invariant ---------------------------------------------
 # `gh` prints HTTP error bodies to STDOUT, so `$(gh api …)` captures the error
 # as data: the caller sees non-empty output and parses {"message":"Not Found"}


### PR DESCRIPTION
Closes #282.

`gh` prints HTTP error bodies to **stdout**, so `$(gh api … || echo "")` captures the error as data. This file's own `gh_json()` helper documents exactly that and exists to prevent it — and four call sites bypassed it.

## The reported one

`host_release_verify`: while the Release workflow is still queued the lookup 404s, so `$rel` held `{"message":"Not Found"}`, passed the non-empty test, and the `jq` below ran against a document with no `.assets`:

```
jq: error (at <stdin>:1): Cannot iterate over null (null)
```

Not fatal — the poll loop recovers — but it fired on every poll of every repo, in all 19 batch logs of the 2026-09-03 sweep, which is what makes a genuine failure hard to see.

## Three more of the same class

The issue suggested checking the other captures on this path. Two of the three are worse than the reported one:

**The tag list** (`host_survey_repo`) used the same shape, and `[.[][]]` does not fail on an error body — it flattens it into a valid array. Measured rather than assumed:

```
$ echo '{"message":"API rate limit exceeded","documentation_url":"…","status":"403"}' | jq -s '[.[][]]'
["API rate limit exceeded", "https://docs.github.com/rest", "403"]
$ … | jq -r 'map(.name) | max_by(.)'
jq: error: Cannot index string with string ("name")
```

So `last_tag` comes back empty and the repo classifies **FIRST-RELEASE**. A rate-limited survey would offer to tag `v1.0.0` over an existing history.

**Review round 2 (CodeRabbit, addressed in 2ab0dc3).** Routing the call through `gh_json` stopped the error body being parsed as data, but the first version still assigned `tags='[]'` on failure — which conflates *the query failed* with *the repo has no tags*. The FIRST-RELEASE outcome above therefore survived the very fix that named it as the danger. The failure now travels in the survey row as `tags_failed`, and `fr_classify` maps it to `SURVEY-INCOMPLETE` — the convention this engine already uses for a failed compare (negative `ahead`/`nonci`). The branch sits *before* the FIRST-RELEASE check rather than in the else-branch, because every branch below it reads `last_tag`. Blocks still outrank it, a driver that does not emit the key is unaffected via `// false`, and the manifest note now names which measurement failed instead of always blaming the compare.

**`FR_SELF_LOGIN`**, at three call sites, had the third variant: `gh api user --jq .login` applies the filter to the error body too, so an expired token yields the literal string `"null"`. The author gate compares every PR author against that, so the sweep's own PRs classify `BLOCKED-FOREIGN-PR`. Now resolved by `fr_resolve_self_login`, called as a statement rather than inside `$( )` — in a command substitution `fr_die` would only end the subshell and the run would continue with an empty login.

## Guard

A source invariant: no bare `$(gh api` capture may exist outside `gh_json` itself. Verified by re-injecting the original line, at which point it fails and names it:

```
FAIL no bare $(gh api ...) capture outside gh_json: expected '', got
'305:        rel=$(gh api "repos/$FR_ORG/$r/releases/tags/$tag" 2> /dev/null || echo "")'
```

The `tags_failed` classification is covered behaviourally: five cases pin it against FIRST-RELEASE, against a plain BUMP row, against a block that must still outrank it, and against rows from a driver that omits the key. Removing the sentinel branch reddens them and they report `FIRST-RELEASE`, the symptom CodeRabbit named.

Stated plainly: the `gh api` invariant is a source check, not a behavioural one. The survey and release-verify paths are network-bound and sit outside this suite's offline scope, which the suite's own header already documents — so there is no test here proving the 404 path now behaves, only one proving the shape cannot return.

Full suite passes; `shellcheck -x` clean on both files.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_

