### PR TITLE
feat(fleet-release): carry operator-defined trailers on bump commits

### DIFF
--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -41,6 +41,14 @@ shared release CI first), and non-default-branch releases — the
 something the driver lacks, extend it in a PR; a session-local driver script
 is how the next incident starts.
 
+**Where a policy requires agent or tool disclosure on every commit, set
+`FR_COMMIT_TRAILERS`** — newline-separated `Key: value` lines that the bump
+commit carries as git trailers, alongside the `--signoff` it already writes.
+The driver appends them verbatim and interprets none of them, so the keys stay
+the operator's decision (`Assisted-by:`, `Agent-Session:`, … ). It applies to
+both commit attempts, including the retry after a reformatting hook — the one
+place a second `git commit` could otherwise drop them. Unset, nothing changes.
+
 **Budget the API before a sweep: the survey costs ~10 calls per repo, and
 each GitHub quota pool (REST 5,000/h, GraphQL 5,000 points/h — separate
 pools) is shared across every tool, watcher and agent in the session.** A

--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -799,6 +799,26 @@ fr_stage_allowlisted() { # REPO WT — stage every pending path, refusing anythi
     git -C "$wt" add -- "${paths[@]}"
 }
 
+fr_trailer_args() { # ARRAY_NAME — fill with --trailer args from FR_COMMIT_TRAILERS
+    # Disclosure trailers (provenance, session, host) are the operator's to
+    # define, not this driver's: it must not know what `Assisted-by` means, so
+    # the caller supplies whole `Key: value` lines, one per line, and each
+    # becomes a `git commit --trailer`. Blank lines are skipped so a
+    # here-doc-assigned variable with a trailing newline behaves.
+    # `--trailer` appends into the message's own trailer block, so it composes
+    # with the `--signoff` above rather than competing with it, and git dedupes
+    # nothing — a line already present in the message would appear twice, which
+    # is why this only ever runs against the generated one-line subject.
+    local -n _out="$1"
+    _out=()
+    [[ -n "${FR_COMMIT_TRAILERS:-}" ]] || return 0
+    local line
+    while IFS= read -r line; do
+        [[ -n "${line//[[:space:]]/}" ]] || continue
+        _out+=(--trailer "$line")
+    done <<< "$FR_COMMIT_TRAILERS"
+}
+
 fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces may
     # move. Two attempts: a reformatting hook (pre-commit's pretty-format-json
     # --autofix, black, ruff format, …) rewrites a staged file and FAILS the
@@ -812,11 +832,13 @@ fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces m
     # deterministic rejection fails the second attempt too and reports as before.
     local repo="$1" wt="$2" version="$3"
     local attempt ec
+    local -a trailer_args=()
+    fr_trailer_args trailer_args
     for attempt in 1 2; do
         echo "--- porcelain (attempt $attempt):"
         git -C "$wt" status --porcelain
         fr_stage_allowlisted "$repo" "$wt" || return 1
-        ( cd "$wt" && git commit -S --signoff -m "${FR_COMMIT_PREFIX}${version}" )
+        ( cd "$wt" && git commit -S --signoff "${trailer_args[@]}" -m "${FR_COMMIT_PREFIX}${version}" )
         ec=$?
         echo "COMMIT EXIT ($attempt): $ec"   # bare exit code — a pipe here once hid a hook abort
         if [[ "$ec" -eq 0 ]]; then

--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -832,13 +832,18 @@ fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces m
     # deterministic rejection fails the second attempt too and reports as before.
     local repo="$1" wt="$2" version="$3"
     local attempt ec
+    # Expanded below as ${trailer_args[@]+"${trailer_args[@]}"}: expanding an
+    # EMPTY array as "${a[@]}" under `set -u` is an error before bash 4.4, and
+    # fr_preflight admits bash >= 4 — so the plain form would break every bump
+    # on exactly the older shells that guard exists for, and only for operators
+    # who did NOT set FR_COMMIT_TRAILERS.
     local -a trailer_args=()
     fr_trailer_args trailer_args
     for attempt in 1 2; do
         echo "--- porcelain (attempt $attempt):"
         git -C "$wt" status --porcelain
         fr_stage_allowlisted "$repo" "$wt" || return 1
-        ( cd "$wt" && git commit -S --signoff "${trailer_args[@]}" -m "${FR_COMMIT_PREFIX}${version}" )
+        ( cd "$wt" && git commit -S --signoff ${trailer_args[@]+"${trailer_args[@]}"} -m "${FR_COMMIT_PREFIX}${version}" )
         ec=$?
         echo "COMMIT EXIT ($attempt): $ec"   # bare exit code — a pipe here once hid a hook abort
         if [[ "$ec" -eq 0 ]]; then

--- a/skills/skill-repo/scripts/fleet-release-github.sh
+++ b/skills/skill-repo/scripts/fleet-release-github.sh
@@ -26,6 +26,17 @@
 # The driver never merges a PR this sweep did not open, never unarchives,
 # never clones, never invents versions or PR bodies, never touches CI files,
 # and only releases the default-branch tip.
+#
+# Environment:
+#   FR_COMMIT_TRAILERS  Newline-separated `Key: value` lines appended to every
+#                       bump commit as git trailers (requires git >= 2.32).
+#                       Where a policy requires agent/tool disclosure on every
+#                       commit, set it — the driver appends the lines verbatim
+#                       and interprets none of them, so which keys a fleet uses
+#                       stays the operator's decision:
+#                         export FR_COMMIT_TRAILERS='Assisted-by: <agent>:<model>
+#                         Agent-Session: <url>'
+#                       Unset, bump commits keep `--signoff` alone.
 
 set -euo pipefail
 

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -416,6 +416,50 @@ check "commit: a hook that always rejects fails after exactly two attempts" yes 
 check "commit: the permanent rejection is reported to the caller" yes \
     "$(grep -q 'FAIL demo: commit' <<< "$out" && grep -q 'rc=1' <<< "$out" && echo yes || echo no)"
 
