### PR TITLE
feat(validate): check that README setup instructions are runnable

### DIFF
--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -961,6 +961,59 @@ if [[ -f "$REPO_DIR/README.md" ]]; then
             fi
         done
     fi
+
+    # --- Install instructions must be runnable -------------------------------
+    # A README documented steps that fail on the first command for as long as it
+    # existed, and no gate could see it: an outside user reported it
+    # (netresearch/retro-skill#90). Only FENCED command lines are considered — a
+    # README may legitimately quote the wrong form in prose to warn against it,
+    # and this one does.
+    README_CMDS=$(awk '/^ {0,3}(```|~~~)/ { infence = !infence; next } infence' \
+        "$REPO_DIR/README.md")
+    MP_ADD=$(grep -E '^[[:space:]]*/plugin[[:space:]]+marketplace[[:space:]]+add[[:space:]]' \
+        <<< "$README_CMDS" || true)
+    if [[ -n "$MP_ADD" ]]; then
+        SELF_SLUG=""
+        if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+            SELF_SLUG="$GITHUB_REPOSITORY"
+        elif git -C "$REPO_DIR" remote get-url origin &> /dev/null; then
+            SELF_SLUG="netresearch/$(basename "$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null)" .git)"
+        fi
+        # `marketplace add` resolves .claude-plugin/marketplace.json in the
+        # TARGET repo. Pointing it at a repo that ships only plugin.json fails
+        # with "Marketplace file not found" — provable locally when the target
+        # is this repo.
+        if [[ -n "$SELF_SLUG" && ! -f "$REPO_DIR/.claude-plugin/marketplace.json" ]] \
+            && grep -qF -- "$SELF_SLUG" <<< "$MP_ADD"; then
+            error "README.md: '/plugin marketplace add $SELF_SLUG' cannot work — the target must be a catalog repo shipping .claude-plugin/marketplace.json, and this repo ships .claude-plugin/plugin.json. Point it at netresearch/claude-code-marketplace (its entry names this repo as the source, so the code still comes from here)."
+        else
+            success "README.md marketplace-add target is not this repo"
+        fi
+        # The add line alone registers a marketplace and installs nothing.
+        MP_INSTALL=$(grep -E '^[[:space:]]*/plugin[[:space:]]+install[[:space:]]' \
+            <<< "$README_CMDS" || true)
+        if [[ -z "$MP_INSTALL" ]]; then
+            warning "README.md documents '/plugin marketplace add' but no '/plugin install <plugin>@<marketplace>' line — following it leaves the reader with a registered marketplace and no plugin"
+        else
+            while IFS= read -r line; do
+                [[ -n "$line" ]] || continue
+                target="${line#*install }"
+                target="${target%%[[:space:]]*}"
+                case "$target" in
+                    *@*/* | */*@*)
+                        error "README.md: '/plugin install $target' — the part after @ is the marketplace NAME (e.g. netresearch-claude-code-marketplace), not owner/repo"
+                        ;;
+                    *@*) success "README.md install target names a marketplace: $target" ;;
+                    *)
+                        warning "README.md: '/plugin install $target' has no @<marketplace> suffix — ambiguous once more than one marketplace is configured"
+                        ;;
+                esac
+            done <<< "$MP_INSTALL"
+        fi
+        # Not checkable here: whether the named catalog actually lists this
+        # plugin. That needs the catalog fetched at validation time — see the
+        # scheduled-job option in netresearch/skill-repo-skill#292.
+    fi
 fi
 
 # --- Summary ---

--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -973,18 +973,26 @@ if [[ -f "$REPO_DIR/README.md" ]]; then
     MP_ADD=$(grep -E '^[[:space:]]*/plugin[[:space:]]+marketplace[[:space:]]+add[[:space:]]' \
         <<< "$README_CMDS" || true)
     if [[ -n "$MP_ADD" ]]; then
