### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skill-repo",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "skill-repo",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Guide for structuring Netresearch skill repositories",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/skill-repo/SKILL.md
+++ b/skills/skill-repo/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, python3."
 metadata:
   author: Netresearch DTT GmbH
-  version: "2.0.1"
+  version: "2.1.0"
   repository: https://github.com/netresearch/skill-repo-skill
 allowed-tools: Bash(${CLAUDE_SKILL_DIR}/scripts/*) Bash(bash ${CLAUDE_SKILL_DIR}/scripts/*) Bash(skills/skill-repo/scripts/*) Bash(bash skills/skill-repo/scripts/*) Read Write Glob Grep
 ---


### PR DESCRIPTION
Version bump to 2.1.0 (minor). Changes since v2.0.1:

- docs: fix marketplace install instructions and document skills-dir route
- docs: correct the skills-directory install instructions
- docs: carry the install corrections into the README template
- docs: drop the bare git clone method from the README
- docs: correct marketplace setup steps and document skills-dir route
- fix(fleet-release): route every gh api capture through gh_json
- fix(fleet-release): keep a failed tag query out of FIRST-RELEASE
- fix(fleet-release): treat lint-config churn as a CI-only delta
- fix(roll-changelog): take the compare base from the headings
- fix(roll-changelog): match the previous definition across tag spellings
- feat(validate): check that README setup instructions are runnable
- fix(validate): compare the add argument, not the line
- feat(fleet-release): carry operator-defined trailers on bump commits
- fix(fleet-release): expand the trailer array safely under set -u
- chore(dependabot): remove the Dependabot configuration

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5