+# --- FR_COMMIT_TRAILERS: disclosure the operator defines, not the driver -----
+# A bump commit must be able to carry provenance trailers (Assisted-by,
+# Agent-Session, Agent-Host …). The driver stays agent-neutral: it appends
+# whatever `Key: value` lines the operator supplies and knows none of them.
+# Unset must remain byte-identical to the old behaviour, or every repo that
+# does not opt in changes shape.
+mk_commit_repo "$WORK/commit-trailers" '#!/bin/sh
+exit 0'
+FR_COMMIT_TRAILERS='Assisted-by: some-agent:some-model
+Agent-Session: https://example.invalid/session_1
+
+Agent-Host: abcdef' \
+    fr_commit_allowlisted demo "$WORK/commit-trailers" 1.1.0 > /dev/null 2>&1
+body=$(git -C "$WORK/commit-trailers" log -1 --format=%B)
+check "trailers: Assisted-by lands in the commit" yes \
+    "$(grep -qx 'Assisted-by: some-agent:some-model' <<< "$body" && echo yes || echo no)"
+check "trailers: Agent-Session lands in the commit" yes \
+    "$(grep -qx 'Agent-Session: https://example.invalid/session_1' <<< "$body" && echo yes || echo no)"
+check "trailers: Agent-Host lands in the commit" yes \
+    "$(grep -qx 'Agent-Host: abcdef' <<< "$body" && echo yes || echo no)"
+check "trailers: a blank line in the variable adds no empty trailer" 3 \
+    "$(grep -cE '^(Assisted-by|Agent-Session|Agent-Host):' <<< "$body")"
+check "trailers: --signoff still applies alongside them" yes \
+    "$(grep -q '^Signed-off-by:' <<< "$body" && echo yes || echo no)"
+check "trailers: the subject is untouched" "chore(release): v1.1.0" \
+    "$(git -C "$WORK/commit-trailers" log -1 --format=%s)"
+# Both attempts must carry them: a reformatting hook aborts the first commit,
+# and the retry is a SECOND `git commit` — the one place trailers could silently
+# be dropped for exactly the repos whose hooks rewrite the manifest.
+mk_commit_repo "$WORK/commit-trailers-retry" "$REFORMAT_HOOK"
+FR_COMMIT_TRAILERS='Assisted-by: some-agent:some-model' \
+    fr_commit_allowlisted demo "$WORK/commit-trailers-retry" 1.1.0 > /dev/null 2>&1
+check "trailers: survive the reformatting-hook retry" yes \
+    "$(git -C "$WORK/commit-trailers-retry" log -1 --format=%B \
+        | grep -qx 'Assisted-by: some-agent:some-model' && echo yes || echo no)"
+# Unset: the opt-out stays exactly as before.
+mk_commit_repo "$WORK/commit-no-trailers" '#!/bin/sh
+exit 0'
+( unset FR_COMMIT_TRAILERS
+  fr_commit_allowlisted demo "$WORK/commit-no-trailers" 1.1.0 > /dev/null 2>&1 )
+check "trailers: unset adds none" 0 \
+    "$(git -C "$WORK/commit-no-trailers" log -1 --format=%B \
+        | grep -cE '^(Assisted-by|Agent-Session|Agent-Host):')"
+
 # --- the shipped fleet list is non-empty and comment-clean -------------------
 n=$(grep -cvE '^\s*(#|$)' "$SCRIPTS/fleet-repos-github.txt")
 check "fleet-repos-github.txt ships a non-empty list" yes \


### PR DESCRIPTION
A fleet whose policy requires agent or tool disclosure on every commit cannot use this driver today. `fr_commit_allowlisted` writes `git commit -S --signoff` with a generated subject and offers no way to add anything to it, so a sweep either drops the disclosure or hand-writes a driver — the outcome #218 exists to prevent.

`FR_COMMIT_TRAILERS` holds newline-separated `Key: value` lines; each becomes a `git commit --trailer`. The driver interprets none of them, so which keys a fleet uses stays an operator decision rather than this script's knowledge — `Assisted-by:`, `Agent-Session:` and vendor-neutral variants all work without a code change. Requires git >= 2.32.

The trailers are computed once and passed to **both** commit attempts. The retry after a reformatting hook is a second `git commit`, and it is the one place they could silently be dropped — for exactly the repos whose hooks rewrite the manifest `sync-plugin-manifest.sh` emits.

Unset, the commit is byte-identical to before.

## Tests

Nine checks in `tests/fleet-release.sh`: the three trailers landing, the blank-line skip, coexistence with `--signoff`, an untouched subject, survival of the reformatting-hook retry, and the unset opt-out.

Verified by mutation rather than by passing on a clean tree: removing the `"${trailer_args[@]}"` expansion reddens five of the nine (the two that stay green assert `--signoff` and the subject, which the mutation does not touch, and the unset case is the opt-out). Restoring makes the full suite pass.

## set -u safety

The array is expanded as `${trailer_args[@]+"${trailer_args[@]}"}`. Expanding an **empty** array as `"${a[@]}"` under `set -u` is an error before bash 4.4, and `fr_preflight` admits bash >= 4 — so the plain form would abort every bump on those shells, and only for operators who did *not* set the variable, which is the default path. Found while reviewing the diff; not reproducible on bash 5.2.

## Documentation

`FR_COMMIT_TRAILERS` is documented in the driver's `--help` header and in `references/release-discipline.md`, in the fleet-sweep section that tells a sweep to extend the driver rather than hand-write one.

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5