+        # The ARGUMENT, not the line: a substring test makes
+        # `add netresearch/foo-catalog` match the slug `netresearch/foo`, and
+        # splitting on a single space mis-parses `install  <two spaces>`.
+        MP_ADD_TARGETS=$(awk '{ for (i = 1; i <= NF; i++) if ($i == "add") { print $(i + 1); break } }' \
+            <<< "$MP_ADD")
         SELF_SLUG=""
         if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
             SELF_SLUG="$GITHUB_REPOSITORY"
-        elif git -C "$REPO_DIR" remote get-url origin &> /dev/null; then
-            SELF_SLUG="netresearch/$(basename "$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null)" .git)"
+        elif SELF_URL=$(git -C "$REPO_DIR" remote get-url origin 2> /dev/null); then
+            # owner/repo from any remote form, including the scp-style
+            # git@host:group/repo.git and a GitLab subgroup path.
+            SELF_URL="${SELF_URL%.git}"
+            SELF_SLUG=$(awk -F'[:/]' '{ print $(NF - 1) "/" $NF }' <<< "$SELF_URL")
         fi
         # `marketplace add` resolves .claude-plugin/marketplace.json in the
         # TARGET repo. Pointing it at a repo that ships only plugin.json fails
         # with "Marketplace file not found" — provable locally when the target
         # is this repo.
         if [[ -n "$SELF_SLUG" && ! -f "$REPO_DIR/.claude-plugin/marketplace.json" ]] \
-            && grep -qF -- "$SELF_SLUG" <<< "$MP_ADD"; then
+            && grep -Fxq -- "$SELF_SLUG" <<< "$MP_ADD_TARGETS"; then
             error "README.md: '/plugin marketplace add $SELF_SLUG' cannot work — the target must be a catalog repo shipping .claude-plugin/marketplace.json, and this repo ships .claude-plugin/plugin.json. Point it at netresearch/claude-code-marketplace (its entry names this repo as the source, so the code still comes from here)."
         else
             success "README.md marketplace-add target is not this repo"
@@ -995,10 +1003,10 @@ if [[ -f "$REPO_DIR/README.md" ]]; then
         if [[ -z "$MP_INSTALL" ]]; then
             warning "README.md documents '/plugin marketplace add' but no '/plugin install <plugin>@<marketplace>' line — following it leaves the reader with a registered marketplace and no plugin"
         else
-            while IFS= read -r line; do
-                [[ -n "$line" ]] || continue
-                target="${line#*install }"
-                target="${target%%[[:space:]]*}"
+            MP_INSTALL_TARGETS=$(awk '{ for (i = 1; i <= NF; i++) if ($i == "install") { print $(i + 1); break } }' \
+                <<< "$MP_INSTALL")
+            while IFS= read -r target; do
+                [[ -n "$target" ]] || continue
                 case "$target" in
                     *@*/* | */*@*)
                         error "README.md: '/plugin install $target' — the part after @ is the marketplace NAME (e.g. netresearch-claude-code-marketplace), not owner/repo"
@@ -1008,7 +1016,7 @@ if [[ -f "$REPO_DIR/README.md" ]]; then
                         warning "README.md: '/plugin install $target' has no @<marketplace> suffix — ambiguous once more than one marketplace is configured"
                         ;;
                 esac
-            done <<< "$MP_INSTALL"
+            done <<< "$MP_INSTALL_TARGETS"
         fi
         # Not checkable here: whether the named catalog actually lists this
         # plugin. That needs the catalog fetched at validation time — see the

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -322,6 +322,21 @@ readme_case prose_ok "$PROSE_ONLY" expect-present \
     "install target names a marketplace" "the correct pair is accepted"
 
 # shellcheck disable=SC2016  # literal markdown fixture, not an expansion
