### PR TITLE
fix(fleet-release): fail the repo when a requested trailer does not land

### DIFF
--- a/skills/skill-repo/references/release-discipline.md
+++ b/skills/skill-repo/references/release-discipline.md
@@ -41,6 +41,22 @@ shared release CI first), and non-default-branch releases — the
 something the driver lacks, extend it in a PR; a session-local driver script
 is how the next incident starts.
 
+**Run the sweep from a checkout you have just pulled, and read the FIRST bump
+commit before letting the phase continue.** `git fetch` is not `git pull`: a
+driver copy can be behind the feature you are relying on, and a copy that
+predates `FR_COMMIT_TRAILERS` ignores the variable rather than complaining about
+it — every repo reports `OK … bump PR open` and the commits carry nothing. On
+2026-09-11 that shipped four bump commits to `main` without their disclosure
+trailers before anyone opened one; auto-merge had already taken them past the
+point where an amend was possible, and rewriting `main` to fix it is worse than
+the defect. `fr_assert_trailers_landed` now fails the repo when a requested
+trailer is absent from the commit, which closes every producer of that symptom
+except the one it cannot see: a stale engine does not know the variable, so it
+cannot check for it. Hence the manual half — `git -C <skill-repo-skill> pull`,
+then `git log -1 --format=%B` on the first repo the phase touches. The same
+applies to a vendored engine: a fleet driver on another host reads *its own*
+copy, so an upstream fix reaches it only after a re-vendor.
+
 **Where a policy requires agent or tool disclosure on every commit, set
 `FR_COMMIT_TRAILERS`** — newline-separated `Key: value` lines that the bump
 commit carries as git trailers, alongside the `--signoff` it already writes.

