### PR TITLE
fix(validate): the Python shebang error offers only half the fix

### DIFF
--- a/skills/skill-repo/scripts/validate-skill.sh
+++ b/skills/skill-repo/scripts/validate-skill.sh
@@ -557,7 +557,7 @@ if git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
     SH_NOT_EXEC="$(shebang_no_exec '*.sh')"; SH_NOT_EXEC="${SH_NOT_EXEC% }"
 
     if [[ -n "$PY_NOT_EXEC" ]]; then
-        error "committed 100644 but carries a shebang: ${PY_NOT_EXEC} — ruff EXE001 fails the build on this, and a local ruff run does not reproduce it (issue #235). Fix: chmod +x <file> && git update-index --chmod=+x <file>"
+        error "committed 100644 but carries a shebang: ${PY_NOT_EXEC} — ruff EXE001 fails the build on this, and a local ruff run does not reproduce it (issue #235). Fix: chmod +x <file> && git update-index --chmod=+x <file>, or drop the shebang if the file is only ever imported — a module is not a script, and making it executable settles the mismatch from the wrong side"
     elif [[ -z "$SH_NOT_EXEC" ]]; then
         success "every committed script with a shebang is mode 100755"
     fi


### PR DESCRIPTION
Merging this changes one error message. The detection, the severity and the exit code are untouched.

## Why

A committed `100644` file carrying a shebang has two honest repairs: make it executable, or drop the shebang. The shell branch two lines below already offers both — *"either make it executable (chmod +x && git update-index --chmod=+x) or drop the shebang if it is only ever run as `bash <file>`"*. The Python branch names only `chmod +x`.

For an **imported module** `chmod +x` is the wrong half. A module is not a script, so the shebang is what does not belong; making the file executable settles the mismatch from the side that leaves a lie in the tree — a file the mode says you can run, which nothing ever runs.

## Evidence

Hit on 2026-09-11 in `netresearch/github-release-skill`: a new `_invocations.py`, imported by both PreToolUse guards and never executed on its own, failed Skill Validation with this message. The message pointed at `chmod`, the correct fix was the other one, and working that out cost a CI round.

## The edit

```diff
-Fix: chmod +x <file> && git update-index --chmod=+x <file>
+Fix: chmod +x <file> && git update-index --chmod=+x <file>, or drop the shebang
+if the file is only ever imported — a module is not a script, and making it
+executable settles the mismatch from the wrong side
```

Wording follows the shell branch, with the Python-specific condition (imported, rather than run as `bash <file>`).

## Testing done

`tests/validate-skill.sh` passes 62 of 62. `shellcheck` clean. `bash -n` clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01SmrDngyNvh2gLMWXkQv5tm)_