+# The slug is compared against the ADD ARGUMENT, not the line. A catalog whose
+# name merely starts with this repo's slug must not read as self-referencing.
+# shellcheck disable=SC2016  # literal markdown fixture, not an expansion
+PREFIX_CATALOG='## Install\n\n```text\n/plugin marketplace add netresearch/demo-skill-catalog\n/plugin install demo@demo-skill-catalog\n```\n'
+readme_case prefix_catalog "$PREFIX_CATALOG" expect-absent \
+    "cannot work" "a catalog whose slug extends this repo's is not self-reference"
+
+# Two spaces after `install` must still yield the target, not an empty string.
+# shellcheck disable=SC2016  # literal markdown fixture, not an expansion
+DOUBLE_SPACE='## Install\n\n```text\n/plugin marketplace add netresearch/claude-code-marketplace\n/plugin  install   demo@netresearch-claude-code-marketplace\n```\n'
+readme_case double_space "$DOUBLE_SPACE" expect-present \
+    "install target names a marketplace: demo@netresearch-claude-code-marketplace" \
+    "irregular spacing still parses the install target"
+
+# shellcheck disable=SC2016  # literal markdown fixture, not an expansion
 NO_INSTALL='## Install\n\n```text\n/plugin marketplace add netresearch/claude-code-marketplace\n```\n'
 readme_case no_install "$NO_INSTALL" expect-present \
     "no plugin" "an add line without an install line warns"

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -279,6 +279,54 @@ at_case 'allowed-tools: [Bash(${CLAUDE_SKILL_DIR}/scripts/*), Read]'          ye
 at_case 'allowed-tools: Read # Bash(bash:*) would be wrong'                   yes quiet 'trailing comment'
 
 echo "----------------------------------------"
+echo "README install-instruction checks"
+echo "----------------------------------------"
+# netresearch/retro-skill#90: the documented steps failed on the first command
+# for as long as the README existed, and nothing in CI could see it.
+
+# readme_case <name> <readme-body> <expect-present|expect-absent> <pattern> <label>
+readme_case() {
+    local name="$1" body="$2" want="$3" pat="$4" label="$5" dir out
+    dir="$TMP/rm_$name"
+    rm -rf "$dir"; mkdir -p "$dir/.claude-plugin"
+    printf '%b' "$body" > "$dir/README.md"
+    printf '{"name":"x","version":"1.0.0"}\n' > "$dir/.claude-plugin/plugin.json"
+    out="$(GITHUB_REPOSITORY=netresearch/demo-skill bash "$VALIDATOR" "$dir" 2>&1)"
+    case "$want" in
+        expect-present)
+            if grep -qF -- "$pat" <<< "$out"; then ((PASS++)); else
+                echo "  FAIL $label: expected output matching '$pat'"; ((FAIL++)); fi ;;
+        expect-absent)
+            if grep -qF -- "$pat" <<< "$out"; then
+                echo "  FAIL $label: '$pat' should NOT have fired"; ((FAIL++)); else ((PASS++)); fi ;;
+    esac
+    return 0
+}
+
+# shellcheck disable=SC2016  # literal markdown fixture, not an expansion
+FENCED_SELF='## Install\n\n```text\n/plugin marketplace add netresearch/demo-skill\n/plugin install demo@netresearch/demo-skill\n```\n'
+readme_case self_add "$FENCED_SELF" expect-present \
+    "cannot work" "self-referencing marketplace add is an error"
+readme_case self_install "$FENCED_SELF" expect-present \
+    "not owner/repo" "owner/repo after @ is an error"
+
+# The same wrong line OUTSIDE a fence is documentation about the mistake, not an
+# instruction — this repo's own README carries one. The unfenced copy below
+# starts at column 0, so only the fence tracking can exclude it: a version of
+# this check that reads the whole file matches it and reports an error.
+# shellcheck disable=SC2016  # literal markdown fixture, not an expansion
+PROSE_ONLY='## Install\n\n```text\n/plugin marketplace add netresearch/claude-code-marketplace\n/plugin install demo@netresearch-claude-code-marketplace\n```\n\nDo not write this, it fails:\n\n/plugin marketplace add netresearch/demo-skill\n'
+readme_case prose_only "$PROSE_ONLY" expect-absent \
+    "cannot work" "the same line in prose does not fire"
+readme_case prose_ok "$PROSE_ONLY" expect-present \
+    "install target names a marketplace" "the correct pair is accepted"
+
+# shellcheck disable=SC2016  # literal markdown fixture, not an expansion
+NO_INSTALL='## Install\n\n```text\n/plugin marketplace add netresearch/claude-code-marketplace\n```\n'
+readme_case no_install "$NO_INSTALL" expect-present \
+    "no plugin" "an add line without an install line warns"
+
+echo "----------------------------------------"
 echo "Passed: $PASS  Failed: $FAIL"
 [[ $FAIL -eq 0 ]] || { echo "Smoke tests FAILED"; exit 1; }
 echo "All validator smoke tests passed"


