### PR TITLE
fix(roll-changelog): take the compare base from the headings

### DIFF
--- a/skills/skill-repo/scripts/roll-changelog.py
+++ b/skills/skill-repo/scripts/roll-changelog.py
@@ -289,6 +289,31 @@ def main() -> None:
         print(defs_note)
 
 
+def released_labels(lines):
+    """Tag labels of every released heading, document order, fences skipped.
+
+    The compare base for a new release is the heading directly below it, not
+    whatever [Unreleased] happened to point at — see update_link_reference_
+    definitions.
+    """
+    labels = []
+    for _, line, in_fence in scan(lines):
+        if in_fence:
+            continue
+        for rx in (LINKED_RE, BRACKETED_RE, BARE_PAREN_RE):
+            m = rx.match(line)
+            if m:
+                labels.append(m.group("tag"))
+                break
+    return labels
+
+
+def styled_tag(label, v_prefixed):
+    """Render `label` in the tag style the link definitions already use."""
+    bare = label.removeprefix("v")
+    return f"v{bare}" if v_prefixed else bare
+
+
 def update_link_reference_definitions(new_lines, new_heading, version):
     """Keep-a-changelog ref-style links: `[Unreleased]: …/compare/vOLD...HEAD`
     at the bottom, one definition per released heading. After a roll the
@@ -316,11 +341,36 @@ def update_link_reference_definitions(new_lines, new_heading, version):
                 f"[{version}] manually"
             )
         old = old_m.group(0)
-        new_tag = f"v{version}" if old.startswith("v") else version
+        v_prefixed = old.startswith("v")
+        new_tag = f"v{version}" if v_prefixed else version
         base = stem[: old_m.start()]
+
+        # The compare base comes from the HEADINGS, not from [Unreleased].
+        # [Unreleased] can be stale — an earlier roll that skipped a definition
+        # leaves it pointing several releases back, and inheriting it spans the
+        # new release across all of them (matrix-skill shipped
+        # v3.1.1...v3.1.3 that way).
+        labels = released_labels(new_lines)
+        head_label = head_m.group("label")
+        prev_label = labels[1] if len(labels) > 1 else None
+        prev_tag = styled_tag(prev_label, v_prefixed) if prev_label else old
+
         new_lines[i] = f"[{m.group('label')}]: {base}{new_tag}...HEAD"
-        new_lines.insert(i + 1, f"[{head_m.group('label')}]: {base}{old}...{new_tag}")
-        return f"updated link-reference definitions ([Unreleased] -> {new_tag}...HEAD)"
+        new_lines.insert(i + 1, f"[{head_label}]: {base}{prev_tag}...{new_tag}")
+
+        # A previous release with no definition of its own is what let the
+        # stale base survive in the first place; write it while we can still
+        # see the version below it.
+        note = f"updated link-reference definitions ([Unreleased] -> {new_tag}...HEAD)"
+        if prev_label is not None and len(labels) > 2:
+            have_prev = any(ln.startswith(f"[{prev_label}]:") for ln in new_lines)
+            if not have_prev:
+                prev2_tag = styled_tag(labels[2], v_prefixed)
+                new_lines.insert(
+                    i + 2, f"[{prev_label}]: {base}{prev2_tag}...{prev_tag}"
+                )
+                note += f"; backfilled the missing [{prev_label}] definition"
+        return note
     return None
 
 

--- a/skills/skill-repo/scripts/roll-changelog.py
+++ b/skills/skill-repo/scripts/roll-changelog.py
@@ -363,7 +363,16 @@ def update_link_reference_definitions(new_lines, new_heading, version):
         # see the version below it.
         note = f"updated link-reference definitions ([Unreleased] -> {new_tag}...HEAD)"
         if prev_label is not None and len(labels) > 2:
-            have_prev = any(ln.startswith(f"[{prev_label}]:") for ln in new_lines)
+            # Compared without the v prefix: a file may head its sections
+            # `## [v3.1.2]` while defining `[3.1.2]:`. A raw match would call
+            # the existing definition missing and add a second one under the
+            # other spelling.
+            want = prev_label.removeprefix("v")
+            have_prev = any(
+                ln.split("]:", 1)[0][1:].removeprefix("v") == want
+                for ln in new_lines
+                if ln.startswith("[") and "]:" in ln
+            )
             if not have_prev:
                 prev2_tag = styled_tag(labels[2], v_prefixed)
                 new_lines.insert(

--- a/tests/roll-changelog.sh
+++ b/tests/roll-changelog.sh
@@ -227,6 +227,54 @@ check "ref-style defs: [Unreleased] range restarts at the new tag" yes \
     "$(grep -qx '\[Unreleased\]: https://github.com/x/y/compare/v1.3.0...HEAD' "$f" && echo yes || echo no)"
 check "ref-style defs: the new release got its own definition" yes \
     "$(grep -qx '\[1.3.0\]: https://github.com/x/y/compare/v1.2.0...v1.3.0' "$f" && echo yes || echo no)"
+# The compare base comes from the headings, not from [Unreleased] (#281).
+# Reproduces matrix-skill: [Unreleased] still points at v3.1.1 and the [3.1.2]
+# definition was never written, so the old code shipped v3.1.1...v3.1.3.
+f="$WORK/refs-stale.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- change
+
+## [3.1.2] - 2026-02-01
+
+- mid
+
+## [3.1.1] - 2026-01-01
+
+- old
+
+[Unreleased]: https://github.com/x/y/compare/v3.1.1...HEAD
+[3.1.1]: https://github.com/x/y/compare/v3.1.0...v3.1.1
+EOF
+check "stale base: exits 0" 0 "$(roll "$f" 3.1.3 --date 2026-08-13)"
+check "stale base: new release compares against the heading below it" yes \
+    "$(grep -qx '\[3.1.3\]: https://github.com/x/y/compare/v3.1.2...v3.1.3' "$f" && echo yes || echo no)"
+check "stale base: NOT the stale [Unreleased] base" yes \
+    "$(grep -q 'compare/v3.1.1\.\.\.v3.1.3' "$f" && echo no || echo yes)"
+check "stale base: the missing [3.1.2] definition is backfilled" yes \
+    "$(grep -qx '\[3.1.2\]: https://github.com/x/y/compare/v3.1.1...v3.1.2' "$f" && echo yes || echo no)"
+check "stale base: [Unreleased] still restarts at the new tag" yes \
+    "$(grep -qx '\[Unreleased\]: https://github.com/x/y/compare/v3.1.3...HEAD' "$f" && echo yes || echo no)"
+
+# Unprefixed tag style must stay unprefixed on both ends of the range.
+f="$WORK/refs-bare.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- change
+
+## [2.0.0] - 2026-02-01
+
+- old
+
+[Unreleased]: https://github.com/x/y/compare/2.0.0...HEAD
+[2.0.0]: https://github.com/x/y/compare/1.9.0...2.0.0
+EOF
+check "bare tag style: exits 0" 0 "$(roll "$f" 2.1.0 --date 2026-08-13)"
+check "bare tag style: no v prefix leaks into the new range" yes \
+    "$(grep -qx '\[2.1.0\]: https://github.com/x/y/compare/2.0.0...2.1.0' "$f" && echo yes || echo no)"
+
 f="$WORK/refs-odd.md"
 printf '## [Unreleased]\n\n- a\n\n## [1.0.0] - 2026-01-01\n\n- b\n\n[Unreleased]: https://example.invalid/branches\n' > "$f"
 check "ref-style defs in an unknown shape: roll succeeds with a warning" 0 \

--- a/tests/roll-changelog.sh
+++ b/tests/roll-changelog.sh
@@ -257,6 +257,29 @@ check "stale base: the missing [3.1.2] definition is backfilled" yes \
 check "stale base: [Unreleased] still restarts at the new tag" yes \
     "$(grep -qx '\[Unreleased\]: https://github.com/x/y/compare/v3.1.3...HEAD' "$f" && echo yes || echo no)"
 
+# Headings and definitions may spell the tag differently. The backfill must see
+# the existing definition through that difference, or it writes a second one.
+f="$WORK/refs-mixed.md"
+cat > "$f" <<'EOF'
+## [Unreleased]
+
+- change
+
+## [v2.1.0] - 2026-02-01
+
+- mid
+
+## [v2.0.0] - 2026-01-01
+
+- old
+
+[Unreleased]: https://github.com/x/y/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/x/y/compare/v2.0.0...v2.1.0
+EOF
+check "mixed label style: exits 0" 0 "$(roll "$f" 2.2.0 --date 2026-08-13)"
+check "mixed label style: no duplicate definition for the previous version" 1 \
+    "$(grep -c 'compare/v2.0.0\.\.\.v2.1.0' "$f")"
+
 # Unprefixed tag style must stay unprefixed on both ends of the range.
 f="$WORK/refs-bare.md"
 cat > "$f" <<'EOF'


### PR DESCRIPTION
Closes #281.

The new release's `[X.Y.Z]:` reference definition took its compare base from the previous `[Unreleased]` link. Where an earlier release had left `[Unreleased]` pointing at an older tag, the new range spanned several releases:

- `matrix-skill`: `[3.1.3]: …/compare/v3.1.1...v3.1.3` — should be `v3.1.2...v3.1.3`
- `php-modernization-skill`: `[1.22.3]: …/compare/v1.21.0...v1.22.3` — should be `v1.22.2...v1.22.3`

Both were corrected by hand in their release PRs, so nothing shipped wrong — but every sweep reproduced it.

## What changed

The base now comes from the **released headings**: the heading directly below the one the roll just wrote. That is independent of whatever `[Unreleased]` pointed at, which is the property the issue asked for.

The second half matters as much. A previous release with no definition of its own is what let the stale base survive across releases — `matrix-skill` never had a `[3.1.2]` line, so nothing ever corrected the drift. When the roll can see the version below it, that definition is now backfilled instead of silently skipped.

Tag style is read from the existing definitions rather than assumed, so a repo using unprefixed tags keeps them unprefixed on both ends of the range.

## Tests, and why both groups exist

Both are verified as guards, each against a mutation the other does not catch — so neither is decoration:

| Mutation | What reddens |
|---|---|
| `prev_tag = old` (inherit the `[Unreleased]` base again) | 3 of the stale-base cases |
| `styled_tag` always adds a `v` | only the bare-tag case |

The stale-base fixture reproduces `matrix-skill` exactly: `[Unreleased]` still at `v3.1.1`, no `[3.1.2]` definition, rolling `3.1.3`. One case asserts the correct range is present, a second asserts the wrong one is *absent* — the pair matters, because a definition can be right and a stale sibling still linger.

The pre-existing `refs.md` case passed either way, since its `[Unreleased]` base happened to equal the previous heading. That is why the bug survived having tests.

`ruff format` and `ruff check` clean. The formatter rewrote the function after the first mutation run, so the mutation was re-run against the final file rather than trusting the earlier result.

## Round 2 — found by reading this diff, not by a bot

Both bot reviewers were unavailable (Copilot out of quota account-wide, CodeRabbit rate-limited and it refused an explicit `@coderabbitai review` with "Action not completed"), so the diff was read by hand. That turned up a defect in this PR's own code, fixed in a follow-up commit.

`have_prev` decided whether the previous version already had a reference definition by matching the heading label verbatim. Headings and definitions spell the tag independently, so a file heading `## [v3.1.2]` while defining `[3.1.2]:` was read as missing the definition and got a **second** one under the other spelling. The comparison now drops the `v` prefix on both sides — the same normalization `styled_tag` already applies.

Covered by a fixture with exactly that mismatch. Reverting to the raw comparison reddens it with `expected '1', got '2'`.

Rebased onto `main` after #294 merged; suite, `ruff format`, `ruff check` and `shellcheck` re-run on the rebased tree.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_