--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -723,6 +723,14 @@ fr_bump_one() { # ROW — runs inside the per-repo subshell; log via redirection
         echo "bump already committed on $branch (crashed before push)"
     fi
 
+    # Also here, not only inside fr_commit_allowlisted: the branch above is the
+    # RESUME path, where the commit was written by an earlier run and this one
+    # never went through the commit function. A commit whose trailers failed the
+    # assertion leaves exactly that state behind — clean worktree, commit in
+    # place — so without this the next run would push the very commit the
+    # previous run refused.
+    fr_assert_trailers_landed "$repo" "$wt" || return 1
+
     ( cd "$wt" && git push -u origin "$branch" )
     local ec=$?
     echo "PUSH EXIT: $ec"
@@ -836,11 +844,17 @@ fr_assert_trailers_landed() { # REPO WT — every requested trailer is in the co
     local repo="$1" wt="$2" line key
     [[ -n "${FR_COMMIT_TRAILERS:-}" ]] || return 0
     local msg
-    msg=$(git -C "$wt" log -1 --format=%B)
+    # `git interpret-trailers --parse`, not the raw %B: a hook that moves a line
+    # into the message BODY leaves it findable by a plain grep while `git log
+    # --grep` and every other trailer consumer no longer see it as a trailer —
+    # which is the whole point of writing one. Compared with `-x` so a line is
+    # matched whole; a substring match would accept a longer line that merely
+    # contains the requested one.
+    msg=$(git -C "$wt" log -1 --format=%B | git interpret-trailers --parse)
     while IFS= read -r line; do
         [[ -n "${line//[[:space:]]/}" ]] || continue
         key=${line%%:*}
-        if ! grep -qF "$line" <<< "$msg"; then
+        if ! grep -qFx -- "$line" <<< "$msg"; then
             echo "FAIL $repo: requested trailer did not land in the commit: ${key}:"
             echo "  set FR_COMMIT_TRAILERS but the message has no such line — is this"
             echo "  driver copy current? git -C <skill-repo-skill> pull, then re-run."

--- a/skills/skill-repo/scripts/fleet-release-common.sh
+++ b/skills/skill-repo/scripts/fleet-release-common.sh
@@ -819,6 +819,37 @@ fr_trailer_args() { # ARRAY_NAME — fill with --trailer args from FR_COMMIT_TRA
     done <<< "$FR_COMMIT_TRAILERS"
 }
 
+fr_assert_trailers_landed() { # REPO WT — every requested trailer is in the commit
+    # A commit that exits 0 is not a commit that carries what was asked for.
+    # The failure this exists for: a driver copy that predates FR_COMMIT_TRAILERS
+    # ignores the variable entirely and commits happily, so the operator sets it,
+    # reads "OK <repo> vX.Y.Z bump PR open" per repo, and finds out only if they
+    # open a commit. On 2026-09-11 that shipped four bump commits to `main`
+    # without their disclosure trailers before anyone looked; auto-merge had
+    # taken them past the point where an amend was possible.
+    #
+    # A stale engine cannot warn about itself — it does not know the variable —
+    # so this check cannot catch that case in the copy that has the bug. It
+    # catches every other producer of the same symptom from here on: a
+    # prepare-commit-msg hook that rewrites the message, a git too old for
+    # --trailer, a trailer whose key git declines to append.
+    local repo="$1" wt="$2" line key
+    [[ -n "${FR_COMMIT_TRAILERS:-}" ]] || return 0
+    local msg
+    msg=$(git -C "$wt" log -1 --format=%B)
+    while IFS= read -r line; do
+        [[ -n "${line//[[:space:]]/}" ]] || continue
+        key=${line%%:*}
+        if ! grep -qF "$line" <<< "$msg"; then
+            echo "FAIL $repo: requested trailer did not land in the commit: ${key}:"
+            echo "  set FR_COMMIT_TRAILERS but the message has no such line — is this"
+            echo "  driver copy current? git -C <skill-repo-skill> pull, then re-run."
+            return 1
+        fi
+    done <<< "$FR_COMMIT_TRAILERS"
+    return 0
+}
+
 fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces may
     # move. Two attempts: a reformatting hook (pre-commit's pretty-format-json
     # --autofix, black, ruff format, …) rewrites a staged file and FAILS the
@@ -847,6 +878,7 @@ fr_commit_allowlisted() { # REPO WT VERSION — only the four version surfaces m
         ec=$?
         echo "COMMIT EXIT ($attempt): $ec"   # bare exit code — a pipe here once hid a hook abort
         if [[ "$ec" -eq 0 ]]; then
+            fr_assert_trailers_landed "$repo" "$wt" || return 1
             return 0
         fi
         # An `if`, not `cond && echo`: the latter is the loop body's last

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -491,6 +491,32 @@ out=$( unset FR_COMMIT_TRAILERS
 check "trailers: the assertion is silent when none were requested" yes \
     "$(grep -q 'rc=0' <<< "$out" && echo yes || echo no)"
 
+# A hook that MOVES a requested line out of the trailer block and into the body
+# leaves it findable by a plain grep, while `git log --grep` and every other
+# trailer consumer stop seeing it as a trailer — which is the point of writing
+# one. Parsed with `git interpret-trailers --parse`, so this still FAILs.
+mk_commit_repo "$WORK/commit-trailer-moved" '#!/bin/sh
+exit 0'
+# shellcheck disable=SC2016  # $1 is the hook's own argument — it must NOT expand here
+printf '%s\n' '#!/bin/sh
+sed -i "s|^Assisted-by: \(.*\)$||" "$1"
+sed -i "2i Assisted-by: some-agent:some-model" "$1"' \
+    > "$WORK/commit-trailer-moved/.git/hooks/prepare-commit-msg"
+chmod +x "$WORK/commit-trailer-moved/.git/hooks/prepare-commit-msg"
+out=$(FR_COMMIT_TRAILERS='Assisted-by: some-agent:some-model' \
+    fr_commit_allowlisted demo "$WORK/commit-trailer-moved" 1.1.0 2>&1; echo "rc=$?")
+check "trailers: a line moved into the BODY does not count as landed" yes \
+    "$(grep -q 'requested trailer did not land' <<< "$out" && echo yes || echo no)"
+# A substring match would accept a longer line that merely contains the request.
+mk_commit_repo "$WORK/commit-trailer-substring" '#!/bin/sh
+exit 0'
+FR_COMMIT_TRAILERS='Assisted-by: some-agent:some-model-extended' \
+    fr_commit_allowlisted demo "$WORK/commit-trailer-substring" 1.1.0 > /dev/null 2>&1
+out=$(FR_COMMIT_TRAILERS='Assisted-by: some-agent:some-model' \
+    fr_assert_trailers_landed demo "$WORK/commit-trailer-substring" 2>&1; echo "rc=$?")
+check "trailers: a longer line is not accepted for a shorter request" yes \
+    "$(grep -q 'rc=1' <<< "$out" && echo yes || echo no)"
+
 # --- the shipped fleet list is non-empty and comment-clean -------------------
 n=$(grep -cvE '^\s*(#|$)' "$SCRIPTS/fleet-repos-github.txt")
 check "fleet-repos-github.txt ships a non-empty list" yes \

--- a/tests/fleet-release.sh
+++ b/tests/fleet-release.sh
@@ -460,6 +460,37 @@ check "trailers: unset adds none" 0 \
     "$(git -C "$WORK/commit-no-trailers" log -1 --format=%B \
         | grep -cE '^(Assisted-by|Agent-Session|Agent-Host):')"
 
+# --- a requested trailer that does not land fails the repo -------------------
+# The 2026-09-11 defect: a driver copy predating FR_COMMIT_TRAILERS ignores the
+# variable, commits cleanly, and reports OK. Four bump commits reached `main`
+# without their disclosure trailers before anyone opened one. A stale engine
+# cannot warn about itself, but every other producer of the same symptom — a
+# message-rewriting hook, a git too old for --trailer — is caught here.
+mk_commit_repo "$WORK/commit-trailer-stripped" '#!/bin/sh
+exit 0'
+# A prepare-commit-msg hook that throws the trailers away, standing in for any
+# cause that leaves the commit without what the operator asked for.
+# shellcheck disable=SC2016  # $1 is the hook's own argument — it must NOT expand here
+printf '%s\n' '#!/bin/sh
+grep -v "^Assisted-by:" "$1" > "$1.tmp" && mv "$1.tmp" "$1"' \
+    > "$WORK/commit-trailer-stripped/.git/hooks/prepare-commit-msg"
+chmod +x "$WORK/commit-trailer-stripped/.git/hooks/prepare-commit-msg"
+out=$(FR_COMMIT_TRAILERS='Assisted-by: some-agent:some-model' \
+    fr_commit_allowlisted demo "$WORK/commit-trailer-stripped" 1.1.0 2>&1; echo "rc=$?")
+check "trailers: a stripped trailer FAILs the repo" yes \
+    "$(grep -q 'requested trailer did not land' <<< "$out" && echo yes || echo no)"
+check "trailers: that failure reaches the caller" yes \
+    "$(grep -q 'rc=1' <<< "$out" && echo yes || echo no)"
+check "trailers: the failure names the key" yes \
+    "$(grep -q 'Assisted-by:' <<< "$out" && echo yes || echo no)"
+# Unset: the assertion must stay silent, or every repo that does not opt in fails.
+mk_commit_repo "$WORK/commit-assert-optout" '#!/bin/sh
+exit 0'
+out=$( unset FR_COMMIT_TRAILERS
+       fr_commit_allowlisted demo "$WORK/commit-assert-optout" 1.1.0 2>&1; echo "rc=$?" )
+check "trailers: the assertion is silent when none were requested" yes \
+    "$(grep -q 'rc=0' <<< "$out" && echo yes || echo no)"
+
 # --- the shipped fleet list is non-empty and comment-clean -------------------
 n=$(grep -cvE '^\s*(#|$)' "$SCRIPTS/fleet-repos-github.txt")
 check "fleet-repos-github.txt ships a non-empty list" yes \


### PR DESCRIPTION
Out of the 2026-09-11 fleet sweep, where this cost four repositories.

## What happened

The sweep was started from a driver checkout that was 9 commits behind and did not contain `FR_COMMIT_TRAILERS` — fetched, never pulled. A copy that predates the feature does not reject the variable, it ignores it. So every repository reported `OK <repo> vX.Y.Z bump PR open`, the phase looked perfect, and the commits carried no disclosure trailers at all.

It surfaced only because the first bump commit was read back rather than trusted. By then auto-merge had taken four of them onto `main`, where an amend is no longer available and rewriting shared history is worse than the defect. Those four keep a `chore(release)` commit without the trailers permanently.

## The guard

`fr_assert_trailers_landed` reads the message back after a successful commit and fails the repository when a requested trailer is absent, naming the key and pointing at the likely cause.

It runs at **two** points, and the second is not redundant. Inside `fr_commit_allowlisted` it fails with the porcelain context, right where the commit was made. Immediately before the push it also covers the **resume path**: a failed assertion leaves the rejected commit in place with a clean worktree, which is exactly the state `fr_bump_one` reads as *"bump already committed (crashed before push)"* — so without it, the next run would push the commit the previous run refused.

The comparison is `git interpret-trailers --parse`, not the raw `%B`. A hook that moves a requested line into the message **body** leaves it findable by a plain grep while `git log --grep` and every other trailer consumer stop seeing it as a trailer — which is the entire point of writing one. Matched with `grep -qFx --`, so a line is compared whole rather than as a substring.

Its scope is stated rather than implied: **a stale engine cannot warn about itself**, because it does not know the variable — the copy with the bug is exactly the copy that cannot run this check. What it does close is every other producer of the same symptom.

## The half the code cannot cover

In `release-discipline.md`, in the fleet-sweep section: `git fetch` is not `git pull`, run the sweep from a freshly pulled checkout, and read the first bump commit before letting the phase run on. Plus the second staleness axis this sweep also hit — a vendored engine on another host reads *its own* copy, so an upstream fix reaches it only after a re-vendor.

## Tests

Six cases: a stripped trailer fails the repository, the failure reaches the caller, it names the key, the assertion stays silent when no trailers were requested, a line moved into the body does not count as landed, and a longer line is not accepted for a shorter request.

Verified by mutation rather than by passing on the finished tree. Removing the call reddens exactly the three failure cases and leaves the opt-out green; restoring `grep -qF` over raw `%B` reddens exactly the two parsing cases. The stand-in for the original cause is a `prepare-commit-msg` hook, since an engine without the feature cannot be reproduced by an engine that has it.

`shellcheck` clean at the pre-commit hook's level, not just at `-S error`; the `SC2016` occurrences are hook fixtures' own `$1`, which must not expand, and carry directives saying so.

Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
Assisted-by: claude-code:claude-opus-5
Agent-Session: https://claude.ai/code/session_01Utz6KTyv1TNKMvXpqyNSv5