### PR DESCRIPTION
Closes #292.

netresearch/retro-skill#90 was an outside user reporting that our documented setup steps fail on the first command. The wrong text had been in that README since it was written, and nothing in CI could have caught it: `check-template-drift` governs the `.github/` tree only, and `validate-skill.sh` never looked at the install block.

## What is checked

Only when the README documents a `/plugin marketplace add`:

| Assertion | Level | The defect it catches |
|---|---|---|
| The add target is not this repo | error | `marketplace add` resolves `.claude-plugin/marketplace.json` in the **target**, so aiming it at a repo shipping `plugin.json` can never work — the exact #90 failure |
| An install line follows | warning | An add line alone registers a marketplace and installs nothing; 28 repos documented exactly that |
| The part after `@` is a marketplace name, not `owner/repo` | error | The second, independent defect in the reported snippet |

**Only fenced lines count.** A README may quote the wrong form deliberately to warn against it — this repo's own does — and a version that reads the whole file reports that warning as a defect.

## Not checked, deliberately

Whether the named catalog actually lists this plugin. That needs the catalog fetched at validation time, which does not belong in an offline validator; the issue's scheduled-job option is the better home, and the omission is marked in the code so the next reader does not assume it is covered.

## Measured before adding, so it turns nothing red

This check runs fleet-wide, so the question is not whether it is correct but what it does to 55 repositories today:

- **39** document an add line → **38 clean, 0 errors**
- the single warning is `pagerangers-skill`, which is archived
- the other **16** document none, and the check stays silent

The first run of that measurement was against stale local refs and reported 25 warnings and 1 error; re-run after fetching, it is the table above. Worth stating, because the stale answer looked plausible.

## Tests

Five cases, each verified against a mutation rather than assumed to cover something:

| Mutation | What reddens |
|---|---|
| Check disabled entirely | 4 of 5 |
| Check made fence-blind | the prose case only |

The prose fixture had to be rewritten to earn that. Its first version put the wrong line behind prose text (`> **Do not** run …`), where the line-start anchor already excluded it — so it passed the fence-blind mutation and proved nothing. It now places the wrong line at column 0 outside a fence, which only the fence tracking can exclude.

`shellcheck -x` clean; the validator passes against this repo with 0 errors and 0 warnings.

## Round 2 — three defects found by reading this diff

Both bot reviewers were unavailable (Copilot out of quota account-wide, CodeRabbit rate-limited and it refused an explicit `@coderabbitai review` with "Action not completed"), so the diff was read by hand. All three defects below would have run in **every** fleet repository:

- The self-reference test substring-matched the whole line. A repo `foo` documenting `add netresearch/foo-catalog` matched the slug `netresearch/foo` and would have failed CI on a **correct** README. It now compares the argument after `add`, exactly.
- The slug hardcoded `netresearch/` and took a `basename`, so a GitLab remote under another group resolved to a name that exists nowhere. Owner and repo are now parsed from the remote URL, scp-style form included.
- The install target was cut with `${line#*install }`, which yields an empty string when the line has two spaces after `install` — and then reports the wrong diagnostic. Both targets are now parsed as fields.

The fleet measurement was **re-run** after these changes, because the slug derivation moved and the earlier number no longer described the new code: 39 repos document an add line, 38 clean, 0 errors, one warning (`pagerangers-skill`, archived).

Both new tests are verified against the defect they cover — re-injecting the substring match and the prefix strip reddens exactly those two.

Rebased onto `main` after #294 merged; tests, self-validation and `shellcheck` re-run on the rebased tree.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01L94yEWSBvuUkLqLpVbMqRh)_

